### PR TITLE
Keep date/datetime/time/timedelta comparisons symbolic

### DIFF
--- a/crosshair/libimpl/datetimelib.py
+++ b/crosshair/libimpl/datetimelib.py
@@ -35,13 +35,34 @@ from crosshair import (
     register_type,
 )
 from crosshair.core import SymbolicFactory
-from crosshair.libimpl.builtinslib import make_bounded_int, smt_or
+from crosshair.libimpl.builtinslib import make_bounded_int, smt_not, smt_or
 from crosshair.statespace import context_statespace
 from crosshair.tracers import NoTracing
 
 
+def _lex_lt(left, right):
+    """Lexicographic strict-less-than over two equal-length sequences."""
+    clauses = []
+    for i in range(len(left)):
+        clause = [left[j] == right[j] for j in range(i)]
+        clause.append(left[i] < right[i])
+        clauses.append(all(clause))
+    return any(clauses)
+
+
 def _cmp(x, y):
-    return 0 if x == y else 1 if x > y else -1
+    # Three-way comparison built from `any`/`all` (which the patched builtins
+    # collapse to single SMT terms), so comparisons of symbolic dates/times
+    # stay symbolic instead of realizing each component via tuple comparison.
+    return _lex_lt(y, x) - _lex_lt(x, y)
+
+
+def _symbolic_ne(eq_result):
+    # Negate an __eq__ result while keeping it symbolic.  (Python's default
+    # __ne__ calls bool() on the __eq__ result, which would realize it.)
+    if eq_result is NotImplemented:
+        return NotImplemented
+    return smt_not(eq_result)
 
 
 MINYEAR = 1
@@ -754,6 +775,9 @@ class timedelta:
         else:
             return NotImplemented
 
+    def __ne__(self, other):
+        return _symbolic_ne(self.__eq__(other))
+
     def __le__(self, other):
         if isinstance(other, any_timedelta):
             return self._cmp(other) <= 0
@@ -1053,6 +1077,9 @@ class date:
         if isinstance(other, any_date):
             return self._cmp(other) == 0
         return NotImplemented
+
+    def __ne__(self, other):
+        return _symbolic_ne(self.__eq__(other))
 
     def __le__(self, other):
         if isinstance(other, any_date):
@@ -1354,6 +1381,9 @@ class time:
             return self._cmp(other, allow_mixed=True) == 0
         else:
             return NotImplemented
+
+    def __ne__(self, other):
+        return _symbolic_ne(self.__eq__(other))
 
     def __le__(self, other):
         if isinstance(other, any_time):
@@ -2114,6 +2144,9 @@ class datetime(date):
         else:
             return False
 
+    def __ne__(self, other):
+        return _symbolic_ne(self.__eq__(other))
+
     def __le__(self, other):
         if isinstance(other, any_datetime):
             return self._cmp(other) <= 0
@@ -2338,6 +2371,9 @@ class timezone(tzinfo):
             return self.utcoffset(None) == other.utcoffset(None)
         return NotImplemented
 
+    def __ne__(self, other):
+        return _symbolic_ne(self.__eq__(other))
+
     def __hash__(self):
         return hash(self._offset)
 
@@ -2531,7 +2567,7 @@ def make_registrations():
     register_patch(real_date, lambda *a, **kw: date(*a, **kw))
 
     def make_time(p: Any) -> time:
-        (hour, minute, sec, usec, fold) = _symbolic_time_fields(p.varname)
+        hour, minute, sec, usec, fold = _symbolic_time_fields(p.varname)
         tzinfo = p(Optional[timezone], "_tzinfo")
         return _time_skip_construct(hour, minute, sec, usec, tzinfo, fold)
 
@@ -2540,7 +2576,7 @@ def make_registrations():
 
     def make_datetime(p: Any) -> datetime:
         year, month, day = _symbolic_date_fields(p.varname)
-        (hour, minute, sec, usec, fold) = _symbolic_time_fields(p.varname)
+        hour, minute, sec, usec, fold = _symbolic_time_fields(p.varname)
         tzinfo = p(Optional[timezone], "_tzinfo")
         return _datetime_skip_construct(
             year, month, day, hour, minute, sec, usec, tzinfo

--- a/crosshair/libimpl/datetimelib_test.py
+++ b/crosshair/libimpl/datetimelib_test.py
@@ -2,8 +2,10 @@ import datetime
 
 import pytest
 
-from crosshair.statespace import CONFIRMED, EXEC_ERR, POST_FAIL
+from crosshair.core import proxy_for_type
+from crosshair.statespace import CONFIRMED, EXEC_ERR, POST_FAIL, StateSpace
 from crosshair.test_util import check_states
+from crosshair.tracers import ResumedTracing
 
 
 def test_timedelta_symbolic_months_fail() -> None:
@@ -99,6 +101,34 @@ def test_timedelta___add___method() -> None:
         return datetime.date(2000, 1, 1) + delta
 
     check_states(f, POST_FAIL)
+
+
+def _assert_both_reachable(space, value, needle) -> None:
+    # The point of keeping comparisons symbolic is that the search can still
+    # reach *both* sides; realizing an operand would pin it and make one side
+    # unreachable (so e.g. a `!= needle` postcondition could never be
+    # falsified).  We check reachability via independent satisfiability
+    # queries -- no reliance on the result's internal type.
+    with ResumedTracing():
+        assert space.is_possible(value == needle)  # can equal the needle
+        assert space.is_possible(value != needle)  # ...and can differ
+        assert space.is_possible(value < needle)  # can be below
+        assert space.is_possible(value >= needle)  # ...and at-or-above
+
+
+def test_date_comparisons_reach_both_sides(space: StateSpace) -> None:
+    d = proxy_for_type(datetime.date, "d")
+    _assert_both_reachable(space, d, datetime.date(2030, 2, 14))
+
+
+def test_datetime_comparisons_reach_both_sides(space: StateSpace) -> None:
+    d = proxy_for_type(datetime.datetime, "d")
+    _assert_both_reachable(space, d, datetime.datetime(2030, 2, 14, 9, 30, 0))
+
+
+def test_timedelta_comparisons_reach_both_sides(space: StateSpace) -> None:
+    d = proxy_for_type(datetime.timedelta, "d")
+    _assert_both_reachable(space, d, datetime.timedelta(days=5, seconds=42))
 
 
 def TODO_test_leap_year() -> None:

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,7 +6,12 @@ Changelog
 Next Version
 ---------------
 
- * Nothing yet!
+  * Compute ``date``/``datetime``/``time``/``timedelta`` comparisons
+    (``==``, ``!=``, ``<``, ``<=``, ``>``, ``>=``) as single symbolic
+    expressions over the component integers, instead of going through tuple
+    comparison (which realized each component individually).  CrossHair can now
+    directly discover specific dates as counterexamples -- e.g.
+    ``post: d != datetime.date(2030, 2, 14)``.
 
 
 Version 0.0.103


### PR DESCRIPTION
The comparison dunders delegated to a module-level _cmp that returned a concrete -1/0/1 by comparing tuples with Python's tuple </==.  That tuple comparison forked on each element to coerce SymbolicBool back to a real bool, so the solver saw a chain of sequential decisions rather than a single constraint.  Separately, none of these classes defined __ne__, so `!=` fell back to Python negating __eq__ via bool(), realizing the operand too.

Make _cmp return a symbolic three-way value, built from a lexicographic less-than (_lex_lt) over the components using the patched any/all builtins (which collapse to single SMT terms).  Every `self._cmp(other) <op> 0` then stays symbolic, with no per-operator changes; timedelta (which routes through the same _cmp) benefits too.  Add __ne__ methods (date, datetime, time, timedelta, timezone) that negate the symbolic __eq__ result with smt_not instead of bool().

Closes https://github.com/pschanely/CrossHair/issues/424; the remaining problems are an issue for how Hypothesis constructs these objects.