### PR TITLE
Upgrade deal, use new features

### DIFF
--- a/crosshair/condition_parser_test.py
+++ b/crosshair/condition_parser_test.py
@@ -257,9 +257,7 @@ class IcontractParserTest(unittest.TestCase):
         decr_conditions = conditions.methods["decr"]
         self.assertEqual(len(decr_conditions.pre), 2)
         # decr() precondition: count > 0
-        self.assertEqual(
-            decr_conditions.pre[0].evaluate({"self": Counter()}), False
-        )
+        self.assertEqual(decr_conditions.pre[0].evaluate({"self": Counter()}), False)
         # invariant: count >= 0
         self.assertEqual(decr_conditions.pre[1].evaluate({"self": Counter()}), True)
 

--- a/crosshair/core_and_libs.py
+++ b/crosshair/core_and_libs.py
@@ -72,8 +72,8 @@ def _make_registrations():
     try:
         import deal
 
-        if LooseVersion(deal.__version__) < LooseVersion("4.11.0"):
-            raise Exception("CrossHair requires deal version >= 4.11.0")
+        if LooseVersion(deal.__version__) < LooseVersion("4.13.0"):
+            raise Exception("CrossHair requires deal version >= 4.13.0")
         deal.disable()
     except ImportError:
         pass

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages  # type: ignore
 # the pre-commit checks through check_init_and_setup_coincide.py.
 setup(
     name="crosshair-tool",
-    version="0.0.17",  #  Update this in crosshair/__init__.py too
+    version="0.0.17",  # Update this in crosshair/__init__.py too
     author="Phillip Schanely",
     author_email="pschanely+vE7F@gmail.com",
     packages=find_packages(),
@@ -44,7 +44,7 @@ setup(
         "dev": [
             "autodocsumm>=0.2.2,<1",
             "black==20.8b1",
-            "deal>=4.11.0",
+            "deal>=4.13.0",
             "flake8",
             "hypothesis>=6.0.0",
             "icontract>=2.4.0",


### PR DESCRIPTION
1. Use `deal.introspection.unwrap` to extract the original function
2. Use `deal.introspection.init_all` to precache contracts
3. Use `pytest.mark.skipif`  to explicitly skip tests if dependencies are missed.

Closes #116 