### PR TITLE
Undry metadata from setup.py

### DIFF
--- a/additional-verbs-in-imperative-mood.txt
+++ b/additional-verbs-in-imperative-mood.txt
@@ -21,3 +21,4 @@ skip
 redirect
 deduplicate
 re-order
+undry

--- a/check_init_and_setup_coincide.py
+++ b/check_init_and_setup_coincide.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+"""Check that the distribution and crosshair/__init__.py are in sync."""
+import subprocess
+import sys
+from typing import Optional, Dict
+
+import pkg_resources
+import email
+
+import crosshair
+
+
+def main() -> int:
+    """Execute the main routine."""
+    success = True
+
+    ##
+    # Check basic fields
+    ##
+
+    setup_py = dict()  # type: Dict[str, str]
+
+    fields = ["version", "author", "license", "description"]
+    for field in fields:
+        out = subprocess.check_output(
+            [sys.executable, "setup.py", f"--{field}"], encoding="utf-8"
+        ).strip()
+
+        setup_py[field] = out
+
+    if setup_py["version"] != crosshair.__version__:
+        print(
+            f"The version in the setup.py is {setup_py['version']}, "
+            f"while the version in crosshair/__init__.py is: "
+            f"{crosshair.__version__}",
+            file=sys.stderr,
+        )
+        success = False
+
+    if setup_py["author"] != crosshair.__author__:
+        print(
+            f"The author in the setup.py is {setup_py['author']}, "
+            f"while the author in crosshair/__init__.py is: "
+            f"{crosshair.__author__}",
+            file=sys.stderr,
+        )
+        success = False
+
+    if setup_py["license"] != crosshair.__license__:
+        print(
+            f"The license in the setup.py is {setup_py['license']}, "
+            f"while the license in crosshair/__init__.py is: "
+            f"{crosshair.__license__}",
+            file=sys.stderr,
+        )
+        success = False
+
+    if setup_py["description"] != crosshair.__doc__:
+        print(
+            f"The description in the setup.py is {setup_py['description']}, "
+            f"while the description in crosshair/__init__.py is: "
+            f"{crosshair.__doc__}",
+            file=sys.stderr,
+        )
+        success = False
+
+    ##
+    # Classifiers need special attention as there are multiple.
+    ##
+
+    # This is the map from the distribution to expected status in __init__.py.
+    status_map = {
+        "Development Status :: 1 - Planning": "Planning",
+        "Development Status :: 2 - Pre-Alpha": "Pre-Alpha",
+        "Development Status :: 3 - Alpha": "Alpha",
+        "Development Status :: 4 - Beta": "Beta",
+        "Development Status :: 5 - Production/Stable": "Production/Stable",
+        "Development Status :: 6 - Mature": "Mature",
+        "Development Status :: 7 - Inactive": "Inactive",
+    }
+
+    classifiers = (
+        subprocess.check_output(
+            [sys.executable, "setup.py", f"--classifiers"], encoding="utf-8"
+        )
+        .strip()
+        .splitlines()
+    )
+
+    status_classifier = None  # type: Optional[str]
+    for classifier in classifiers:
+        if classifier in status_map:
+            status_classifier = classifier
+            break
+
+    if status_classifier is None:
+        print(
+            f"Expected a status classifier in setup.py "
+            f"(e.g., 'Development Status :: 3 - Alpha'), but found none.",
+            file=sys.stderr,
+        )
+        success = False
+    else:
+        expected_status_in_init = status_map[status_classifier]
+
+        if expected_status_in_init != crosshair.__status__:
+            print(
+                f"Expected status {expected_status_in_init} "
+                f"according to setup.py in crosshair/__init__.py, "
+                f"but found: {crosshair.__status__}"
+            )
+            success = False
+
+    if not success:
+        return -1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crosshair/__init__.py
+++ b/crosshair/__init__.py
@@ -1,3 +1,5 @@
+"""Analyze Python code for correctness using symbolic execution."""
+
 from crosshair.core import realize
 from crosshair.core import with_realized_args
 from crosshair.core import register_patch
@@ -5,3 +7,9 @@ from crosshair.core import register_type
 from crosshair.statespace import StateSpace
 from crosshair.util import IgnoreAttempt
 from crosshair.util import debug
+
+# Do not forget to update in setup.py!
+__version__ = "0.0.9"
+__author__ = "Phillip Schanely"
+__license__ = "MIT"
+__status__ = "Alpha"

--- a/precommit.py
+++ b/precommit.py
@@ -14,6 +14,7 @@ class Step(enum.Enum):
     PYDOCSTYLE = "pydocstyle"
     TEST = "test"
     DOCTEST = "doctest"
+    CHECK_INIT_AND_SETUP_COINCIDE = "check-init-and-setup-coincide"
 
 
 def main() -> int:
@@ -61,7 +62,8 @@ def main() -> int:
         black_targets = [
             "crosshair",
             "precommit.py",
-            "setup.py"
+            "setup.py",
+            "check_init_and_setup_coincide.py"
         ]
         # fmt: on
 
@@ -79,7 +81,8 @@ def main() -> int:
         # fmt: off
         subprocess.check_call(
             [
-                "flake8", "crosshair", "--count", "--select=E9,F63,F7,F82", "--show-source",
+                "flake8", "crosshair", "--count", "--select=E9,F63,F7,F82",
+                "--show-source",
                 "--statistics"
             ],
             cwd=str(repo_root)
@@ -142,6 +145,15 @@ def main() -> int:
         subprocess.check_call([sys.executable, "-m", "doctest", "README.md"])
     else:
         print("Skipped doctesting.")
+
+    if (
+        Step.CHECK_INIT_AND_SETUP_COINCIDE in selects
+        and Step.CHECK_INIT_AND_SETUP_COINCIDE not in skips
+    ):
+        print("Checking that crosshair/__init__.py and setup.py coincide...")
+        subprocess.check_call([sys.executable, "check_init_and_setup_coincide.py"])
+    else:
+        print("Skipped checking that crosshair/__init__.py and " "setup.py coincide.")
 
     return 0
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,17 @@
 from setuptools import setup, find_packages
 
+# Do not forget to update and sync the fields in crosshair/__init__.py!
+#
+# (mristin, 2021-02-05): It is almost impossible to refer to the
+# crosshair/__init__.py from within setup.py as the source distribution will
+# run setup.py while installing the package.
+# That is why we can not be DRY here and need to sync manually.
+#
+# See also this StackOverflow question:
+# https://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package
+#
+# The fields between crosshair/__init__.py and this file are checked as part of
+# the pre-commit checks through check_init_and_setup_coincide.py.
 setup(
     name="crosshair-tool",
     version="0.0.9",
@@ -12,7 +24,7 @@ setup(
     },
     url="https://github.com/pschanely/CrossHair",
     license="MIT",
-    description="A static analysis tool for Python using symbolic execution.",
+    description="Analyze Python code for correctness using symbolic execution.",
     long_description=open("README.md")
     .read()
     .replace(


### PR DESCRIPTION
We need to denormalize the medata (such as version, author, license
*etc.*) between `setup.py` and `crosshair/__init__.py` so that both
Sphinx and setup can access them.

Mind that you can not import the module (`crosshair/__init__.py`) from
within `setup.py` as this would cause race condition during the
installation.

To enforce the consistency, we add a script to the pre-commit checks.