### PR TITLE
Add pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+# flake8 config
+
+[flake8]
+max-line-length = 79
+max-complexity = 18
+select= E9,F63,F7,F82

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# pre-commit config
+# see docs at https://pre-commit.com/
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,9 @@ repos:
     rev: 3.7.9
     hooks:
     - id: flake8
+- repo: https://github.com/PyCQA/pydocstyle
+  rev: 6.1.1
+  hooks:
+    - id: pydocstyle
+      args:
+        - --ignore=D1,D203,D212

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
     - id: pydocstyle
       args:
         - --ignore=D1,D203,D212
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.902'
+    hooks:
+    -   id: mypy
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,14 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
-    -   id: check-yaml
+    # -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
     rev: 19.3b0
     hooks:
     -   id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    - id: flake8


### PR DESCRIPTION
For review... this is an initial stab at migrating your `precommit.py` file to the `pre-commit` git hook. It can be run by first installing `pre-commit` with `pip install pre-commit` then running `pre-commit install` and then you can run it with `pre-commit run` and since it's a git hook it will run on commit - which can be bypassed with `--no-verify`.

Pre-commit docs are pretty solid, and I just thought, in the spirit of hacktoberfest to see if you might like to migrate.

Note: No doctest is here, or pytest necessarily but I think we could work them in if desired.

Reasons: the config is much more extensible and more easily worked with than a custom .py file and there's wide support for numerous hooks.

Let me know what you think!