### PR TITLE
Keep symbolic booleans and date leap-year detection symbolic

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+# CrossHair dev environment: isolated from the host for safer agent work.
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+# Build deps for pyenv/CPython and the _crosshair_tracers C extension.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends \
+        build-essential curl git \
+        libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+        libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
+        libffi-dev liblzma-dev \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+USER vscode
+ENV PYENV_ROOT="/home/vscode/.pyenv"
+ENV PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:${PATH}"
+
+RUN curl -fsSL https://pyenv.run | bash

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,25 @@
+# CrossHair devcontainer
+
+A reproducible dev environment that matches CI — dev dependencies, pre-commit
+hooks, and pyenv-managed Python — keeping the project's Python toolchain
+separate from whatever you have on your host.
+
+## Getting started
+
+Open the repo in the container with **Dev Containers: Reopen in Container**
+(VS Code / Cursor). The first build installs Python 3.13 via pyenv, runs
+`pip install -e .[dev]`, and installs the pre-commit hooks.
+
+## Python versions
+
+CrossHair is version-sensitive. Switch interpreters with `switch-python 3.11`;
+`switch-python --install-all` preinstalls them all.
+Run `switch-python --list` to see what's installed.
+
+## What's shared with your host
+
+The container isolates the **Python toolchain**, but it is not a security
+sandbox. Your host `~/.claude` directory (Claude Code credentials and sessions)
+is bind-mounted in so that state persists across rebuilds, and shell history
+lives in a named volume. Don't treat the container as a trust boundary for
+anything you wouldn't already expose to your host credentials.

--- a/.devcontainer/bin/switch-python
+++ b/.devcontainer/bin/switch-python
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "${SCRIPT_DIR}/../switch-python.sh" "$@"

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+{
+  "name": "CrossHair",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteEnv": {
+    "PYTHONHASHSEED": "0",
+    "CROSSHAIR_EXTRA_ASSERTS": "1",
+    "PYENV_ROOT": "/home/vscode/.pyenv",
+    "PATH": "${containerWorkspaceFolder}/.devcontainer/bin:/home/vscode/.pyenv/bin:/home/vscode/.pyenv/shims:${containerEnv:PATH}",
+    "HISTFILE": "/home/vscode/.commandhistory/.zsh_history"
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "CrossHair.crosshair"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/home/vscode/.pyenv/shims/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "crosshair",
+          "-n",
+          "auto",
+          "--dist=worksteal"
+        ],
+        "editor.formatOnSave": true,
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.black-formatter",
+          "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+          }
+        },
+        "isort.args": [
+          "--profile",
+          "black"
+        ]
+      }
+    }
+  },
+  // Installs Claude Code automatically inside the container
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+  },
+  // Persists Claude sessions/credentials (host bind) and shell history (named
+  // volume, so it survives rebuilds without depending on a host file existing).
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
+    "source=crosshair-commandhistory,target=/home/vscode/.commandhistory,type=volume"
+  ],
+  "remoteUser": "vscode",
+  "containerUser": "vscode"
+}

--- a/.devcontainer/install-crosshair.sh
+++ b/.devcontainer/install-crosshair.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -e ".[dev]"
+
+# Quick sanity check that the CLI and C extension built for this interpreter.
+crosshair -h >/dev/null
+python -c "import _crosshair_tracers"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A fresh named volume mounts root-owned; make the history dir writable by us.
+sudo chown -R "$(id -u):$(id -g)" /home/vscode/.commandhistory
+
+pyenv update
+pyenv install -s 3.13
+pyenv local 3.13
+
+bash "$(dirname "$0")/install-crosshair.sh"
+pre-commit install --install-hooks
+
+echo "CrossHair devcontainer is ready (Python 3.13)."
+echo "Use 'switch-python 3.11' (etc.) to test other CI versions."

--- a/.devcontainer/switch-python.sh
+++ b/.devcontainer/switch-python.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Versions exercised in .github/workflows/test_crosshair.yml
+CI_PYTHON_VERSIONS=(3.9 3.10 3.11 3.12 3.13 3.14)
+
+usage() {
+  cat <<EOF
+Usage:
+  switch-python <version>       Switch Python and reinstall CrossHair
+  switch-python --install-all   Preinstall all CI Python versions (slow, one-time)
+  switch-python --list          Show installed and CI target versions
+
+Examples:
+  switch-python 3.11
+  switch-python 3.13.2
+
+If a version isn't found, run 'pyenv update' to refresh the known list.
+
+CI matrix: ${CI_PYTHON_VERSIONS[*]}
+EOF
+}
+
+list_versions() {
+  echo "CI versions: ${CI_PYTHON_VERSIONS[*]}"
+  echo "Installed:"
+  pyenv versions
+}
+
+install_all() {
+  pyenv update
+  for version in "${CI_PYTHON_VERSIONS[@]}"; do
+    echo "Installing Python ${version}..."
+    pyenv install -s "${version}"
+  done
+  echo "All CI Python versions are installed."
+}
+
+switch_version() {
+  local version="$1"
+  pyenv install -s "${version}"
+  pyenv local "${version}"
+  bash "$(dirname "$0")/install-crosshair.sh"
+  python --version
+  echo "CrossHair is ready on $(python --version)."
+}
+
+case "${1:-}" in
+  --help|-h)
+    usage
+    ;;
+  --list)
+    list_versions
+    ;;
+  --install-all)
+    install_all
+    ;;
+  "")
+    usage
+    exit 1
+    ;;
+  *)
+    switch_version "$1"
+    ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ ENV/
 
 # Z3
 .z3-trace
+
+# Claude Code (personal/local settings; shared .claude/settings.json may be committed)
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,15 @@ CrossHair is a Python analysis tool that uses **symbolic execution** and an **SM
 - **`crosshair/tracers.py`** – Bytecode tracing for symbolic execution (C extension in `_tracers.c`)
 - **`crosshair/smtlib.py`**, **`crosshair/z3util.py`** – Z3/SMT integration
 - **`doc/source/`** - documentation (log user-facing changes in `changelog.rst`)
+## Development Environment
+
+The repo ships a **devcontainer** (`.devcontainer/`) that matches CI (dev deps, pre-commit hooks, pyenv-managed Python). It's the recommended way to run agents but not required — the notes below apply in any environment. See `.devcontainer/README.md` for host setup and what the container shares with your host.
+
+- **Tests** run with `PYTHONHASHSEED=0` for reproducibility:
+  - Smoke tests: `PYTHONHASHSEED=0 python -m pytest -m smoke -n auto --dist=worksteal`
+  - Full suite: `PYTHONHASHSEED=0 python -m pytest -n auto --dist=worksteal crosshair`
+- **CrossHair is very sensitive to Python version differences**. After changing the active interpreter, reinstall with `pip install -e .[dev]` so the `_crosshair_tracers` C extension is rebuilt for it — a stale `.so` from another version causes confusing failures. Inside the devcontainer, `switch-python <version>` does the install-and-reinstall in one step (see `.devcontainer/README.md`).
+
 ## Key Conventions
 
 - **Formatting**: Black (88 chars), isort, flake8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ CrossHair is a Python analysis tool that uses **symbolic execution** and an **SM
   - **`isinstance` and `type` depend on tracing** – symbolic values report their emulated type when tracing is on.
   - **Tracing enables overrides/patches** – function patches (`register_patch`, `register_type`) and bytecode overrides (`opcode_intercept.py`). The code for a patch always starts with tracing on.
   - Add `@assert_tracing(True)` (or False) to clarify that your function expects a specific tracing status. (assert_tracing becomes enforced with a CROSSHAIR_EXTRA_ASSERTS=1 env var)
-  - **Ensure tracing is on during symbolic operations.** ALL operations that involve symbolics require tracing. You will likey get an exception will usually fail if tracing isn't on. Examples that require tracing:
+  - **Ensure tracing is on during symbolic operations.** ALL operations that involve symbolics require tracing. You'll likey get an exception if tracing isn't on. Examples that require tracing:
     - `len(symbolic_list)`
     - `symbolic_int > 0`
     - `next(symbolic_iter)`
@@ -40,12 +40,18 @@ CrossHair is a Python analysis tool that uses **symbolic execution** and an **SM
     - You never need import the "original" version of some function - the function never changes.
     - CrossHair uses function identity to intercept calls
   - To call the unpatched version of a function, you can either call it directly from the function body of its patch, or disable tracing.
-  - **Consider leaving tracing on** – disabling gives a speedup but is error-prone. C-level code is often patched with plain Python with tracing enabled.
   - Nest NoTracing and ResumedTracing blocks inside each other to toggle tracing. It's ok to nest NoTracing inside NoTracing (or ResumedTracing inside ResumedTracing), but the inner block effectively does nothing.
+- How to add symbolic support for something
+  - **Consider leaving tracing on** – disabling gives a speedup but is error-prone. C-level code is often patched with plain Python + tracing.
+  - In general, **avoid branching**. `x or y` implicitly creates a branch; instead, use something without short-circuiting like `x | y` or `any([x, y])`. Similarly, consider `(cond) * value` instead of `value if cond else 0`.
+  - OTOH, consider **adding branching** to enable simpler execution paths or simpler SMT expressions. A central design tension in CrossHair is trading execution paths to keep solve times managable. (especially nonlinear integer arithmetic — floor division, multiplication of unknowns) Measure, don't assume.
+  - Consider realizing symbolics early when we know they can't remain symbolic. (an integer that determines a future loop iteration)
+  - Re-order operations to retain a larger state space for longer. Push work towards values that are likely to be concrete.
 - Testing
   - **Unit tests start without tracing.**
     – If you use a `space` fixture parameter, you can `with ResumedTracing():` to enable tracing.
     - Otherwise, enter a statespace context to begin tracing.
+  - To assert something is symbolic, query both sides for satisfiability: `assert space.is_possible(x == a)` and `assert space.is_possible(x != a)`.
   - Most pytest nicities (value printing!) are disabled because operating on symbolics under failure modes tends to obscure problems.
   - The test suite is large; use `pytest -n auto --dist=worksteal` when running several tests (`pytest-xdist` is already in dev dependencies).
   - Consider **debugging individual tests with `pytest -v`** - CrossHair's logging is verbose, but will display some important events:

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -967,7 +967,21 @@ def setup_binops():
         with NoTracing():
             return SymbolicBool(apply_smt(op, a.var, b.var))
 
-    setup_binop(_, {ops.eq, ops.ne})
+    # Bitwise &/|/^ on bools is logical and/or/xor; keep it symbolic instead of
+    # upconverting to int (z3's Int sort has no bitwise ops, forcing realization).
+    setup_binop(_, {ops.eq, ops.ne, ops.and_, ops.or_, ops.xor})
+
+    def _(op: BinFn, a: SymbolicBool, b: bool):
+        with NoTracing():
+            return SymbolicBool(apply_smt(op, a.var, z3.BoolVal(b)))
+
+    setup_binop(_, {ops.and_, ops.or_, ops.xor})
+
+    def _(op: BinFn, a: bool, b: SymbolicBool):
+        with NoTracing():
+            return SymbolicBool(apply_smt(op, z3.BoolVal(a), b.var))
+
+    setup_binop(_, {ops.and_, ops.or_, ops.xor})
 
 
 #

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -67,6 +67,7 @@ from crosshair.libimpl.builtinslib import (
     SymbolicRange,
     SymbolicType,
     crosshair_types_for_python_type,
+    smt_not,
 )
 from crosshair.options import AnalysisOptionSet
 from crosshair.statespace import (
@@ -565,6 +566,39 @@ def test_bool_bitwise_negation(space: StateSpace) -> None:
 
         space.add(symbool)
         assert not space.is_possible(neg_symbool == 1)
+
+
+@pytest.mark.parametrize("op", (operator.and_, operator.or_, operator.xor))
+def test_symbolic_bool_logic_stays_symbolic(space: StateSpace, op) -> None:
+    # `&`, `|`, `^` between two symbolic bools must stay symbolic rather than
+    # realizing (and thereby pinning) the operands.  Previously these promoted
+    # the bools to ints and fell through to the integer-bitwise handlers, which
+    # realize because z3's Int sort has no bitwise operators.
+    a = proxy_for_type(bool, "a")
+    b = proxy_for_type(bool, "b")
+    with ResumedTracing():
+        result = op(a, b)
+        # Neither operand was pinned by the operation:
+        assert space.is_possible(a)
+        assert space.is_possible(smt_not(a))
+        assert space.is_possible(b)
+        assert space.is_possible(smt_not(b))
+        # ...and the result can still go either way:
+        assert space.is_possible(result)
+        assert space.is_possible(smt_not(result))
+
+
+@pytest.mark.parametrize("op", (operator.and_, operator.or_, operator.xor))
+@pytest.mark.parametrize("bv", (False, True))
+@pytest.mark.parametrize("av", (False, True))
+def test_symbolic_bool_logic_truth_table(space: StateSpace, op, av, bv) -> None:
+    a = proxy_for_type(bool, "a")
+    b = proxy_for_type(bool, "b")
+    with ResumedTracing():
+        result = op(a, b)
+        space.add(a if av else smt_not(a))
+        space.add(b if bv else smt_not(b))
+        assert bool(result) == op(av, bv)
 
 
 def test_float_from_hex(space: StateSpace) -> None:

--- a/crosshair/libimpl/datetimelib.py
+++ b/crosshair/libimpl/datetimelib.py
@@ -82,20 +82,18 @@ del dbm, dim
 
 
 def _is_leap(year):
-    """year -> 1 if leap year, else 0."""
+    """year -> True if leap year, else False."""
     return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
 
 
-import z3  # type: ignore
+def _is_leap_int(year):
+    """year -> 1 if leap year else 0, as a (possibly symbolic) integer.
 
-
-def _smt_is_leap(smt_year):
-    """year -> 1 if leap year, else 0."""
-    return context_statespace().smt_fork(
-        z3.And(smt_year % 4 == 0, z3.Or(smt_year % 100 != 0, smt_year % 400 == 0)),
-        "is leap year",
-        probability_true=0.25,
-    )
+    Unlike ``_is_leap``, this uses only arithmetic and (in)equality (no
+    short-circuiting ``and``/``or``), so a symbolic year stays symbolic
+    instead of forking the search on its leap-ness.
+    """
+    return (year % 4 == 0) * (1 - (year % 100 == 0) * (year % 400 != 0))
 
 
 def _days_before_year(year):
@@ -112,47 +110,40 @@ def _days_in_month(year, month):
         return 31 if month % 2 == 0 else 30
     else:
         if month == 2:
-            return 29 if _is_leap(year) else 28
+            return 28 + _is_leap_int(year)
         else:
             return 30 if month % 2 == 0 else 31
 
 
-def _smt_days_in_month(smt_year, smt_month, smt_day):
-    """constraint smt_day to match the year and month."""
-    feb_days = 29 if _smt_is_leap(smt_year) else 28
-    return z3.Or(
-        z3.And(
-            smt_day <= feb_days,
-            smt_month == 2,
-        ),
-        z3.And(
-            smt_day <= 30,
-            z3.Or(
-                smt_month == 4,
-                smt_month == 6,
-                smt_month == 9,
-                smt_month == 11,
-            ),
-        ),
-        z3.And(
-            smt_day <= 31,
-            z3.Or(
-                smt_month == 1,
-                smt_month == 3,
-                smt_month == 5,
-                smt_month == 7,
-                smt_month == 8,
-                smt_month == 10,
-                smt_month == 12,
-            ),
-        ),
+def _day_in_month_constraint(year, month, day):
+    """Return a symbolic constraint that day is valid for the given month/year.
+
+    Uses arithmetic and bitwise &/| (which stay symbolic for booleans) so that
+    the year's leap-ness is never forked/realized.
+    """
+    feb_days = 28 + _is_leap_int(year)
+    return (
+        ((day <= feb_days) & (month == 2))
+        | ((day <= 30) & ((month == 4) | (month == 6) | (month == 9) | (month == 11)))
+        | (
+            (day <= 31)
+            & (
+                (month == 1)
+                | (month == 3)
+                | (month == 5)
+                | (month == 7)
+                | (month == 8)
+                | (month == 10)
+                | (month == 12)
+            )
+        )
     )
 
 
 def _days_before_month(year, month):
     """year, month -> number of days in year preceding first day of month."""
     assert 1 <= month <= 12, "month must be in 1..12"
-    return _DAYS_BEFORE_MONTH[month] + (month > 2 and _is_leap(year))
+    return _DAYS_BEFORE_MONTH[month] + (month > 2) * _is_leap_int(year)
 
 
 def _ymd2ord(year, month, day):
@@ -2525,7 +2516,9 @@ def _symbolic_date_fields(varname: str) -> Tuple:
     year = make_bounded_int(varname + "_year", MINYEAR, MAXYEAR)
     month = make_bounded_int(varname + "_month", 1, 12)
     day = make_bounded_int(varname + "_day", 1, 31)
-    context_statespace().add(_smt_days_in_month(year.var, month.var, day.var))
+    with ResumedTracing():
+        constraint = _day_in_month_constraint(year, month, day)
+    context_statespace().add(constraint)
     return (year, month, day)
 
 

--- a/crosshair/libimpl/datetimelib.py
+++ b/crosshair/libimpl/datetimelib.py
@@ -104,7 +104,8 @@ def _days_before_year(year):
 
 def _days_in_month(year, month):
     """year, month -> number of days in that month in that year."""
-    # Avoid _DAYS_IN_MONTH so that we don't realize the month
+    # NB: _DAYS_IN_MONTH[month] would also keep `month` symbolic (symbolic
+    # indexing into a concrete list is supported); this branches instead.
     assert 1 <= month <= 12, month
     if month >= 8:
         return 31 if month % 2 == 0 else 30

--- a/crosshair/libimpl/datetimelib_test.py
+++ b/crosshair/libimpl/datetimelib_test.py
@@ -184,9 +184,15 @@ def test_leap_year() -> None:
         Adding 365 days does not always land on the next year (leap years
         have 366), so this postcondition is falsifiable.
 
+        pre: start.month == 1 and start.day == 1
         post: _.year == start.year + 1
         raises: OverflowError
         """
         return start + datetime.timedelta(days=365)
 
+    # Pin month/day to Jan 1 so the search only has to find a leap year, rather
+    # than exploring all month/day combinations. Without this the counterexample
+    # is found but timing-sensitively (~12-22s; the per-path Z3 timeout is
+    # wall-clock), which flaked across CI runners. The symbolic year still
+    # exercises the date + timedelta arithmetic that crosses the calendar.
     check_states(f, POST_FAIL)

--- a/crosshair/libimpl/datetimelib_test.py
+++ b/crosshair/libimpl/datetimelib_test.py
@@ -178,11 +178,14 @@ def test_symbolic_date_feb29_only_on_leap_years(space: StateSpace) -> None:
         assert not space.is_possible((d.year == 1900) & feb29)  # century non-leap
 
 
-def TODO_test_leap_year() -> None:
-    # The solver returns unknown when adding a delta to a symbolic date. (nonlinear I think)
+def test_leap_year() -> None:
     def f(start: datetime.date) -> datetime.date:
         """
+        Adding 365 days does not always land on the next year (leap years
+        have 366), so this postcondition is falsifiable.
+
         post: _.year == start.year + 1
+        raises: OverflowError
         """
         return start + datetime.timedelta(days=365)
 

--- a/crosshair/libimpl/datetimelib_test.py
+++ b/crosshair/libimpl/datetimelib_test.py
@@ -1,8 +1,11 @@
+import calendar
 import datetime
 
 import pytest
 
 from crosshair.core import proxy_for_type
+from crosshair.libimpl.builtinslib import make_bounded_int
+from crosshair.libimpl.datetimelib import _is_leap_int
 from crosshair.statespace import CONFIRMED, EXEC_ERR, POST_FAIL, StateSpace
 from crosshair.test_util import check_states
 from crosshair.tracers import ResumedTracing
@@ -129,6 +132,50 @@ def test_datetime_comparisons_reach_both_sides(space: StateSpace) -> None:
 def test_timedelta_comparisons_reach_both_sides(space: StateSpace) -> None:
     d = proxy_for_type(datetime.timedelta, "d")
     _assert_both_reachable(space, d, datetime.timedelta(days=5, seconds=42))
+
+
+@pytest.mark.parametrize(
+    "year",
+    [1, 4, 100, 400, 1900, 1996, 2000, 2001, 2004, 2023, 2100, 2400, 9999],
+)
+def test_is_leap_int_matches_calendar(year: int) -> None:
+    # Concrete inputs must produce the same answer as the stdlib (as a 0/1 int).
+    assert _is_leap_int(year) == int(calendar.isleap(year))
+
+
+def test_is_leap_int_stays_symbolic(space: StateSpace) -> None:
+    # The whole point of the arithmetic form: it must NOT fork/realize the
+    # year.  After the call, both a known leap year and a known common year
+    # remain reachable, and the result can be both 1 and 0.  The old
+    # ``_is_leap`` (which uses ``and``/``or``) would pin the year here.
+    year = make_bounded_int("year", 1, 9999)
+    with ResumedTracing():
+        result = _is_leap_int(year)
+        assert space.is_possible((year == 2000).var)  # leap still reachable
+        assert space.is_possible((year == 2001).var)  # common still reachable
+        assert space.is_possible((result == 1).var)  # result can be leap
+        assert space.is_possible((result == 0).var)  # ...and common
+
+
+def test_symbolic_date_year_stays_symbolic(space: StateSpace) -> None:
+    # Constructing a symbolic date must not fork on the year's leap-ness.
+    # (Previously the day-validity constraint forked on whether the year was a
+    # leap year, pinning it so that one of these became unreachable.)
+    d = proxy_for_type(datetime.date, "d")
+    with ResumedTracing():
+        year = d.year
+        assert space.is_possible(year == 2000)  # leap reachable
+        assert space.is_possible(year == 2001)  # common reachable
+
+
+def test_symbolic_date_feb29_only_on_leap_years(space: StateSpace) -> None:
+    d = proxy_for_type(datetime.date, "d")
+    with ResumedTracing():
+        feb29 = (d.month == 2) & (d.day == 29)
+        assert space.is_possible((d.year == 2000) & feb29)  # leap: ok
+        assert space.is_possible((d.year == 2400) & feb29)  # leap: ok
+        assert not space.is_possible((d.year == 2001) & feb29)  # common
+        assert not space.is_possible((d.year == 1900) & feb29)  # century non-leap
 
 
 def TODO_test_leap_year() -> None:

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -11,6 +11,10 @@ Next Version
    realizing the operands. Previously these forced concrete values, because
    z3's integer sort has no bitwise operators; now they produce a single
    symbolic boolean and the search can still reach both sides.
+ * Keep ``date``/``datetime`` leap-year detection symbolic: constructing a
+   symbolic date no longer forks on whether its year is a leap year, so the
+   year stays unrealized (e.g. both leap and common years remain reachable
+   for a single symbolic date).
 
 
 Version 0.0.106

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,7 +6,11 @@ Changelog
 Next Version
 ---------------
 
- * Nothing yet!
+ * Keep the bitwise operators ``&``, ``|``, and ``^`` between symbolic booleans
+   symbolic (as logical and/or/xor), instead of upconverting to integers and
+   realizing the operands. Previously these forced concrete values, because
+   z3's integer sort has no bitwise operators; now they produce a single
+   symbolic boolean and the search can still reach both sides.
 
 
 Version 0.0.106


### PR DESCRIPTION
Two related changes, in separate commits.

## 1. Bitwise `&` / `|` / `^` on symbolic booleans stay symbolic

These operators upconverted both bools to ints and fell through to the integer-bitwise handlers, which **realize** because z3's `Int` sort has no bitwise operators — so `a & b` between two symbolic bools pinned both operands. They now dispatch directly on `SymbolicBool` (and the `SymbolicBool`/concrete-`bool` mixes) as logical And/Or/Xor, producing a single symbolic boolean. `bool & int` still upconverts to int, matching Python semantics.

## 2. Date leap-year detection stays symbolic

Unify leap-year detection on a single arithmetic helper, `_is_leap_int`, which uses only arithmetic and (in)equality (no short-circuiting `and`/`or`), so a symbolic year stays symbolic instead of forking the search on its leap-ness. The day-validity constraint (`_day_in_month_constraint`, formerly `_smt_days_in_month`) now builds on it with bitwise `&`/`|` — symbolic as of change #1 — replacing the z3-native, forking `_smt_is_leap` path entirely.

Net effect: constructing a symbolic `date`/`datetime` no longer pins the year to a leap or common year; both stay reachable for the solver.

## Tests / checks
- New unit tests assert the property that matters (operands/year stay reachable on both sides), via independent `is_possible` queries — no reliance on internal types.
- `builtinslib_test.py` (470) + `datetimelib_test.py` (27) + `datetimelib_ch_test.py` (CrossHair-on-CrossHair) pass locally; smoke + pre-commit (black, isort, flake8, mypy) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-up commits in this PR:**
- *Enable the leap-year date-arithmetic test* — un-disables `TODO_test_leap_year`. Its "solver returns unknown" note was stale; the only blocker was an undeclared near-`MAXYEAR` `OverflowError` escaping as `EXEC_ERR`. With `raises: OverflowError` declared it finds the leap-year counterexample (~12s). (We also evaluated the experimental `_symbolic_fromordinal`/forked-`__add__` rework against this test and **dropped it** — slower *and* regressed the result to `CANNOT_CONFIRM`; `_ord2ymd` is tractable now.)
- *Fix misleading comment in `_days_in_month`* — the "avoid `_DAYS_IN_MONTH` so we don't realize the month" note was wrong (symbolic indexing into a concrete list stays symbolic); corrected so it doesn't assert a non-reason.
- Update AGENTS.md
- Add devcontainer support
