### PR TITLE
Document command-line interface

### DIFF
--- a/check_help_in_doc.py
+++ b/check_help_in_doc.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+
+"""Check that the help snippets in the doc coincide with the actual output."""
+import argparse
+import os
+import pathlib
+import re
+import subprocess
+import sys
+from typing import List, Tuple, Optional
+
+import icontract
+
+
+class Block:
+    """Represent a block in the readme that needs to be checked."""
+
+    @icontract.require(lambda command: command != "")
+    @icontract.require(
+        lambda start_line_idx, end_line_idx: start_line_idx <= end_line_idx
+    )
+    def __init__(self, command: str, start_line_idx: int, end_line_idx: int) -> None:
+        """
+        Initialize with the given values.
+
+        :param command: help command
+        :param start_line_idx: index of the first relevant line
+        :param end_line_idx: index of the first line excluded from the block
+        """
+        self.command = command
+        self.start_line_idx = start_line_idx
+        self.end_line_idx = end_line_idx
+
+
+HELP_STARTS_RE = re.compile(r"^.. Help starts: (?P<command>.*)$")
+
+
+def parse_rst(lines: List[str]) -> Tuple[List[Block], List[str]]:
+    """
+    Parse the code blocks that represent help commands in the RST file.
+
+    :param lines: lines of the readme file
+    :return: (help blocks, errors if any)
+    """
+    blocks = []  # type: List[Block]
+    errors = []  # type: List[str]
+
+    i = 0
+    while i < len(lines):
+        mtch = HELP_STARTS_RE.match(lines[i])
+        if mtch:
+            command = mtch.group("command")
+            help_ends = ".. Help ends: {}".format(command)
+            try:
+                end_index = lines.index(help_ends, i)
+            except ValueError:
+                end_index = -1
+
+            if end_index == -1:
+                return [], ["Could not find the end marker {!r}".format(help_ends)]
+
+            blocks.append(
+                Block(command=command, start_line_idx=i + 1, end_line_idx=end_index)
+            )
+
+            i = end_index + 1
+
+        else:
+            i += 1
+
+    return blocks, errors
+
+
+def capture_output_lines(command: str) -> List[str]:
+    """Capture the output of a help command."""
+    command_parts = command.split(" ")
+    if command_parts[0] in ["python", "python3"]:
+        # We need to replace "python" with "sys.executable" on Windows as the environment
+        # is not properly inherited.
+        command_parts[0] = sys.executable
+
+    proc = subprocess.Popen(
+        command_parts,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    output, err = proc.communicate()
+    if err:
+        raise RuntimeError(
+            f"The command {command!r} failed with exit code {proc.returncode} and "
+            f"stderr:\n{err}"
+        )
+
+    return output.splitlines()
+
+
+def output_lines_to_code_block(output_lines: List[str]) -> List[str]:
+    """Translate the output of a help command to a RST code block."""
+    result = (
+        [".. code-block:: text", ""]
+        + ["    " + output_line for output_line in output_lines]
+        + [""]
+    )
+
+    result = [line.rstrip() for line in result]
+    return result
+
+
+def diff(got_lines: List[str], expected_lines: List[str]) -> Optional[str]:
+    """
+    Report a difference between the ``got`` and ``expected``.
+
+    Return None if no difference.
+    """
+    if got_lines == expected_lines:
+        return None
+
+    result = []
+
+    result.append("Expected:")
+    for i, line in enumerate(expected_lines):
+        if i >= len(got_lines) or line != got_lines[i]:
+            print("DIFF: {:2d}: {!r}".format(i, line))
+        else:
+            print("OK  : {:2d}: {!r}".format(i, line))
+
+    result.append("Got:")
+    for i, line in enumerate(got_lines):
+        if i >= len(expected_lines) or line != expected_lines[i]:
+            print("DIFF: {:2d}: {!r}".format(i, line))
+        else:
+            print("OK  : {:2d}: {!r}".format(i, line))
+
+    return "\n".join(result)
+
+def process_file(path: pathlib.Path, overwrite: bool) -> List[str]:
+    """Check or overwrite the help blocks in the given file.
+
+    :param path: to the doc file
+    :param overwrite: if set, overwrite the help blocks
+    :return: list of errors, if any
+    """
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    blocks, errors = parse_rst(lines=lines)
+    if errors:
+        return errors
+
+    if len(blocks) == 0:
+        return []
+
+    if overwrite:
+        result = []  # type: List[str]
+
+        previous_block = None  # type: Optional[Block]
+        for block in blocks:
+            output_lines = capture_output_lines(command=block.command)
+            code_block_lines = output_lines_to_code_block(output_lines=output_lines)
+
+            if previous_block is None:
+                result.extend(lines[: block.start_line_idx])
+            else:
+                result.extend(lines[previous_block.end_line_idx: block.start_line_idx])
+
+            result.extend(code_block_lines)
+            previous_block = block
+
+        result.extend(lines[previous_block.end_line_idx:])
+        result.append("")  # new line at the end of file
+
+        path.write_text("\n".join(result))
+
+    else:
+        for block in blocks:
+            output_lines = capture_output_lines(command=block.command)
+            code_block_lines = output_lines_to_code_block(output_lines=output_lines)
+
+            expected_lines = lines[block.start_line_idx: block.end_line_idx]
+            expected_lines = [line.rstrip() for line in expected_lines]
+
+            error = diff(got_lines=code_block_lines, expected_lines=expected_lines)
+            if error:
+                return [error]
+
+def main() -> int:
+    """Execute the main routine."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--overwrite",
+        help="If set, overwrite the relevant part of the doc in-place.",
+        action="store_true",
+    )
+
+    args = parser.parse_args()
+    overwrite = bool(args.overwrite)
+
+    this_dir = pathlib.Path(os.path.realpath(__file__)).parent
+
+    pths = [
+        this_dir / "doc" / "source" / "command-line_interface.rst",
+        this_dir / "doc" / "source" / "contributing.rst",
+    ]
+
+    success = True
+
+    for pth in pths:
+        errors = process_file(path=pth, overwrite=overwrite)
+        if errors:
+            print("One or more errors in {}:".format(pth), file=sys.stderr)
+            for error in errors:
+                print(error, file=sys.stderr)
+            success = False
+
+    if not success:
+        return -1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/source/command-line_interface.rst
+++ b/doc/source/command-line_interface.rst
@@ -1,0 +1,123 @@
+**********************
+Command-line Interface
+**********************
+
+Crosshair provides the following commands:
+
+.. code-block::
+
+    crosshair --help
+
+.. Help starts: crosshair --help
+.. code-block:: text
+
+    usage: crosshair [-h] {check,watch,diffbehavior} ...
+
+    CrossHair Analysis Tool
+
+    positional arguments:
+      {check,watch,diffbehavior}
+                            sub-command help
+        check               Analyze a file
+        watch               Continuously watch and analyze a directory
+        diffbehavior        Find differences in behavior between two functions
+
+    optional arguments:
+      -h, --help            show this help message and exit
+
+.. Help ends: crosshair --help
+
+``check``
+=========
+
+.. code-block::
+
+    crosshair check --help
+
+.. Help starts: crosshair check --help
+.. code-block:: text
+
+    usage: crosshair check [-h] [--verbose] [--per_path_timeout PER_PATH_TIMEOUT]
+                           [--per_condition_timeout PER_CONDITION_TIMEOUT]
+                           [--report_all] [--analysis_kind ANALYSIS_KIND]
+                           F [F ...]
+
+    positional arguments:
+      F                     file or fully qualified module, class, or function
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --verbose, -v
+      --per_path_timeout PER_PATH_TIMEOUT
+                            Maximum seconds to spend checking one execution path
+      --per_condition_timeout PER_CONDITION_TIMEOUT
+                            Maximum seconds to spend checking execution paths for
+                            one condition
+      --report_all          Output analysis results for all postconditions (not
+                            just failing ones)
+      --analysis_kind ANALYSIS_KIND
+                            Kinds of analysis to perform.
+
+.. Help ends: crosshair check --help
+
+``watch``
+=========
+
+.. code-block::
+
+    crosshair watch --help
+
+.. Help starts: crosshair watch --help
+.. code-block:: text
+
+    usage: crosshair watch [-h] [--verbose] [--per_path_timeout PER_PATH_TIMEOUT]
+                           [--per_condition_timeout PER_CONDITION_TIMEOUT]
+                           [--analysis_kind ANALYSIS_KIND]
+                           F [F ...]
+
+    positional arguments:
+      F                     file or directory to analyze
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --verbose, -v
+      --per_path_timeout PER_PATH_TIMEOUT
+                            Maximum seconds to spend checking one execution path
+      --per_condition_timeout PER_CONDITION_TIMEOUT
+                            Maximum seconds to spend checking execution paths for
+                            one condition
+      --analysis_kind ANALYSIS_KIND
+                            Kinds of analysis to perform.
+
+.. Help ends: crosshair watch --help
+
+``diffbehavior``
+================
+
+.. code-block::
+
+    crosshair diffbehavior --help
+
+.. Help starts: crosshair diffbehavior --help
+.. code-block:: text
+
+    usage: crosshair diffbehavior [-h] [--verbose]
+                                  [--per_path_timeout PER_PATH_TIMEOUT]
+                                  [--per_condition_timeout PER_CONDITION_TIMEOUT]
+                                  fn1 fn2
+
+    positional arguments:
+      fn1                   first module+function to compare (e.g.
+                            "mymodule.myfunc")
+      fn2                   second function to compare
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --verbose, -v
+      --per_path_timeout PER_PATH_TIMEOUT
+                            Maximum seconds to spend checking one execution path
+      --per_condition_timeout PER_CONDITION_TIMEOUT
+                            Maximum seconds to spend checking execution paths for
+                            one condition
+
+.. Help ends: crosshair diffbehavior --help

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -90,33 +90,30 @@ You can automatically re-format the code with:
 
 Here is the full manual of the pre-commit script:
 
-.. code-block::
+.. Help starts: python precommit.py --help
+.. code-block:: text
 
-    usage: precommit.py
+    usage: precommit.py [-h] [--overwrite] [--select  [...]] [--skip  [...]]
 
     Run pre-commit checks on the repository.
 
     optional arguments:
-      -h, --help            show this help message and exit
+      -h, --help        show this help message and exit
+      --overwrite       Try to automatically fix the offending files (e.g., by re-
+                        formatting).
+      --select  [ ...]  If set, only the selected steps are executed. This is
+                        practical if some of the steps failed and you want to fix
+                        them in isolation. The steps are given as a space-
+                        separated list of: black flake8 pydocstyle test doctest
+                        check-init-and-setup-coincide check-help-in-doc
+      --skip  [ ...]    If set, skips the specified steps. This is practical if
+                        some of the steps passed and you want to fix the remainder
+                        in isolation. The steps are given as a space-separated
+                        list of: black flake8 pydocstyle test doctest check-init-
+                        and-setup-coincide check-help-in-doc
 
-      --overwrite
-            Overwrites the unformatted source files with the well-formatted code
-            in place.
+.. Help ends: python precommit.py --help
 
-            If not set, an exception is raised if any of the files do not conform
-            to the style guide.
-
-      --select {black,flake8,pydocstyle,test,doctest} [{black,flake8,pydocstyle,test,doctest} ...]
-            If set, only the selected steps are executed.
-
-            This is practical if some of the steps failed and you want to fix
-            them in isolation.
-
-      --skip {black,flake8,pydocstyle,test,doctest} [{black,flake8,pydocstyle,test,doctest} ...]
-            If set, skips the specified steps.
-
-            This is practical if some of the steps passed and you want to fix
-            the remainder in isolation.
 
 The pre-commit script also runs as part of our continuous integration pipeline.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,5 +1,6 @@
+*************************************
 Welcome to CrossHair's documentation!
-=================================================
+*************************************
 
 .. toctree::
    :maxdepth: 1
@@ -9,6 +10,7 @@ Welcome to CrossHair's documentation!
    why_should_i_use_crosshair
    kinds_of_contracts
    get_started
+   command-line_interface
    ide_integrations
    limitations
    diff_behavior

--- a/precommit.py
+++ b/precommit.py
@@ -15,6 +15,7 @@ class Step(enum.Enum):
     TEST = "test"
     DOCTEST = "doctest"
     CHECK_INIT_AND_SETUP_COINCIDE = "check-init-and-setup-coincide"
+    CHECK_HELP_IN_DOC = "check-help-in-doc"
 
 
 def main() -> int:
@@ -22,23 +23,32 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--overwrite",
-        help="Overwrites the unformatted source files with the well-formatted code in place. "
-        "If not set, an exception is raised "
-        "if any of the files do not conform to the style guide.",
+        help="Try to automatically fix the offending files (e.g., by re-formatting).",
         action="store_true",
     )
     parser.add_argument(
         "--select",
-        help="If set, only the selected steps are executed. "
-        "This is practical if some of the steps failed and you want to fix them in isolation.",
+        help=(
+            "If set, only the selected steps are executed. "
+            "This is practical if some of the steps failed and you want to "
+            "fix them in isolation. "
+            "The steps are given as a space-separated list of: "
+            + " ".join(value.value for value in Step)
+        ),
+        metavar="",
         nargs="+",
         choices=[value.value for value in Step],
     )
     parser.add_argument(
         "--skip",
-        help="If set, skips the specified steps. "
-        "This is practical if some of the steps passed and "
-        "you want to fix the remainder in isolation.",
+        help=(
+            "If set, skips the specified steps. "
+            "This is practical if some of the steps passed and "
+            "you want to fix the remainder in isolation. "
+            "The steps are given as a space-separated list of: "
+            + " ".join(value.value for value in Step)
+        ),
+        metavar="",
         nargs="+",
         choices=[value.value for value in Step],
     )
@@ -154,6 +164,20 @@ def main() -> int:
         subprocess.check_call([sys.executable, "check_init_and_setup_coincide.py"])
     else:
         print("Skipped checking that crosshair/__init__.py and " "setup.py coincide.")
+
+    if Step.CHECK_HELP_IN_DOC in selects and Step.CHECK_HELP_IN_DOC not in skips:
+        cmd = [sys.executable, "check_help_in_doc.py"]
+        if overwrite:
+            cmd.append("--overwrite")
+
+        if not overwrite:
+            print("Checking that --help's and the doc coincide...")
+        else:
+            print("Overwriting the --help's in the doc...")
+
+        subprocess.check_call(cmd)
+    else:
+        print("Skipped checking that --help's and the doc coincide.")
 
     return 0
 


### PR DESCRIPTION
This patch documents the command-line interface in the documentation.

To ensure that the documentation is always up-to-date, the patch also
includes a script that verifies the output of `--help` against the
documentation.