### PR TITLE
Move call target normalization into C tracer

### DIFF
--- a/crosshair/_tracers.c
+++ b/crosshair/_tracers.c
@@ -1262,6 +1262,166 @@ static PyObject *crosshair_tracers_call_stack_info(PyObject *self, PyObject *arg
     Py_RETURN_NONE;
 }
 
+static int
+crosshair_tracers_generic_getattr_optional(
+    PyObject *obj,
+    const char *name,
+    PyObject **ret
+) {
+    PyObject *name_obj = PyUnicode_InternFromString(name);
+    if (name_obj == NULL) {
+        return RET_ERROR;
+    }
+    *ret = PyObject_GenericGetAttr(obj, name_obj);
+    Py_DECREF(name_obj);
+    if (*ret == NULL) {
+        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            PyErr_Clear();
+            return 0;
+        }
+        return RET_ERROR;
+    }
+    return 1;
+}
+
+static PyObject *
+crosshair_tracers_normalize_call_target(PyObject *self, PyObject *args)
+{
+    PyObject *target;
+    PyObject *selfless_callable_types;
+    PyObject *normal_callable_types;
+    if (!PyArg_ParseTuple(
+            args,
+            "OOO",
+            &target,
+            &selfless_callable_types,
+            &normal_callable_types)) {
+        return NULL;
+    }
+
+    PyObject *target_obj = target;
+    Py_INCREF(target_obj);
+    PyObject *bound_self = Py_None;
+    Py_INCREF(bound_self);
+    PyObject *binding_target = Py_None;
+    Py_INCREF(binding_target);
+
+    int is_selfless = PyObject_IsInstance(target_obj, selfless_callable_types);
+    if (is_selfless < 0) {
+        goto error;
+    }
+    if (!is_selfless) {
+        PyObject *maybe_self = NULL;
+        int has_self = crosshair_tracers_generic_getattr_optional(
+            target_obj,
+            "__self__",
+            &maybe_self
+        );
+        if (has_self < 0) {
+            goto error;
+        }
+        if (has_self) {
+            Py_DECREF(bound_self);
+            bound_self = maybe_self;
+        }
+    }
+
+    if (bound_self == Py_None) {
+        int is_normal = PyObject_IsInstance(target_obj, normal_callable_types);
+        if (is_normal < 0) {
+            goto error;
+        }
+        if (!is_normal) {
+            PyObject *call_target = NULL;
+            int has_call = crosshair_tracers_generic_getattr_optional(
+                target_obj,
+                "__call__",
+                &call_target
+            );
+            if (has_call < 0) {
+                goto error;
+            }
+            if (has_call) {
+                PyObject *call_self = NULL;
+                int has_call_self = crosshair_tracers_generic_getattr_optional(
+                    call_target,
+                    "__self__",
+                    &call_self
+                );
+                if (has_call_self < 0) {
+                    Py_DECREF(call_target);
+                    goto error;
+                }
+                Py_DECREF(target_obj);
+                target_obj = call_target;
+                if (has_call_self) {
+                    Py_DECREF(bound_self);
+                    bound_self = call_self;
+                }
+            }
+        }
+    }
+
+    if (bound_self != Py_None) {
+        PyObject *func = NULL;
+        int has_func = crosshair_tracers_generic_getattr_optional(
+            target_obj,
+            "__func__",
+            &func
+        );
+        if (has_func < 0) {
+            goto error;
+        }
+        if (has_func) {
+            Py_DECREF(binding_target);
+            binding_target = bound_self;
+            Py_INCREF(binding_target);
+            Py_DECREF(target_obj);
+            target_obj = func;
+        } else {
+            PyObject *target_name = PyObject_GetAttrString(target_obj, "__name__");
+            if (target_name == NULL) {
+                goto error;
+            }
+            PyObject *typelevel_target = PyObject_GetAttr(
+                (PyObject *)Py_TYPE(bound_self),
+                target_name
+            );
+            Py_DECREF(target_name);
+            if (typelevel_target == NULL) {
+                if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+                    PyErr_Clear();
+                } else {
+                    goto error;
+                }
+            } else if (typelevel_target != Py_None) {
+                Py_DECREF(binding_target);
+                binding_target = bound_self;
+                Py_INCREF(binding_target);
+                Py_DECREF(target_obj);
+                target_obj = typelevel_target;
+            } else {
+                Py_DECREF(typelevel_target);
+            }
+        }
+    }
+
+    PyObject *ret = PyTuple_New(2);
+    if (ret == NULL) {
+        goto error;
+    }
+    PyTuple_SET_ITEM(ret, 0, target_obj);
+    PyTuple_SET_ITEM(ret, 1, binding_target);
+    Py_DECREF(bound_self);
+    return ret;
+
+error:
+    Py_DECREF(target_obj);
+    Py_DECREF(bound_self);
+    Py_DECREF(binding_target);
+    return NULL;
+}
+
 
 static PyObject* crosshair_tracers_code_stack_depths(PyObject *self, PyObject *args)
 {
@@ -1315,6 +1475,12 @@ static PyMethodDef TracersMethods[] = {
     {"frame_stack_read",  crosshair_tracers_stack_read, METH_VARARGS, "Fetch a value from the interpreter stack."},
     {"frame_stack_write",  crosshair_tracers_stack_write, METH_VARARGS, "Overwrite a value on the interpreter stack."},
     {"call_stack_info", crosshair_tracers_call_stack_info, METH_VARARGS, "Fetch call target metadata from the interpreter stack."},
+    {
+        "normalize_call_target",
+        crosshair_tracers_normalize_call_target,
+        METH_VARARGS,
+        "Normalize a callable target and its optional binding target."
+    },
     {"code_stack_depths", crosshair_tracers_code_stack_depths, METH_VARARGS, "Find stack depths at various wordcode locations"},
     {"supported_opcodes", crosshair_tracers_supported_opcodes, METH_VARARGS, "Return opcodes that are supported by the C tracer"},
     {NULL, NULL, 0, NULL}        /* Sentinel */

--- a/crosshair/tracers.py
+++ b/crosshair/tracers.py
@@ -27,6 +27,7 @@ from _crosshair_tracers import (  # type: ignore
     CTracer,
     TraceSwap,
     call_stack_info,
+    normalize_call_target,
     supported_opcodes,
 )
 
@@ -141,33 +142,11 @@ class TracingModule:
         (fn_idx, target, kwargs_idx) = info
         if target is None:
             target = NULL_POINTER
-        binding_target = None
-
-        __self = None
-        if not isinstance(target, _SELFLESS_CALLABLE_TYPES):
-            try:
-                __self = object.__getattribute__(target, "__self__")
-            except AttributeError:
-                pass
-        if (__self is None) and (not isinstance(target, _NORMAL_CALLABLE_TYPES)):
-            try:
-                target = object.__getattribute__(target, "__call__")
-                __self = object.__getattribute__(target, "__self__")
-            except AttributeError:
-                pass
-        if __self is not None:
-            try:
-                __func = object.__getattribute__(target, "__func__")
-            except AttributeError:
-                # The implementation is likely in C.
-                # Attempt to get a function via the type:
-                typelevel_target = getattr(type(__self), target.__name__, None)
-                if typelevel_target is not None:
-                    binding_target = __self
-                    target = typelevel_target
-            else:
-                binding_target = __self
-                target = __func
+        target, binding_target = normalize_call_target(
+            target,
+            _SELFLESS_CALLABLE_TYPES,
+            _NORMAL_CALLABLE_TYPES,
+        )
 
         if kwargs_idx is not None:
             try:

--- a/crosshair/tracers_test.py
+++ b/crosshair/tracers_test.py
@@ -1,8 +1,13 @@
 import dis
+import gc
+import sys
 
 import pytest
 
+import _crosshair_tracers
 from crosshair.tracers import (
+    _NORMAL_CALLABLE_TYPES,
+    _SELFLESS_CALLABLE_TYPES,
     COMPOSITE_TRACER,
     CompositeTracer,
     CoverageTracingModule,
@@ -28,8 +33,18 @@ def overridemethod(*a, **kw):
     return 2
 
 
+def overridecallable(*a, **kw):
+    assert isinstance(a[0], CallableExample)
+    return 2
+
+
 class Example:
     def example_method(self, a: int, **kw) -> int:
+        return 1
+
+
+class CallableExample:
+    def __call__(self) -> int:
         return 1
 
 
@@ -40,6 +55,7 @@ tracer.push_module(
         {
             examplefn: overridefn,
             Example.__dict__["example_method"]: overridemethod,
+            CallableExample.__dict__["__call__"]: overridecallable,
             tuple.__len__: (lambda a: 42),
         }
     )
@@ -76,9 +92,96 @@ def test_CALL_METHOD():
         assert Example().example_method(42) == 2
 
 
+def test_CALLABLE_INSTANCE():
+    with tracer:
+        assert CallableExample()() == 2
+
+
 def test_override_method_in_c():
     with tracer:
         assert (1, 2, 3).__len__() == 42
+
+
+def _normalize_call_target(target):
+    return _crosshair_tracers.normalize_call_target(
+        target,
+        _SELFLESS_CALLABLE_TYPES,
+        _NORMAL_CALLABLE_TYPES,
+    )
+
+
+def test_normalize_call_target_helper_is_exported():
+    assert hasattr(_crosshair_tracers, "normalize_call_target")
+
+
+def test_normalize_bound_method_target():
+    example = Example()
+
+    target, binding_target = _normalize_call_target(example.example_method)
+
+    assert target is Example.example_method
+    assert binding_target is example
+
+
+def test_normalize_callable_instance_target():
+    example = CallableExample()
+
+    target, binding_target = _normalize_call_target(example)
+
+    assert target is CallableExample.__call__
+    assert binding_target is example
+
+
+def test_normalize_c_bound_method_target():
+    example = (1, 2, 3)
+
+    target, binding_target = _normalize_call_target(example.__len__)
+
+    assert target is tuple.__len__
+    assert binding_target is example
+
+
+def test_normalize_call_target_propagates_type_lookup_errors():
+    class ExplodingDescriptor:
+        def __get__(self, obj, owner=None):
+            raise RuntimeError("type-level lookup failed")
+
+    class ExplodingType:
+        exploding = ExplodingDescriptor()
+
+    class BoundLikeTarget:
+        __name__ = "exploding"
+
+        def __init__(self, bound_self):
+            self.__self__ = bound_self
+
+    with pytest.raises(RuntimeError, match="type-level lookup failed"):
+        _normalize_call_target(BoundLikeTarget(ExplodingType()))
+
+
+def test_normalize_call_target_refcounts_dont_leak():
+    method_example = Example()
+    callable_example = CallableExample()
+    c_method_example = (1, 2, 3)
+    method_example_base = sys.getrefcount(method_example)
+    callable_example_base = sys.getrefcount(callable_example)
+    c_method_example_base = sys.getrefcount(c_method_example)
+    method_base = sys.getrefcount(Example.example_method)
+    call_base = sys.getrefcount(CallableExample.__call__)
+    c_method_base = sys.getrefcount(tuple.__len__)
+
+    for _ in range(1000):
+        _normalize_call_target(method_example.example_method)
+        _normalize_call_target(callable_example)
+        _normalize_call_target(c_method_example.__len__)
+
+    gc.collect()
+    assert sys.getrefcount(method_example) == method_example_base
+    assert sys.getrefcount(callable_example) == callable_example_base
+    assert sys.getrefcount(c_method_example) == c_method_example_base
+    assert sys.getrefcount(Example.example_method) == method_base
+    assert sys.getrefcount(CallableExample.__call__) == call_base
+    assert sys.getrefcount(tuple.__len__) == c_method_base
 
 
 def test_no_tracing():


### PR DESCRIPTION
Addresses part of #115.

This moves the call target normalization currently done inside `TracingModule.trace_op()` into the existing `_crosshair_tracers` C extension. The stack decoding remains in `call_stack_info()` from #410, while keyword normalization and replacement write-back stay in Python, so this keeps the behavior boundary small.

What changed:
- Added `_crosshair_tracers.normalize_call_target()` for the `__self__` / `__call__` / `__func__` / type-level descriptor normalization path.
- Updated `TracingModule.trace_op()` to call the C helper before handling keyword dictionaries and `trace_call()`.
- Added direct tests for bound Python methods, callable instances, C-level bound methods, reference stability, and non-`AttributeError` propagation during type-level lookup.
- Added an integration test showing callable instance calls still get patched through the tracer.

This includes the error handling requested on #411: type-level lookup clears `AttributeError`, but propagates other descriptor/access errors instead of continuing with an exception set.

This intentionally does not touch the open CompositeTracer removal work in #409 or the opcode callback argument caching work in #412.

Verification:
- `python3 -m venv .venv && .venv/bin/python -m pip install --upgrade pip setuptools wheel && .venv/bin/python -m pip install --editable '.[dev]'`
- `.venv/bin/python setup.py build_ext --inplace`
- `PYTHONHASHSEED=0 .venv/bin/python -m pytest crosshair/tracers_test.py::test_normalize_call_target_helper_is_exported -q` failed before implementation as expected.
- `PYTHONHASHSEED=0 .venv/bin/python -m pytest crosshair/tracers_test.py crosshair/_tracers_test.py -q` -> `18 passed`
- `PYTHONHASHSEED=0 .venv/bin/python -m pytest crosshair/core_test.py crosshair/libimpl/builtinslib_test.py crosshair/tracers_test.py crosshair/_tracers_test.py -q` -> `564 passed, 2 skipped`
- `CROSSHAIR_EXTRA_ASSERTS=1 PYTHONHASHSEED=0 .venv/bin/python -m pytest crosshair/core_test.py crosshair/libimpl/builtinslib_test.py crosshair/tracers_test.py crosshair/_tracers_test.py -q` -> `564 passed, 2 skipped`
- `CROSSHAIR_EXTRA_ASSERTS=1 PYTHONHASHSEED=0 .venv/bin/python -m pytest -m smoke -n auto --dist worksteal crosshair -q` -> `13 passed`
- `.venv/bin/python -m black --check crosshair/tracers.py crosshair/tracers_test.py`
- `.venv/bin/python -m isort --check-only crosshair/tracers.py crosshair/tracers_test.py`
- `.venv/bin/pre-commit run flake8 --files crosshair/tracers.py crosshair/tracers_test.py`
- `git diff --check`

I also attempted the full local xdist suite. It reported 8 failures in symbolic/time-sensitive areas under local parallel load; each failed nodeid that I reran in isolation passed with `PYTHONHASHSEED=0`. I left this note here so CI remains the source of truth for the full matrix.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#115: Improve trace callback performance](https://oss.issuehunt.io/repos/101762821/issues/115)
---
</details>
<!-- /Issuehunt content-->