### PR TITLE
Run CrossHair as module

### DIFF
--- a/crosshair/__main__.py
+++ b/crosshair/__main__.py
@@ -1,0 +1,8 @@
+"""Run CrossHair as Python module."""
+
+import crosshair.main
+
+if __name__ == '__main__':
+    # The ``prog`` needs to be set in the argparse.
+    # Otherwise the program name in the help shown to the user will be ``__main__``.
+    crosshair.main.main()

--- a/crosshair/main.py
+++ b/crosshair/main.py
@@ -54,7 +54,7 @@ def command_line_parser() -> argparse.ArgumentParser:
                         help='Maximum seconds to spend checking one execution path')
     common.add_argument('--per_condition_timeout', type=float,
                         help='Maximum seconds to spend checking execution paths for one condition')
-    parser = argparse.ArgumentParser(description='CrossHair Analysis Tool')
+    parser = argparse.ArgumentParser(prog='crosshair', description='CrossHair Analysis Tool')
     subparsers = parser.add_subparsers(help='sub-command help', dest='action')
     check_parser = subparsers.add_parser(
         'check', help='Analyze a file', parents=[common])


### PR DESCRIPTION
This patch allows CrossHair to be run as a module, *i.e.*,
`python -m crosshair ...`. This is necessary for the environments which
depend on Python interpreter (*e.g.*, IDEs in Windows).