### PR TITLE
Add precommit script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ python:
  - '3.7.0'  # Test the .0 version for some breaking changes
  - '3.8'
 install:
- - "pip install flake8 -e ."
- - "pip install codecov -e ."
- - "pip install -e .[test]"  # test extras
+ - "pip install -e .[dev]"  # development extras
 env:
  - PYTHONHASHSEED=0
 script:
- - "flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics"
- - "coverage run --omit=__init__.py --omit=*_test.py -m pytest --doctest-modules"
+ - "precommit.py"
 after_success:
   - codecov

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ A (wildly incomplete) list of present limitations. Some of these will be lifted 
 * Participate (or just lurk) in the [gitter chat](https://gitter.im/Cross_Hair/Lobby).
 * [File an issue](https://github.com/pschanely/CrossHair/issues).
 * [Ask a question](https://stackoverflow.com/questions/tagged/crosshair) on stackoverflow.
-* Make a pull request. There aren't contributing guidelines yet - just check in on [gitter](https://gitter.im/Cross_Hair/Lobby) to coordinate.
+* Make a pull request. Please read the [contributing guidelines](doc/contributing.md).
 * Help me evangelize: Share with your friends and coworkers. If you think it's neato, star the repo. :star:
 * Contact me at `pschanely@gmail.com` or [Twitter](https://twitter.com/pschanely)... even if it's just to say that you'd like me to cc you on future CrossHair-related developments.
 

--- a/crosshair/examples/icontract/bugs_detected/showcase.py
+++ b/crosshair/examples/icontract/bugs_detected/showcase.py
@@ -30,6 +30,7 @@ def higher_order(fn: Callable[[int], int]) -> int:
     # Bug when given something like lambda a: 42 if (a == 0) else 0.
     return fn(fn(100))
 
+
 @snapshot(lambda lists: lists[:])
 @ensure(
     lambda lists, OLD: all(len(x) == len(OLD.lists[i] + 1) for i, x in enumerate(lists))

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,0 +1,117 @@
+# Contributing
+
+Table of Contents:
+* [Coordinate First](#coordinate-first)
+* [Create a Development Environment](#create-a-development-environment)
+* [Install Development Dependencies](#install-development-dependencies)
+* [Pre-commit Checks](#pre-commit-checks)
+
+## Coordinate First
+
+Before you create a pull request, please [create a new issue][new_issue] first 
+or check in on [gitter](https://gitter.im/Cross_Hair/Lobby) to coordinate.
+
+It might be that we are already working on the same or similar feature, but we 
+haven't made our work visible yet.
+
+[new_issue]: https://github.com/pschanely/CrossHair/issues/new/choose
+
+## Create a Development Environment
+
+We usually develop in a [virtual environment][venv].
+To create one, change to the root directory of the repository and invoke:
+
+```
+python -m venv venv
+```
+
+You need to activate it. On *nix (Linux, Mac, *etc.*):
+
+```
+source venv/bin/activate
+```
+
+and on Windows:
+
+```
+venv\Scripts\activate
+```
+
+[venv]: https://docs.python.org/3/tutorial/venv.html
+
+## Install Development Dependencies
+
+Once you activated the virtual environment, you can install the development 
+dependencies using `pip`:
+
+```
+pip3 install --editable .[dev]
+```
+
+The [`--editable`][pip-editable] option is necessary so that all the changes 
+made to the repository are automatically reflected in the virtual environment 
+(see also [this StackOverflow question][pip-editable-stackoverflow]).
+
+[pip-editable]: https://pip.pypa.io/en/stable/reference/pip_install/#install-editable 
+[pip-editable-stackoverflow]: https://stackoverflow.com/questions/35064426/when-would-the-e-editable-option-be-useful-with-pip-install
+
+## Pre-commit Checks
+
+We provide a battery of pre-commit checks to make the code uniform and 
+consistent across the code base.
+
+We use [black](https://pypi.org/project/black/) to format the code and use
+the default maximum line length of 88 characters.
+
+The docstrings need to conform to [PEP257][pep257].
+We use [Sphinx docstring format][sphinx-format] to mark special fields (such as
+function arguments, return values *etc.*).
+Please annotate your function with type annotations instead of writing the types
+in the docstring. 
+
+[pep257]: https://www.python.org/dev/peps/pep-0257/
+[sphinx-format]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
+
+To run all pre-commit checks, run from the root directory:
+
+```
+python precommit.py
+```
+
+You can automatically re-format the code with:
+
+```
+python precommit.py --overwrite
+```
+
+Here is the full manual of the pre-commit script:
+
+```
+usage: precommit.py 
+
+Run pre-commit checks on the repository.
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+  --overwrite           
+        Overwrites the unformatted source files with the well-formatted code 
+        in place. 
+
+        If not set, an exception is raised if any of the files do not conform 
+        to the style guide.
+
+  --select {black,flake8,pydocstyle,test,doctest} [{black,flake8,pydocstyle,test,doctest} ...]
+        If set, only the selected steps are executed. 
+
+        This is practical if some of the steps failed and you want to fix 
+        them in isolation.
+
+  --skip {black,flake8,pydocstyle,test,doctest} [{black,flake8,pydocstyle,test,doctest} ...]
+        If set, skips the specified steps. 
+
+        This is practical if some of the steps passed and you want to fix 
+        the remainder in isolation.
+```
+
+The pre-commit script also runs as part of our continuous integration pipeline.

--- a/precommit.py
+++ b/precommit.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Run pre-commit checks on the repository."""
+import argparse
+import enum
+import os
+import pathlib
+import subprocess
+import sys
+
+
+class Step(enum.Enum):
+    BLACK = "black"
+    FLAKE8 = "flake8"
+    PYDOCSTYLE = "pydocstyle"
+    TEST = "test"
+    DOCTEST = "doctest"
+
+
+def main() -> int:
+    """"Execute entry_point routine."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--overwrite",
+        help="Overwrites the unformatted source files with the well-formatted code in place. "
+        "If not set, an exception is raised "
+        "if any of the files do not conform to the style guide.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--select",
+        help="If set, only the selected steps are executed. "
+        "This is practical if some of the steps failed and you want to fix them in isolation.",
+        nargs="+",
+        choices=[value.value for value in Step],
+    )
+    parser.add_argument(
+        "--skip",
+        help="If set, skips the specified steps. "
+        "This is practical if some of the steps passed and "
+        "you want to fix the remainder in isolation.",
+        nargs="+",
+        choices=[value.value for value in Step],
+    )
+
+    args = parser.parse_args()
+
+    overwrite = bool(args.overwrite)
+
+    selects = (
+        [Step(value) for value in args.select]
+        if args.select is not None
+        else [value for value in Step]
+    )
+    skips = [Step(value) for value in args.skip] if args.skip is not None else []
+
+    repo_root = pathlib.Path(__file__).parent
+
+    if Step.BLACK in selects and Step.BLACK not in skips:
+        print("Black'ing...")
+        # fmt: off
+        black_targets = [
+            "crosshair",
+            "precommit.py",
+            "setup.py"
+        ]
+        # fmt: on
+
+        if overwrite:
+            subprocess.check_call(["black"] + black_targets, cwd=str(repo_root))
+        else:
+            subprocess.check_call(
+                ["black", "--check"] + black_targets, cwd=str(repo_root)
+            )
+    else:
+        print("Skipped black'ing.")
+
+    if Step.FLAKE8 in selects and Step.FLAKE8 not in skips:
+        print("Flake8'ing...")
+        # fmt: off
+        subprocess.check_call(
+            [
+                "flake8", "crosshair", "--count", "--select=E9,F63,F7,F82", "--show-source",
+                "--statistics"
+            ],
+            cwd=str(repo_root)
+        )
+        # fmt: on
+    else:
+        print("Skipped flake8'ing.")
+
+    if Step.PYDOCSTYLE in selects and Step.PYDOCSTYLE not in skips:
+        print("Pydocstyle'ing...")
+        subprocess.check_call(
+            [
+                "pydocstyle",
+                "--ignore=D1,D203,D212",
+                r"--match=.*(?<!_test).py$",
+                r"--match-dir=(?!/examples/)",
+                "crosshair",
+            ],
+            cwd=str(repo_root),
+        )
+    else:
+        print("Skipped pydocstyle'ing.")
+
+    if Step.TEST in selects and Step.TEST not in skips:
+        print("Testing...")
+        env = os.environ.copy()
+        env["ICONTRACT_SLOW"] = "true"
+
+        # fmt: off
+        subprocess.check_call(
+            [
+                "coverage", "run",
+                "--source", "crosshair",
+                "--omit=__init__.py"
+                "--omit=*_test.py",
+                "-m", "pytest",
+                "--doctest-modules"
+            ],
+            cwd=str(repo_root),
+            env=env,
+        )
+        # fmt: on
+
+        subprocess.check_call(["coverage", "report"])
+    else:
+        print("Skipped testing.")
+
+    if Step.DOCTEST in selects and Step.DOCTEST not in skips:
+        print("Doctesting...")
+        for pth in (repo_root / "doc").glob("**/*.md"):
+            subprocess.check_call([sys.executable, "-m", "doctest", str(pth)])
+        subprocess.check_call([sys.executable, "-m", "doctest", "README.md"])
+    else:
+        print("Skipped doctesting.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,52 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='crosshair-tool',
-    version='0.0.9',
-    author='Phillip Schanely',
-    author_email='pschanely+vE7F@gmail.com',
+    name="crosshair-tool",
+    version="0.0.9",
+    author="Phillip Schanely",
+    author_email="pschanely+vE7F@gmail.com",
     packages=find_packages(),
     scripts=[],
-    entry_points = {
-        'console_scripts': ['crosshair=crosshair.main:main'],
+    entry_points={
+        "console_scripts": ["crosshair=crosshair.main:main"],
     },
-    url='https://github.com/pschanely/CrossHair',
-    license='MIT',
-    description='A static analysis tool for Python using symbolic execution.',
-    long_description=open('README.md').read().replace('doc/', 'https://raw.githubusercontent.com/pschanely/CrossHair/master/doc/'),
-    long_description_content_type='text/markdown',
+    url="https://github.com/pschanely/CrossHair",
+    license="MIT",
+    description="A static analysis tool for Python using symbolic execution.",
+    long_description=open("README.md")
+    .read()
+    .replace(
+        "doc/", "https://raw.githubusercontent.com/pschanely/CrossHair/master/doc/"
+    ),
+    long_description_content_type="text/markdown",
     install_requires=[
-        'forbiddenfruit',
-        'typing-inspect',
-        'z3-solver==4.8.9.0',
+        "forbiddenfruit",
+        "typing-inspect",
+        "z3-solver==4.8.9.0",
     ],
     extras_require={
-        'test': [
-            'icontract',
-            'numpy', # For doctests in example code
-            'pytest',
+        "dev": [
+            "icontract",
+            "numpy",  # For doctests in example code
+            "pytest",
+            "flake8",
+            "coverage",
+            "codecov",
+            "black==20.8b1",
+            "pydocstyle==5.1.1",
         ]
     },
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Topic :: Software Development :: Quality Assurance',
-        'Topic :: Software Development :: Testing',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: Software Development :: Quality Assurance",
+        "Topic :: Software Development :: Testing",
     ],
-    python_requires='>=3.7',
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
This patch introduces a commit script to run one, more or all pre-commit
checks from the command line or as part of our continuous integration
pipeline.

It also documents the contributing guidelines, which also explain how to
set up the development environment.