### PR TITLE
Move call target normalization into C tracer

### DIFF
--- a/crosshair/_tracers.c
+++ b/crosshair/_tracers.c
@@ -1262,6 +1262,142 @@ static PyObject *crosshair_tracers_call_stack_info(PyObject *self, PyObject *arg
     Py_RETURN_NONE;
 }
 
+static PyObject *
+crosshair_tracers_getattr_or_none(PyObject *obj, const char *name)
+{
+    PyObject *name_obj = PyUnicode_InternFromString(name);
+    if (name_obj == NULL) {
+        return NULL;
+    }
+    PyObject *ret = PyObject_GenericGetAttr(obj, name_obj);
+    Py_DECREF(name_obj);
+    if (ret == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        PyErr_Clear();
+        Py_RETURN_NONE;
+    }
+    return ret;
+}
+
+static PyObject *
+crosshair_tracers_normalize_call_target(PyObject *self, PyObject *args)
+{
+    PyObject *target;
+    PyObject *selfless_callable_types;
+    PyObject *normal_callable_types;
+    if (!PyArg_ParseTuple(
+            args,
+            "OOO",
+            &target,
+            &selfless_callable_types,
+            &normal_callable_types)) {
+        return NULL;
+    }
+
+    PyObject *target_obj = target;
+    PyObject *owned_target = NULL;
+    PyObject *binding_target = Py_None;
+    PyObject *bound_self = Py_None;
+
+    int is_selfless = PyObject_IsInstance(target, selfless_callable_types);
+    if (is_selfless < 0) {
+        return NULL;
+    }
+    if (!is_selfless) {
+        bound_self = crosshair_tracers_getattr_or_none(target, "__self__");
+        if (bound_self == NULL) {
+            return NULL;
+        }
+    } else {
+        Py_INCREF(bound_self);
+    }
+
+    if (bound_self == Py_None) {
+        int is_normal = PyObject_IsInstance(target, normal_callable_types);
+        if (is_normal < 0) {
+            Py_DECREF(bound_self);
+            return NULL;
+        }
+        if (!is_normal) {
+            PyObject *call_target = crosshair_tracers_getattr_or_none(target, "__call__");
+            if (call_target == NULL) {
+                Py_DECREF(bound_self);
+                return NULL;
+            }
+            if (call_target != Py_None) {
+                PyObject *call_self = crosshair_tracers_getattr_or_none(
+                    call_target, "__self__");
+                if (call_self == NULL) {
+                    Py_DECREF(bound_self);
+                    Py_DECREF(call_target);
+                    return NULL;
+                }
+                Py_DECREF(bound_self);
+                Py_XDECREF(owned_target);
+                owned_target = call_target;
+                target_obj = call_target;
+                bound_self = call_self;
+            } else {
+                Py_DECREF(call_target);
+            }
+        }
+    }
+
+    if (bound_self != Py_None) {
+        PyObject *func = crosshair_tracers_getattr_or_none(target_obj, "__func__");
+        if (func == NULL) {
+            Py_DECREF(bound_self);
+            Py_XDECREF(owned_target);
+            return NULL;
+        }
+        if (func != Py_None) {
+            binding_target = bound_self;
+            Py_XDECREF(owned_target);
+            owned_target = func;
+            target_obj = func;
+        } else {
+            PyObject *target_name = crosshair_tracers_getattr_or_none(
+                target_obj, "__name__");
+            if (target_name == NULL) {
+                Py_DECREF(bound_self);
+                Py_DECREF(func);
+                Py_XDECREF(owned_target);
+                return NULL;
+            }
+            if (target_name != Py_None) {
+                PyObject *typelevel_target = PyObject_GetAttr(
+                    (PyObject *)Py_TYPE(bound_self), target_name);
+                if (typelevel_target == NULL &&
+                        PyErr_ExceptionMatches(PyExc_AttributeError)) {
+                    PyErr_Clear();
+                }
+                if (typelevel_target != NULL) {
+                    binding_target = bound_self;
+                    Py_XDECREF(owned_target);
+                    owned_target = typelevel_target;
+                    target_obj = typelevel_target;
+                }
+            }
+            Py_DECREF(target_name);
+            Py_DECREF(func);
+        }
+    }
+
+    PyObject *ret = PyTuple_New(2);
+    if (ret == NULL) {
+        Py_DECREF(bound_self);
+        Py_XDECREF(owned_target);
+        return NULL;
+    }
+    Py_INCREF(target_obj);
+    Py_INCREF(binding_target);
+    PyTuple_SET_ITEM(ret, 0, target_obj);
+    PyTuple_SET_ITEM(ret, 1, binding_target);
+
+    Py_DECREF(bound_self);
+    Py_XDECREF(owned_target);
+    return ret;
+}
+
 
 static PyObject* crosshair_tracers_code_stack_depths(PyObject *self, PyObject *args)
 {
@@ -1315,6 +1451,12 @@ static PyMethodDef TracersMethods[] = {
     {"frame_stack_read",  crosshair_tracers_stack_read, METH_VARARGS, "Fetch a value from the interpreter stack."},
     {"frame_stack_write",  crosshair_tracers_stack_write, METH_VARARGS, "Overwrite a value on the interpreter stack."},
     {"call_stack_info", crosshair_tracers_call_stack_info, METH_VARARGS, "Fetch call target metadata from the interpreter stack."},
+    {
+        "normalize_call_target",
+        crosshair_tracers_normalize_call_target,
+        METH_VARARGS,
+        "Normalize a callable target and its optional binding target."
+    },
     {"code_stack_depths", crosshair_tracers_code_stack_depths, METH_VARARGS, "Find stack depths at various wordcode locations"},
     {"supported_opcodes", crosshair_tracers_supported_opcodes, METH_VARARGS, "Return opcodes that are supported by the C tracer"},
     {NULL, NULL, 0, NULL}        /* Sentinel */

--- a/crosshair/tracers.py
+++ b/crosshair/tracers.py
@@ -27,6 +27,7 @@ from _crosshair_tracers import (  # type: ignore
     CTracer,
     TraceSwap,
     call_stack_info,
+    normalize_call_target,
     supported_opcodes,
 )
 
@@ -141,33 +142,9 @@ class TracingModule:
         (fn_idx, target, kwargs_idx) = info
         if target is None:
             target = NULL_POINTER
-        binding_target = None
-
-        __self = None
-        if not isinstance(target, _SELFLESS_CALLABLE_TYPES):
-            try:
-                __self = object.__getattribute__(target, "__self__")
-            except AttributeError:
-                pass
-        if (__self is None) and (not isinstance(target, _NORMAL_CALLABLE_TYPES)):
-            try:
-                target = object.__getattribute__(target, "__call__")
-                __self = object.__getattribute__(target, "__self__")
-            except AttributeError:
-                pass
-        if __self is not None:
-            try:
-                __func = object.__getattribute__(target, "__func__")
-            except AttributeError:
-                # The implementation is likely in C.
-                # Attempt to get a function via the type:
-                typelevel_target = getattr(type(__self), target.__name__, None)
-                if typelevel_target is not None:
-                    binding_target = __self
-                    target = typelevel_target
-            else:
-                binding_target = __self
-                target = __func
+        target, binding_target = normalize_call_target(
+            target, _SELFLESS_CALLABLE_TYPES, _NORMAL_CALLABLE_TYPES
+        )
 
         if kwargs_idx is not None:
             try:

--- a/crosshair/tracers_test.py
+++ b/crosshair/tracers_test.py
@@ -1,7 +1,10 @@
 import dis
+import gc
+import sys
 
 import pytest
 
+from _crosshair_tracers import normalize_call_target
 from crosshair.tracers import (
     COMPOSITE_TRACER,
     CompositeTracer,
@@ -30,6 +33,11 @@ def overridemethod(*a, **kw):
 
 class Example:
     def example_method(self, a: int, **kw) -> int:
+        return 1
+
+
+class CallableExample:
+    def __call__(self) -> int:
         return 1
 
 
@@ -79,6 +87,59 @@ def test_CALL_METHOD():
 def test_override_method_in_c():
     with tracer:
         assert (1, 2, 3).__len__() == 42
+
+
+def test_normalize_bound_method_target():
+    example = Example()
+
+    target, binding_target = normalize_call_target(
+        example.example_method,
+        (type, type(examplefn)),
+        (type, type(examplefn), type(example.example_method)),
+    )
+
+    assert target is Example.example_method
+    assert binding_target is example
+
+
+def test_normalize_callable_instance_target():
+    example = CallableExample()
+
+    target, binding_target = normalize_call_target(
+        example,
+        (type, type(examplefn)),
+        (type, type(examplefn), type(example.__call__)),
+    )
+
+    assert target is CallableExample.__call__
+    assert binding_target is example
+
+
+def test_normalize_call_target_refcounts_dont_leak():
+    method_example = Example()
+    callable_example = CallableExample()
+    method_example_base = sys.getrefcount(method_example)
+    callable_example_base = sys.getrefcount(callable_example)
+    method_base = sys.getrefcount(Example.example_method)
+    call_base = sys.getrefcount(CallableExample.__call__)
+
+    for _ in range(1000):
+        normalize_call_target(
+            method_example.example_method,
+            (type, type(examplefn)),
+            (type, type(examplefn), type(method_example.example_method)),
+        )
+        normalize_call_target(
+            callable_example,
+            (type, type(examplefn)),
+            (type, type(examplefn), type(callable_example.__call__)),
+        )
+
+    gc.collect()
+    assert sys.getrefcount(method_example) == method_example_base
+    assert sys.getrefcount(callable_example) == callable_example_base
+    assert sys.getrefcount(Example.example_method) == method_base
+    assert sys.getrefcount(CallableExample.__call__) == call_base
 
 
 def test_no_tracing():


### PR DESCRIPTION
This is a focused follow-up slice for #115 after #410 moved call stack decoding into the C extension.

`TracingModule.trace_op()` still normalized bound methods and callable instances in Python on every traced call opcode. This moves that target-normalization step into `_crosshair_tracers.normalize_call_target()`, while keeping the existing Python `trace_call()` override hook, keyword handling, and stack write-back behavior unchanged.

What changed:
- Added a C helper that mirrors the existing `object.__getattribute__`-based normalization of bound methods and callable instances.
- Replaced the Python normalization block in `TracingModule.trace_op()` with the C helper.
- Added coverage for bound methods, callable instances, and refcount stability.

Verification:
- `PYTHONHASHSEED=0 python -m pytest crosshair/tracers_test.py crosshair/_tracers_test.py -q` -> `13 passed, 2 skipped`
- `PYTHONHASHSEED=0 python -m pytest crosshair/core_test.py crosshair/libimpl/builtinslib_test.py crosshair/tracers_test.py crosshair/_tracers_test.py -q` -> `556 passed, 6 skipped`
- `python -m black --check crosshair/tracers.py crosshair/tracers_test.py`
- `python -m isort --check-only crosshair/tracers.py crosshair/tracers_test.py`
- `python -m flake8 crosshair/tracers.py crosshair/tracers_test.py`
- `git diff --check`

This intentionally avoids touching the open CompositeTracer-removal work in #409.