### PR TITLE
Fix links and code blocks in the doc

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -9,7 +9,7 @@ Version 0.0.9
 * Introduce :ref:`the diffbehavior command <diffbehavior>` which finds
   inputs that distinguish the behavior of two functions.
 * Upgrade to the latest release of Z3 (4.8.9.0)
-* Fix `an installation error on Windows <issue_41>`_.
+* Fix `an installation error on Windows <issue_41_>`_.
 * Fix a variety of other bugs.
 
 .. _issue_41: https://github.com/pschanely/CrossHair/issues/41

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -6,12 +6,13 @@ Coordinate First
 ================
 
 Before you create a pull request, please `create a new issue`_ first 
-or check in on [gitter](https://gitter.im/Cross_Hair/Lobby) to coordinate.
+or check in on `gitter`_ to coordinate.
 
 It might be that we are already working on the same or similar feature, but we 
 haven't made our work visible yet.
 
 .. _create a new issue: https://github.com/pschanely/CrossHair/issues/new/choose
+.. _gitter: https://gitter.im/Cross_Hair/Lobby
 
 Create a Development Environment
 ================================
@@ -19,20 +20,20 @@ Create a Development Environment
 We usually develop in a `virtual environment`_.
 To create one, change to the root directory of the repository and invoke:
 
-.. code-block:
+.. code-block::
 
     python -m venv venv
 
 
 You need to activate it. On *nix (Linux, Mac, *etc.*):
 
-.. code-block:
+.. code-block::
 
     source venv/bin/activate
 
 and on Windows:
 
-.. code-block:
+.. code-block::
 
     venv\Scripts\activate
 
@@ -44,13 +45,13 @@ Install Development Dependencies
 Once you activated the virtual environment, you can install the development 
 dependencies using ``pip``:
 
-.. code-block:
+.. code-block::
 
     pip3 install --editable .[dev]
 
-The `--editable <pip-editable>`_ option is necessary so that all the changes
+The `--editable <pip-editable_>`_ option is necessary so that all the changes
 made to the repository are automatically reflected in the virtual environment 
-(see also `this StackOverflow question <pip-editable-stackoverflow>`_).
+(see also `this StackOverflow question <pip-editable-stackoverflow_>`_).
 
 .. _pip-editable: https://pip.pypa.io/en/stable/reference/pip_install/#install-editable
 .. _pip-editable-stackoverflow: https://stackoverflow.com/questions/35064426/when-would-the-e-editable-option-be-useful-with-pip-install
@@ -61,33 +62,35 @@ Pre-commit Checks
 We provide a battery of pre-commit checks to make the code uniform and 
 consistent across the code base.
 
-We use `black <https://pypi.org/project/black/>`_ to format the code and use
-the default maximum line length of 88 characters.
+We use `black`_ to format the code and use the default maximum line length of
+88 characters.
 
-The docstrings need to conform to `PEP 257 <pep257>`_.
-We use `Sphinx docstring format <sphinx-format>`_ to mark special fields (such
-as function arguments, return values *etc.*).
+.. _black: https://pypi.org/project/black/
+
+The docstrings need to conform to `PEP 257`_.
+We use `Sphinx docstring format`_ to mark special fields (such as function
+arguments, return values *etc.*).
 Please annotate your function with type annotations instead of writing the types
 in the docstring. 
 
-.. _pep257: https://www.python.org/dev/peps/pep-0257/
-.. sphinx-format: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
+.. _PEP 257: https://www.python.org/dev/peps/pep-0257/
+.. _Sphinx docstring format: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
 
 To run all pre-commit checks, run from the root directory:
 
-.. code-block:
+.. code-block::
 
     python precommit.py
 
 You can automatically re-format the code with:
 
-.. code-block:
+.. code-block::
 
     python precommit.py --overwrite
 
 Here is the full manual of the pre-commit script:
 
-.. code-block:
+.. code-block::
 
     usage: precommit.py
 
@@ -120,7 +123,7 @@ The pre-commit script also runs as part of our continuous integration pipeline.
 Write Commit Message
 ====================
 
-We follow Chris Beams' `guidelines on commit messages <commit-guidelines>`_:
+We follow Chris Beams' `guidelines on commit messages`_:
 
 1) Separate subject from body with a blank line
 2) Limit the subject line to 50 characters
@@ -130,4 +133,4 @@ We follow Chris Beams' `guidelines on commit messages <commit-guidelines>`_:
 6) Wrap the body at 72 characters
 7) Use the body to explain *what* and *why* vs. *how*
 
-.. _commit-guidelines: https://chris.beams.io/posts/git-commit/
+.. _guidelines on commit messages: https://chris.beams.io/posts/git-commit/

--- a/doc/source/related_work.rst
+++ b/doc/source/related_work.rst
@@ -30,7 +30,7 @@ Related Work
     Unlike these tools, CrossHair models the semantics of Python directly.
 
 `PyExZ3`_, `pySim`_, `PEF`_
-    Take approaches that are very similar to CrossHair, in various states
+    These approaches that are very similar to CrossHair, in various states
     of completeness.
     CrossHair is generally more prescriptive or product-like than
     these tools.

--- a/doc/source/why_should_i_use_crosshair.rst
+++ b/doc/source/why_should_i_use_crosshair.rst
@@ -45,7 +45,7 @@ which will find exceptions like index out-of-bounds errors:
     :alt: Image showing CrossHair contract and IndexError
 
 **Support your type checker.**
-CrossHair is a nice companion to `mypy`_].
+CrossHair is a nice companion to `mypy`_.
 Assert statements divide work between the two systems:
 
 .. image:: pair_with_mypy.png


### PR DESCRIPTION
This patch makes various minor fixes to the documentation. Namely, the
external links with the named target were lacking the suffix underscore
("_"), and certain code blocks were missing double colon suffix 
(`..code-block:` instead of `.. code-block::`).