### PR TITLE
Avoid hashing when adding symbolic to a concrete set or dict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,12 +49,12 @@ repos:
         files: .+\.rst|main\.py
       - id: smoke test
         name: Run smoke tests
-        entry: env PYTHONHASHSEED=0 python -m pytest -m smoke -n 3
+        entry: env PYTHONHASHSEED=0 python -m pytest -m smoke -n auto --dist worksteal
         language: system
         pass_filenames: false
       - id: pytest
         name: Run all pytest tests
-        entry: env PYTHONHASHSEED=0 python -m pytest -n 3
+        entry: env PYTHONHASHSEED=0 python -m pytest -n auto --dist worksteal
         language: system
         stages: [manual]
         pass_filenames: false

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -4083,6 +4083,24 @@ def _chr(i: int) -> Union[str, LazyIntSymbolicStr]:
     return chr(realize(i))
 
 
+def _dict(arg=_MISSING) -> Union[dict, ShellMutableMap]:
+    if optional_context_statespace():
+        debug(test_stack())
+        if isinstance(arg, dict):
+            return ShellMutableMap(arg)
+        elif arg is _MISSING:
+            return ShellMutableMap(SimpleDict([]))
+        elif not is_iterable(arg):
+            raise TypeError
+        else:
+            if any(len(x) != 2 for x in arg):
+                raise ValueError
+            if any(not is_hashable(k) for (k, v) in arg):
+                raise TypeError
+            return ShellMutableMap(SimpleDict(list(arg)))
+    return dict() if arg is _MISSING else dict(arg)
+
+
 def _eval(expr: str, _globals=None, _locals=None) -> object:
     # This is fragile: consider detecting _crosshair_wrapper(s):
     calling_frame = sys._getframe(1)
@@ -4607,6 +4625,7 @@ def make_registrations():
     # Patches on constructors
     register_patch(bytearray, _bytearray)
     register_patch(bytes, _bytes)
+    register_patch(dict, _dict)
     register_patch(float, _float)
     register_patch(int, _int)
     register_patch(memoryview, _memoryview)

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -2574,6 +2574,19 @@ def test_set_no_duplicates() -> None:
     check_states(f, CONFIRMED)
 
 
+def test_set_additions_to_concrete() -> None:
+    class F:
+        set_type = set
+
+    def f(self: F, x: int) -> Set[int]:
+        """
+        post: _ != set([1234])
+        """
+        return self.set_type([x, x])
+
+    check_states(f, POST_FAIL)
+
+
 def test_frozenset_realize():
     with standalone_statespace as space:
         with NoTracing():

--- a/crosshair/patch_equivalence_test.py
+++ b/crosshair/patch_equivalence_test.py
@@ -38,6 +38,8 @@ possible_args = [
     (42, int),  # isinstance
     (re.compile("(ab|a|b)"), r"\n", ""),  # re methods
     (bool, [1, 1, 0]),  # itertools.takewhile and friends
+    ([(1, 2), (3, 4)]),  # key-value pairs
+    ([(1, 2), ([], 4)]),  # key-value pairs w/ unhashable key
 ]
 
 untested_patches = {

--- a/crosshair/simplestructs.py
+++ b/crosshair/simplestructs.py
@@ -71,7 +71,8 @@ _MISSING = object()
 
 class SimpleDict(MapBase):
     """
-    Provide a pure Python implementation of a dictionary.
+    A pure Python implementation of a dictionary.
+    Intentionally does no hashing (linear searches).
 
     #inv: set(self.keys()) == set(dict(self.items()).keys())
 
@@ -93,7 +94,7 @@ class SimpleDict(MapBase):
 
     def __init__(self, contents: MutableSequence):
         """
-        Initialize with the given value.
+        Initialize with (key, value) pairs.
 
         ``contents`` is assumed to not have duplicate keys.
         """

--- a/crosshair/simplestructs_test.py
+++ b/crosshair/simplestructs_test.py
@@ -1,7 +1,9 @@
+import copy
 import sys
 
 import pytest
 
+from crosshair.core import deep_realize
 from crosshair.simplestructs import (
     LazySetCombination,
     SequenceConcatenation,
@@ -76,6 +78,13 @@ def test_LazySetCombination_xor() -> None:
     assert s == {2, 5, 7}
     assert 4 not in s
     assert 5 in s
+
+
+def test_ShellMutableSet_deepcopy() -> None:
+    ls = ["0", "1", "2", "3"]
+    shell = ShellMutableSet(ls)
+    # deep_realize(shell)
+    copy.deepcopy(shell)
 
 
 def test_ShellMutableSequence_slice_assignment() -> None:

--- a/crosshair/tracers.py
+++ b/crosshair/tracers.py
@@ -7,7 +7,18 @@ import sys
 from collections import defaultdict
 from sys import _getframe
 from types import CodeType
-from typing import Any, Callable, DefaultDict, Dict, List, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+)
 
 from _crosshair_tracers import CTracer, TraceSwap
 
@@ -422,3 +433,20 @@ def NoTracing():
 
 def ResumedTracing():
     return TraceSwap(COMPOSITE_TRACER.ctracer, False)
+
+
+_T = TypeVar("_T")
+
+
+def tracing_iter(itr: Iterable[_T]) -> Iterable[_T]:
+    """Selectively re-enable tracing only during iteration."""
+    assert not is_tracing()
+    # TODO: should we protect his line with ResumedTracing() too?:
+    itr = iter(itr)
+    while True:
+        try:
+            with ResumedTracing():
+                value = next(itr)
+        except StopIteration:
+            return
+        yield value

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -75,6 +75,20 @@ To run all pre-commit checks, run from the root directory:
 
 The pre-commit hooks also run as part of our continuous integration pipeline.
 
+Tests
+=====
+
+The pre-commit command will run smoke tests, but you should run the full set
+of tests with pytest too; use a command like this:
+
+.. code-block::
+
+    env PYTHONHASHSEED=0 python -m pytest -n auto --dist worksteal
+
+There are many tests, but they parallelize; having more cores will help a lot.
+Note that the super fest tests run first; don't assume pytest is hanging later on!
+
+
 Write Commit Message
 ====================
 


### PR DESCRIPTION
Wraps plain `set()` and `dict()` constructors in object that can detect later symbolic additions and avoid realizing them.