### PR TITLE
Comment why doctest on doc separate in precommit

### DIFF
--- a/precommit.py
+++ b/precommit.py
@@ -128,6 +128,14 @@ def main() -> int:
         print("Skipped testing.")
 
     if Step.DOCTEST in selects and Step.DOCTEST not in skips:
+        # We doctest the documentation in a separate step from testing so that
+        # the two steps can run in isolation.
+        #
+        # It is indeed possible to doctest the documentation *together* with
+        # the other tests using pytest (and even measure the code coverage),
+        # but this is not desirable as tests can take quite long to run.
+        # This would slow down the development if all we want is to iterate
+        # on documentation doctests.
         print("Doctesting...")
         for pth in (repo_root / "doc").glob("**/*.md"):
             subprocess.check_call([sys.executable, "-m", "doctest", str(pth)])


### PR DESCRIPTION
This patch adds a comment explaining why we run doctests in a separate
step in the precommit script. This is necessary in order to avoid
confusion as it is actually possible to execute doctests during testing.

See also [this comment on the pull request #71][comment].

[comment]: https://github.com/pschanely/CrossHair/pull/71#discussion_r570356585