### PR TITLE
Undefined name: import operator

### DIFF
--- a/crosshair/objectproxy.py
+++ b/crosshair/objectproxy.py
@@ -2,11 +2,6 @@ import copy
 import operator
 import sys
 
-try:
-    long
-except NameError:
-    long = int
-
 #
 # Adapted from:
 # https://github.com/GrahamDumpleton/wrapt/blob/develop/src/wrapt/wrappers.py
@@ -283,9 +278,6 @@ class ObjectProxy:
 
     def __int__(self):
         return int(self._wrapped())
-
-    def __long__(self):
-        return long(self._wrapped())
 
     def __float__(self):
         return float(self._wrapped())

--- a/crosshair/objectproxy.py
+++ b/crosshair/objectproxy.py
@@ -1,4 +1,5 @@
 import copy
+import operator
 import sys
 
 #

--- a/crosshair/objectproxy.py
+++ b/crosshair/objectproxy.py
@@ -2,6 +2,11 @@ import copy
 import operator
 import sys
 
+try:
+    long
+except NameError:
+    long = int
+
 #
 # Adapted from:
 # https://github.com/GrahamDumpleton/wrapt/blob/develop/src/wrapt/wrappers.py


### PR DESCRIPTION
__import [operator](https://docs.python.org/3/library/operator.html)__ to avoid raising NameError at runtime.