### PR TITLE
WIP: Implement zfill

### DIFF
--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -1678,10 +1678,11 @@ class SmtStr(AtomicSmtValue, SmtSequence, AbcString):
         return ret
     
     def zfill(self, width: int):
-        size = SmtInt(z3.Length(self.var)) # Why does this need to be casted to SmtInt?
-        offset = width - size # Unsure about the type of offset at this point
-        buffer = SmtStr("0") * offset
-        return buffer + self
+        size = len(self)
+        offset = width - size
+        buffer = "0" * offset
+        filled_str = buffer + self
+        return filled_str
 
 _CACHED_TYPE_ENUMS: Dict[FrozenSet[type], z3.SortRef] = {}
 

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -1676,7 +1676,12 @@ class SmtStr(AtomicSmtValue, SmtSequence, AbcString):
         new_maxsplit = -1 if maxsplit == -1 else maxsplit - 1
         ret.extend(self[first_occurance+1:].split(sep=sep, maxsplit=new_maxsplit))
         return ret
-
+    
+    def zfill(self, width: int):
+        size = SmtInt(z3.Length(self.var)) # Why does this need to be casted to SmtInt?
+        offset = width - size # Unsure about the type of offset at this point
+        buffer = SmtStr("0") * offset
+        return buffer + self
 
 _CACHED_TYPE_ENUMS: Dict[FrozenSet[type], z3.SortRef] = {}
 
@@ -2014,8 +2019,7 @@ def make_registrations():
             'splitlines',
             'startswith',
             'strip',
-            'translate',
-            'zfill',
+            'translate'
     ]:
         orig_impl = getattr(orig_builtins.str, name)
         register_patch(orig_builtins.str, with_realized_args(orig_impl), name)

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -289,6 +289,12 @@ class NumbersTest(unittest.TestCase):
 
 class StringsTest(unittest.TestCase):
 
+    def test_zfill_fail(self) -> None:
+        def f(s: str) -> str:
+            ''' post: __return__ != "00012"'''
+            return s.zfill(5)
+        self.assertEqual(*check_fail(f))
+
     def test_cast_to_bool_fail(self) -> None:
         def f(a: str) -> str:
             ''' post: a '''

--- a/func.py
+++ b/func.py
@@ -1,3 +1,0 @@
-def find_zfill(s: str) -> str:
-  ''' post: __return__ != "00012" '''
-  return s.zfill(5)

--- a/func.py
+++ b/func.py
@@ -1,0 +1,3 @@
+def find_zfill(s: str) -> str:
+  ''' post: __return__ != "00012" '''
+  return s.zfill(5)


### PR DESCRIPTION
Related to: https://github.com/pschanely/CrossHair/issues/39
Previously, using CrossHair on a function with `zfill`  required Z3 to use a "best effort" approach: materialize concrete values of strings as inputs and try its best to find a counter example to the user-provided post-condition. This PR attempts to provide a symbolic implementation of `zfill` using pre-existing functionality.

So far, this is passing a simple unit test! More testing is needed, especially around negative width values. _This is just a start!_

**Heads up:**
At the time of writing, this is a very naive approach. I expect we'll go through a few iterations of this.
I also left some questions as comments on my implementation, would love to hear your thoughts.
Finally, I realize this is a very naive first PR. I promise future ones will be a bit more substantial once I get more familiarized with the design of CrossHair :) 

Thanks!