### PR TITLE
Publish continuously to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,36 @@
+# Based on https://github.com/actions/starter-workflows/blob/main/ci/python-publish.yml
+name: Publish to Pypi
+
+on:
+  release:
+    types: [created]
+
+  push:
+    branches:
+      - '*/fixed-publishing-to-pypi'
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: "__token__"
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        python setup.py bdist_wheel sdist
+        twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
             "codecov",
             "black==20.8b1",
             "pydocstyle==5.1.1",
+            "wheel",
         ]
     },
     classifiers=[


### PR DESCRIPTION
This patch introduces a GitHub workflow that is triggered on a GitHub
release. The workflow automatically builds the source distribution and
uploads it to PyPI.