### PR TITLE
Update contracts.rst (fix typos)

### DIFF
--- a/doc/source/contracts.rst
+++ b/doc/source/contracts.rst
@@ -36,8 +36,8 @@ There are many different ways to specify what CrossHair should check:
 * Files. e.g. ``crosshair check mypkg/foo.py``
 * File and line number. e.g. ``crosshair check mypkg/foo.py:23``
 * Modules. e.g. ``crosshair check mypkg.foo``
-* Classes. e.g. crosshair ``check mypkg.foo.MyClass``
-* Functions or methods. e.g. crosshair ``check mypkg.foo.MyClass.my_method``
+* Classes. e.g. ``crosshair check mypkg.foo.MyClass``
+* Functions or methods. e.g. ``crosshair check mypkg.foo.MyClass.my_method``
 
 
 .. _contract_configuration:

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -123,3 +123,4 @@ In order of initial commit. Many thanks!
 * `Tomasz Kosiński <https://github.com/azewiusz>`_
 * `Abhiram Bellur <https://github.com/Abhiram98>`_
 * `Kevin Turcios <https://github.com/KRRT7>`_
+* `Tony Dang <https://github.com/Dang-Hoang-Tung>`_


### PR DESCRIPTION
Hey, thanks for this really cool library. I skipped creating an issue since it's such a small change.

# PR Description
Fix minor typos in the docs - the "crosshair" keyword is outside of the example code block.