### PR TITLE
Move call stack decoding into the C tracer

### DIFF
--- a/crosshair/_tracers.c
+++ b/crosshair/_tracers.c
@@ -985,14 +985,8 @@ static PyObject **crosshair_tracers_stack_lookup(PyFrameObject *frame, int index
 
 #if PY_VERSION_HEX >= 0x030E0000
 // Python 3.14+
-static PyObject *crosshair_tracers_stack_read(PyObject *self, PyObject *args)
+static PyObject *crosshair_tracers_stack_read_at(PyFrameObject *frame, int index)
 {
-    PyFrameObject *frame;
-    int index;
-    if (!PyArg_ParseTuple(args, "Oi", &frame, &index)) {
-        return NULL;
-    }
-
     _PyInterpreterFrame* interpreterFrame = frame->f_frame;
     if (PyStackRef_IsNull(interpreterFrame->stackpointer[index])) {
         PyErr_SetString(PyExc_ValueError, "No stack value is present");
@@ -1000,6 +994,16 @@ static PyObject *crosshair_tracers_stack_read(PyObject *self, PyObject *args)
     } else {
         return PyStackRef_AsPyObjectNew(interpreterFrame->stackpointer[index]);
     }
+}
+
+static PyObject *crosshair_tracers_stack_read(PyObject *self, PyObject *args)
+{
+    PyFrameObject *frame;
+    int index;
+    if (!PyArg_ParseTuple(args, "Oi", &frame, &index)) {
+        return NULL;
+    }
+    return crosshair_tracers_stack_read_at(frame, index);
 }
 
 static PyObject* crosshair_tracers_stack_write(PyObject *self, PyObject *args)
@@ -1020,13 +1024,8 @@ static PyObject* crosshair_tracers_stack_write(PyObject *self, PyObject *args)
 
 #else
 
-static PyObject *crosshair_tracers_stack_read(PyObject *self, PyObject *args)
+static PyObject *crosshair_tracers_stack_read_at(PyFrameObject *frame, int index)
 {
-    PyFrameObject *frame;
-    int index;
-    if (!PyArg_ParseTuple(args, "Oi", &frame, &index)) {
-        return NULL;
-    }
     PyObject **retaddr = crosshair_tracers_stack_lookup(frame, index);
     if (retaddr == NULL) {
         PyErr_SetString(PyExc_TypeError, "Stack computation overflow");
@@ -1041,6 +1040,17 @@ static PyObject *crosshair_tracers_stack_read(PyObject *self, PyObject *args)
         return ret;
     }
 }
+
+static PyObject *crosshair_tracers_stack_read(PyObject *self, PyObject *args)
+{
+    PyFrameObject *frame;
+    int index;
+    if (!PyArg_ParseTuple(args, "Oi", &frame, &index)) {
+        return NULL;
+    }
+    return crosshair_tracers_stack_read_at(frame, index);
+}
+
 static PyObject* crosshair_tracers_stack_write(PyObject *self, PyObject *args)
 {
     PyFrameObject *frame;
@@ -1062,6 +1072,195 @@ static PyObject* crosshair_tracers_stack_write(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 #endif
+
+static PyObject *crosshair_tracers_stack_read_or_none(PyFrameObject *frame, int index)
+{
+    PyObject *ret = crosshair_tracers_stack_read_at(frame, index);
+    if (ret == NULL && PyErr_ExceptionMatches(PyExc_ValueError)) {
+        PyErr_Clear();
+        Py_RETURN_NONE;
+    }
+    return ret;
+}
+
+static PyObject *crosshair_tracers_build_call_stack_info(
+    int fn_idx,
+    PyObject *target,
+    int has_kwargs_idx,
+    int kwargs_idx
+) {
+    PyObject *ret = PyTuple_New(3);
+    if (ret == NULL) {
+        Py_DECREF(target);
+        return NULL;
+    }
+    PyObject *fn_idx_obj = PyLong_FromLong(fn_idx);
+    PyObject *kwargs_idx_obj = NULL;
+    if (has_kwargs_idx) {
+        kwargs_idx_obj = PyLong_FromLong(kwargs_idx);
+    } else {
+        kwargs_idx_obj = Py_None;
+        Py_INCREF(kwargs_idx_obj);
+    }
+    if (fn_idx_obj == NULL || kwargs_idx_obj == NULL) {
+        Py_XDECREF(fn_idx_obj);
+        Py_XDECREF(kwargs_idx_obj);
+        Py_DECREF(target);
+        Py_DECREF(ret);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(ret, 0, fn_idx_obj);
+    PyTuple_SET_ITEM(ret, 1, target);
+    PyTuple_SET_ITEM(ret, 2, kwargs_idx_obj);
+    return ret;
+}
+
+static PyObject *crosshair_tracers_call_stack_info(PyObject *self, PyObject *args)
+{
+    PyFrameObject *frame;
+    int opcode;
+    if (!PyArg_ParseTuple(args, "Oi", &frame, &opcode)) {
+        return NULL;
+    }
+
+    PyCodeObject *code = PyFrame_GetCode(frame);
+    if (code == NULL) {
+        return NULL;
+    }
+    PyObject *code_bytes_object = PyCode_GetCode(code);
+    Py_DECREF(code);
+    if (code_bytes_object == NULL) {
+        return NULL;
+    }
+    unsigned char *code_bytes = (unsigned char *)PyBytes_AS_STRING(code_bytes_object);
+    int oparg = code_bytes[PyFrame_GetLasti(frame) + 1];
+    Py_DECREF(code_bytes_object);
+
+    int fn_idx;
+    int kwargs_idx = 0;
+    int has_kwargs_idx = FALSE;
+    PyObject *target = NULL;
+
+#ifdef BUILD_TUPLE_UNPACK_WITH_CALL
+    if (opcode == BUILD_TUPLE_UNPACK_WITH_CALL) {
+        fn_idx = -(oparg + 1);
+        target = crosshair_tracers_stack_read_or_none(frame, fn_idx);
+        if (target == NULL) {
+            return NULL;
+        }
+        return crosshair_tracers_build_call_stack_info(
+            fn_idx, target, has_kwargs_idx, kwargs_idx
+        );
+    }
+#endif
+
+#ifdef CALL
+    if (opcode == CALL) {
+#if PY_VERSION_HEX >= 0x030D0000
+        fn_idx = -(oparg + 2);
+        target = crosshair_tracers_stack_read_at(frame, fn_idx);
+#else
+        fn_idx = -(oparg + 1);
+        target = crosshair_tracers_stack_read_at(frame, fn_idx - 1);
+        if (target == NULL && PyErr_ExceptionMatches(PyExc_ValueError)) {
+            PyErr_Clear();
+            target = crosshair_tracers_stack_read_at(frame, fn_idx);
+        } else {
+            fn_idx--;
+        }
+#endif
+        if (target == NULL) {
+            return NULL;
+        }
+        return crosshair_tracers_build_call_stack_info(
+            fn_idx, target, has_kwargs_idx, kwargs_idx
+        );
+    }
+#endif
+
+#ifdef CALL_KW
+    if (opcode == CALL_KW) {
+        fn_idx = -(oparg + 3);
+        target = crosshair_tracers_stack_read_at(frame, fn_idx);
+        if (target == NULL) {
+            return NULL;
+        }
+        return crosshair_tracers_build_call_stack_info(
+            fn_idx, target, has_kwargs_idx, kwargs_idx
+        );
+    }
+#endif
+
+#ifdef CALL_FUNCTION
+    if (opcode == CALL_FUNCTION) {
+        fn_idx = -(oparg + 1);
+        target = crosshair_tracers_stack_read_or_none(frame, fn_idx);
+        if (target == NULL) {
+            return NULL;
+        }
+        return crosshair_tracers_build_call_stack_info(
+            fn_idx, target, has_kwargs_idx, kwargs_idx
+        );
+    }
+#endif
+
+#ifdef CALL_FUNCTION_KW
+    if (opcode == CALL_FUNCTION_KW) {
+        fn_idx = -(oparg + 2);
+        target = crosshair_tracers_stack_read_or_none(frame, fn_idx);
+        if (target == NULL) {
+            return NULL;
+        }
+        return crosshair_tracers_build_call_stack_info(
+            fn_idx, target, has_kwargs_idx, kwargs_idx
+        );
+    }
+#endif
+
+#ifdef CALL_FUNCTION_EX
+    if (opcode == CALL_FUNCTION_EX) {
+        int has_kwargs = oparg & 1;
+        kwargs_idx = -1;
+#if PY_VERSION_HEX >= 0x030E0000
+        fn_idx = -4;
+        has_kwargs_idx = TRUE;
+#elif PY_VERSION_HEX >= 0x030D0000
+        fn_idx = -(has_kwargs + 3);
+        has_kwargs_idx = has_kwargs;
+#else
+        fn_idx = -(has_kwargs + 2);
+        has_kwargs_idx = has_kwargs;
+#endif
+        target = crosshair_tracers_stack_read_or_none(frame, fn_idx);
+        if (target == NULL) {
+            return NULL;
+        }
+        return crosshair_tracers_build_call_stack_info(
+            fn_idx, target, has_kwargs_idx, kwargs_idx
+        );
+    }
+#endif
+
+#ifdef CALL_METHOD
+    if (opcode == CALL_METHOD) {
+        fn_idx = -(oparg + 2);
+        target = crosshair_tracers_stack_read_at(frame, fn_idx);
+        if (target == NULL && PyErr_ExceptionMatches(PyExc_ValueError)) {
+            PyErr_Clear();
+            fn_idx++;
+            target = crosshair_tracers_stack_read_at(frame, fn_idx);
+        }
+        if (target == NULL) {
+            return NULL;
+        }
+        return crosshair_tracers_build_call_stack_info(
+            fn_idx, target, has_kwargs_idx, kwargs_idx
+        );
+    }
+#endif
+
+    Py_RETURN_NONE;
+}
 
 
 static PyObject* crosshair_tracers_code_stack_depths(PyObject *self, PyObject *args)
@@ -1115,6 +1314,7 @@ static PyObject* crosshair_tracers_supported_opcodes(PyObject *self, PyObject *a
 static PyMethodDef TracersMethods[] = {
     {"frame_stack_read",  crosshair_tracers_stack_read, METH_VARARGS, "Fetch a value from the interpreter stack."},
     {"frame_stack_write",  crosshair_tracers_stack_write, METH_VARARGS, "Overwrite a value on the interpreter stack."},
+    {"call_stack_info", crosshair_tracers_call_stack_info, METH_VARARGS, "Fetch call target metadata from the interpreter stack."},
     {"code_stack_depths", crosshair_tracers_code_stack_depths, METH_VARARGS, "Find stack depths at various wordcode locations"},
     {"supported_opcodes", crosshair_tracers_supported_opcodes, METH_VARARGS, "Return opcodes that are supported by the C tracer"},
     {NULL, NULL, 0, NULL}        /* Sentinel */

--- a/crosshair/tracers.py
+++ b/crosshair/tracers.py
@@ -23,7 +23,12 @@ from typing import (
     TypeVar,
 )
 
-from _crosshair_tracers import CTracer, TraceSwap, supported_opcodes  # type: ignore
+from _crosshair_tracers import (  # type: ignore
+    CTracer,
+    TraceSwap,
+    call_stack_info,
+    supported_opcodes,
+)
 
 CROSSHAIR_EXTRA_ASSERTS = os.environ.get("CROSSHAIR_EXTRA_ASSERTS", "0") == "1"
 
@@ -228,10 +233,12 @@ class TracingModule:
     def trace_op(self, frame, codeobj, opcodenum):
         if is_tracing():
             raise TraceException
-        call_handler = _CALL_HANDLERS.get(opcodenum)
-        if not call_handler:
+        info = call_stack_info(frame, opcodenum)
+        if info is None:
             return None
-        (fn_idx, target, kwargs_idx) = call_handler(frame)
+        (fn_idx, target, kwargs_idx) = info
+        if target is None:
+            target = NULL_POINTER
         binding_target = None
 
         __self = None

--- a/crosshair/tracers.py
+++ b/crosshair/tracers.py
@@ -66,115 +66,17 @@ class RawNullPointer:
 
 
 NULL_POINTER = RawNullPointer()
-CallStackInfo = (
-    Tuple[  # Information about the interpreter stack just before calling a function
-        int,  # stack index of the callable
-        Callable,  # the callable object itself
-        Optional[int],  # index of kwargs dict (if used in this call)
+_CALL_OPCODES = frozenset(
+    [
+        BUILD_TUPLE_UNPACK_WITH_CALL,
+        CALL,
+        CALL_KW,
+        CALL_FUNCTION,
+        CALL_FUNCTION_KW,
+        CALL_FUNCTION_EX,
+        CALL_METHOD,
     ]
 )
-
-
-def handle_build_tuple_unpack_with_call(frame) -> CallStackInfo:
-    idx = -(
-        frame.f_code.co_code[frame.f_lasti + 1] + 1
-    )  # TODO: account for EXTENDED_ARG, here and elsewhere
-    try:
-        return (idx, frame_stack_read(frame, idx), None)
-    except ValueError:
-        return (idx, NULL_POINTER)  # type: ignore
-
-
-def handle_call_3_11(frame) -> CallStackInfo:
-    idx = -(frame.f_code.co_code[frame.f_lasti + 1] + 1)
-    try:
-        ret = (idx - 1, frame_stack_read(frame, idx - 1), None)
-    except ValueError:
-        ret = (idx, frame_stack_read(frame, idx), None)
-    return ret
-
-
-def handle_call_3_13(frame) -> CallStackInfo:
-    idx = -(frame.f_code.co_code[frame.f_lasti + 1] + 2)
-    return (idx, frame_stack_read(frame, idx), None)
-
-
-def handle_call_function(frame) -> CallStackInfo:
-    idx = -(frame.f_code.co_code[frame.f_lasti + 1] + 1)
-    try:
-        return (idx, frame_stack_read(frame, idx), None)
-    except ValueError:
-        return (idx, NULL_POINTER)  # type: ignore
-
-
-def handle_call_function_kw(frame) -> CallStackInfo:
-    idx = -(frame.f_code.co_code[frame.f_lasti + 1] + 2)
-    try:
-        return (idx, frame_stack_read(frame, idx), None)
-    except ValueError:
-        return (idx, NULL_POINTER)  # type: ignore
-
-
-def handle_call_kw(frame) -> CallStackInfo:
-    idx = -(frame.f_code.co_code[frame.f_lasti + 1] + 3)
-    return (idx, frame_stack_read(frame, idx), None)
-
-
-def handle_call_function_ex_3_6(frame) -> CallStackInfo:
-    has_kwargs = frame.f_code.co_code[frame.f_lasti + 1] & 1
-    idx = -(has_kwargs + 2)
-    kwargs_idx = -1 if has_kwargs else None
-    try:
-        return (idx, frame_stack_read(frame, idx), kwargs_idx)
-    except ValueError:
-        return (idx, NULL_POINTER, kwargs_idx)  # type: ignore
-
-
-def handle_call_function_ex_3_13(frame) -> CallStackInfo:
-    has_kwargs = frame.f_code.co_code[frame.f_lasti + 1] & 1
-    idx = -(has_kwargs + 3)
-    kwargs_idx = -1 if has_kwargs else None
-    try:
-        return (idx, frame_stack_read(frame, idx), kwargs_idx)
-    except ValueError:
-        return (idx, NULL_POINTER, kwargs_idx)  # type: ignore
-
-
-def handle_call_function_ex_3_14(frame) -> CallStackInfo:
-    callable_idx, kwargs_idx = -4, -1
-    try:
-        return (callable_idx, frame_stack_read(frame, callable_idx), kwargs_idx)
-    except ValueError:
-        return (callable_idx, NULL_POINTER, kwargs_idx)  # type: ignore
-
-
-def handle_call_method(frame) -> CallStackInfo:
-    idx = -(frame.f_code.co_code[frame.f_lasti + 1] + 2)
-    try:
-        return (idx, frame_stack_read(frame, idx), None)
-    except ValueError:
-        # not a sucessful method lookup; no call happens here
-        idx += 1
-        return (idx, frame_stack_read(frame, idx), None)
-
-
-_CALL_HANDLERS: Dict[int, Callable[[object], CallStackInfo]] = {
-    BUILD_TUPLE_UNPACK_WITH_CALL: handle_build_tuple_unpack_with_call,
-    CALL: handle_call_3_13 if sys.version_info >= (3, 13) else handle_call_3_11,
-    CALL_KW: handle_call_kw,
-    CALL_FUNCTION: handle_call_function,
-    CALL_FUNCTION_KW: handle_call_function_kw,
-    CALL_FUNCTION_EX: (
-        handle_call_function_ex_3_14
-        if sys.version_info >= (3, 14)
-        else (
-            handle_call_function_ex_3_13
-            if sys.version_info >= (3, 13)
-            else handle_call_function_ex_3_6
-        )
-    ),
-    CALL_METHOD: handle_call_method,
-}
 
 
 class Untracable:
@@ -197,7 +99,7 @@ def check_opcode_support(opcodes: FrozenSet[int]):
         )
 
 
-check_opcode_support(frozenset(_CALL_HANDLERS.keys()))
+check_opcode_support(_CALL_OPCODES)
 
 
 wrapper_descriptor_type = type(int.__bool__)
@@ -225,7 +127,7 @@ _SELFLESS_CALLABLE_TYPES = (
 
 class TracingModule:
     # override these!:
-    opcodes_wanted = frozenset(_CALL_HANDLERS.keys())
+    opcodes_wanted = _CALL_OPCODES
 
     def __call__(self, frame, codeobj, opcodenum):
         return self.trace_op(frame, codeobj, opcodenum)

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -124,3 +124,4 @@ In order of initial commit. Many thanks!
 * `Abhiram Bellur <https://github.com/Abhiram98>`_
 * `Kevin Turcios <https://github.com/KRRT7>`_
 * `Tony Dang <https://github.com/Dang-Hoang-Tung>`_
+* `Michael Schvarcz <https://github.com/michael-schvarcz>`_


### PR DESCRIPTION
Addresses part of #115.

This is a focused slice of the remaining tracer hot-path work, separate from #409's `CompositeTracer` removal. It moves the call-opcode stack decoding currently done by Python `_CALL_HANDLERS` into the existing `_crosshair_tracers` C extension, then has `TracingModule.trace_op()` consume the new `call_stack_info()` helper.

The target normalization, kwargs symbolic-string handling, and replacement write-back behavior stay in Python for now, so this keeps the behavioral surface small while removing several Python function dispatches from every traced call opcode.

Tests run:

- `PYTHONHASHSEED=0 .venv/bin/python -m pytest crosshair/tracers_test.py crosshair/_tracers_test.py -q`
- `PYTHONHASHSEED=0 .venv/bin/python -m pytest crosshair/core_test.py crosshair/libimpl/builtinslib_test.py crosshair/tracers_test.py crosshair/_tracers_test.py -q`
- `.venv/bin/python -m black --check crosshair/tracers.py`
- `.venv/bin/python -m isort --check-only crosshair/tracers.py`

AI-assisted with Codex, with local build and tests run before submission.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#115: Improve trace callback performance](https://oss.issuehunt.io/repos/101762821/issues/115)
---
</details>
<!-- /Issuehunt content-->