### PR TITLE
Represent symbolic dates by ordinal, decomposing calendar fields lazily (#428)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,6 +51,7 @@
   // volume, so it survives rebuilds without depending on a host file existing).
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
+    "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind",
     "source=crosshair-commandhistory,target=/home/vscode/.commandhistory,type=volume"
   ],
   "remoteUser": "vscode",

--- a/crosshair/libimpl/datetimelib.py
+++ b/crosshair/libimpl/datetimelib.py
@@ -1078,6 +1078,12 @@ class date:
         contribute to the result.
         """
         if self._ord is None:
+            # For a components-backed date the ordinal is derived lazily here, on
+            # first arithmetic/comparison, as the inline _ymd2ord(y, m, d)
+            # expression.  Naming it instead with a fresh bridged variable
+            # (ordinal == _ymd2ord(y, m, d)) was measured slower -- the extra
+            # nonlinear bridge equation outweighs any benefit -- so we keep the
+            # inline form.  See #428 / the #427 "more symbolic isn't faster" lesson.
             y, m, d = self._ymd
             self._ord = _ymd2ord(y, m, d)
         return self._ord

--- a/crosshair/libimpl/datetimelib.py
+++ b/crosshair/libimpl/datetimelib.py
@@ -1945,7 +1945,10 @@ class datetime(date):
 
     def date(self):
         """Return the date part."""
-        return date(self._year, self._month, self._day)
+        if self._ymd is None:
+            return _date_from_ordinal(self._ord)
+        y, m, d = self._ymd
+        return date(y, m, d)
 
     def time(self):
         """Return the time part, with tzinfo None."""
@@ -2236,20 +2239,27 @@ class datetime(date):
             base_compare = myoff == otoff
 
         if base_compare:
+            # Comparing ordinals is order-equivalent to comparing (y, m, d) but
+            # linear; use it when either side is ordinal-backed to avoid forcing
+            # the nonlinear _ord2ymd decomposition.  Otherwise keep the fast
+            # lexicographic (y, m, d) prefix that computes no ordinal at all.
+            other_ordinal_only = isinstance(other, datetime) and other._ymd is None
+            if self._ymd is None or other_ordinal_only:
+                self_date: Tuple = (self.toordinal(),)
+                other_date: Tuple = (other.toordinal(),)
+            else:
+                self_date = (self._year, self._month, self._day)
+                other_date = (other.year, other.month, other.day)
             return _cmp(
                 (
-                    self._year,
-                    self._month,
-                    self._day,
+                    *self_date,
                     self._hour,
                     self._minute,
                     self._second,
                     self._microsecond,
                 ),
                 (
-                    other.year,
-                    other.month,
-                    other.day,
+                    *other_date,
                     other.hour,
                     other.minute,
                     other.second,
@@ -2282,9 +2292,10 @@ class datetime(date):
         hour, rem = divmod(delta.seconds, 3600)
         minute, second = divmod(rem, 60)
         if 0 < delta.days <= _MAXORDINAL:
-            return datetime.combine(
-                date.fromordinal(delta.days),
-                time(hour, minute, second, delta.microseconds, tzinfo=self._tzinfo),
+            # delta.days is the result ordinal; keep the date part ordinal-backed
+            # (lazy) rather than eagerly decomposing via combine/fromordinal.
+            return _datetime_from_ordinal(
+                delta.days, hour, minute, second, delta.microseconds, self._tzinfo
             )
         raise OverflowError("result out of range")
 
@@ -2332,10 +2343,18 @@ class datetime(date):
         return self._hashcode
 
     def __ch_realize__(self):
+        # Realize the date part via the ordinal (stdlib decomposition) when
+        # ordinal-backed, so symbolic _ord2ymd never runs under NoTracing.
+        if self._ymd is None:
+            d = real_date.fromordinal(realize(self._ord))
+            year, month, day = d.year, d.month, d.day
+        else:
+            y, m, d = self._ymd
+            year, month, day = realize(y), realize(m), realize(d)
         return real_datetime(
-            realize(self._year),
-            realize(self._month),
-            realize(self._day),
+            year,
+            month,
+            day,
             realize(self._hour),
             realize(self._minute),
             realize(self._second),
@@ -2564,6 +2583,19 @@ def _datetime_skip_construct(
     return dt
 
 
+def _datetime_from_ordinal(ordinal, hour, minute, second, microsecond, tzinfo):
+    """Build an ordinal-backed datetime; the date part decomposes lazily."""
+    dt = datetime(2020, 1, 1)
+    dt._ymd = None
+    dt._ord = ordinal
+    dt._hour = hour
+    dt._minute = minute
+    dt._second = second
+    dt._microsecond = microsecond
+    dt._tzinfo = tzinfo
+    return dt
+
+
 def _symbolic_date_fields(varname: str) -> Tuple:
     year = make_bounded_int(varname + "_year", MINYEAR, MAXYEAR)
     month = make_bounded_int(varname + "_month", 1, 12)
@@ -2630,12 +2662,10 @@ def make_registrations():
     register_patch(real_time, lambda *a, **kw: time(*a, **kw))
 
     def make_datetime(p: Any) -> datetime:
-        year, month, day = _symbolic_date_fields(p.varname)
+        ordinal = _symbolic_date_ordinal(p.varname)
         hour, minute, sec, usec, fold = _symbolic_time_fields(p.varname)
         tzinfo = p(Optional[timezone], "_tzinfo")
-        return _datetime_skip_construct(
-            year, month, day, hour, minute, sec, usec, tzinfo
-        )
+        return _datetime_from_ordinal(ordinal, hour, minute, sec, usec, tzinfo)
 
     register_type(real_datetime, make_datetime)
     register_patch(real_datetime, lambda *a, **kw: datetime(*a, **kw))

--- a/crosshair/libimpl/datetimelib.py
+++ b/crosshair/libimpl/datetimelib.py
@@ -886,10 +886,36 @@ class date:
                 year, month, day = dt.year, dt.month, dt.day
         else:
             year, month, day = _check_date_fields(year, month, day)
-        self._year = year
-        self._month = month
-        self._day = day
+        self._ymd = (year, month, day)
+        self._ord = None
         self._hashcode = -1
+
+    # Internal representation.
+    #
+    # A date is backed by its calendar fields (``_ymd``) and/or its proleptic
+    # Gregorian ordinal (``_ord``); at least one is always present.  Either is
+    # derived from the other lazily and cached, so a program that only does
+    # arithmetic/comparison never pays the nonlinear ordinal<->calendar
+    # conversion, and one that only reads calendar fields never computes an
+    # ordinal.  See https://github.com/pschanely/CrossHair/issues/428.
+
+    def _decompose(self):
+        """Lazily derive (year, month, day) from the ordinal, caching the result."""
+        if self._ymd is None:
+            self._ymd = _ord2ymd(self._ord)
+        return self._ymd
+
+    @property
+    def _year(self):
+        return self._decompose()[0]
+
+    @property
+    def _month(self):
+        return self._decompose()[1]
+
+    @property
+    def _day(self):
+        return self._decompose()[2]
 
     # Additional constructors
 
@@ -1051,7 +1077,10 @@ class date:
         January 1 of year 1 is day 1.  Only the year, month and day values
         contribute to the result.
         """
-        return _ymd2ord(self._year, self._month, self._day)
+        if self._ord is None:
+            y, m, d = self._ymd
+            self._ord = _ymd2ord(y, m, d)
+        return self._ord
 
     def replace(self, year=None, month=None, day=None):
         """Return a new date with new values for the specified fields."""
@@ -1095,6 +1124,14 @@ class date:
 
     def _cmp(self, other):
         assert isinstance(other, any_date)
+        # If either side is ordinal-backed, compare ordinals: a single linear
+        # term, and it avoids forcing the nonlinear _ord2ymd decomposition (which
+        # also forks the path).  When both sides carry calendar fields
+        # (component-backed or a concrete date), the lexicographic (y, m, d)
+        # comparison is already fast and computes no ordinal at all.
+        other_ordinal_only = isinstance(other, date) and other._ymd is None
+        if self._ymd is None or other_ordinal_only:
+            return _cmp((self.toordinal(),), (other.toordinal(),))
         y, m, d = self._year, self._month, self._day
         y2, m2, d2 = other.year, other.month, other.day
         return _cmp((y, m, d), (y2, m2, d2))
@@ -1111,7 +1148,9 @@ class date:
         if isinstance(other, any_timedelta):
             o = self.toordinal() + other.days
             if 0 < o <= _MAXORDINAL:
-                return date.fromordinal(o)
+                # Keep the result ordinal-backed: calendar fields are decomposed
+                # lazily, so the addition stays linear unless a field is read.
+                return _date_from_ordinal(o)
             raise OverflowError("result out of range")
         return NotImplemented
 
@@ -1168,7 +1207,13 @@ class date:
         return _IsoCalendarDate(year, week + 1, day + 1)
 
     def __ch_realize__(self):
-        return real_date(realize(self._year), realize(self._month), realize(self._day))
+        # For an ordinal-backed date, realize the ordinal and let the stdlib do
+        # the decomposition concretely -- never run the symbolic _ord2ymd under
+        # the NoTracing realization context.
+        if self._ymd is None:
+            return real_date.fromordinal(realize(self._ord))
+        y, m, d = self._ymd
+        return real_date(realize(y), realize(m), realize(d))
 
     def __ch_pytype__(self):
         return real_date
@@ -2492,9 +2537,16 @@ def _time_skip_construct(hour, minute, second, microsecond, tzinfo, fold):
 
 def _date_skip_construct(year, month, day):
     dt = date(2020, 1, 1)
-    dt._year = year
-    dt._month = month
-    dt._day = day
+    dt._ymd = (year, month, day)
+    dt._ord = None
+    return dt
+
+
+def _date_from_ordinal(ordinal):
+    """Build an ordinal-backed date; calendar fields are decomposed lazily."""
+    dt = date(2020, 1, 1)
+    dt._ymd = None
+    dt._ord = ordinal
     return dt
 
 
@@ -2502,9 +2554,8 @@ def _datetime_skip_construct(
     year, month, day, hour, minute, second, microsecond, tzinfo
 ):
     dt = datetime(2020, 1, 1)
-    dt._year = year
-    dt._month = month
-    dt._day = day
+    dt._ymd = (year, month, day)
+    dt._ord = None
     dt._hour = hour
     dt._minute = minute
     dt._second = second
@@ -2521,6 +2572,16 @@ def _symbolic_date_fields(varname: str) -> Tuple:
         constraint = _day_in_month_constraint(year, month, day)
     context_statespace().add(constraint)
     return (year, month, day)
+
+
+def _symbolic_date_ordinal(varname: str):
+    """Allocate a symbolic date as a single ordinal in [1, _MAXORDINAL].
+
+    Every integer in that range is a valid date by construction, so (unlike
+    _symbolic_date_fields) no day-validity disjunction is needed, and the
+    nonlinear calendar decomposition is deferred to field access.
+    """
+    return make_bounded_int(varname + "_ord", 1, _MAXORDINAL)
 
 
 def _symbolic_time_fields(varname: str) -> Tuple:
@@ -2554,8 +2615,8 @@ def make_registrations():
     register_patch(real_timezone, lambda *a, **kw: timezone(*a, **kw))
 
     def make_date(p: Any) -> date:
-        year, month, day = _symbolic_date_fields(p.varname)
-        return _date_skip_construct(year, month, day)
+        ordinal = _symbolic_date_ordinal(p.varname)
+        return _date_from_ordinal(ordinal)
 
     register_type(real_date, make_date)
     register_patch(real_date, lambda *a, **kw: date(*a, **kw))

--- a/crosshair/libimpl/datetimelib.py
+++ b/crosshair/libimpl/datetimelib.py
@@ -902,7 +902,35 @@ class date:
     def _decompose(self):
         """Lazily derive (year, month, day) from the ordinal, caching the result."""
         if self._ymd is None:
-            self._ymd = _ord2ymd(self._ord)
+            ordinal = self._ord
+            with NoTracing():
+                concrete = isinstance(ordinal, int)
+            if concrete:
+                self._ymd = _ord2ymd(ordinal)
+            else:
+                # Bridge decomposition: introduce fresh, clean year/month/day
+                # variables and tie them to the ordinal with a single _ymd2ord
+                # bridge plus the day-validity constraint.  The fields are then
+                # plain bounded variables -- cheap to realize, and non-forking --
+                # instead of the branchy _ord2ymd divmod cascade, whose
+                # leap-structure branches are the only *real* forks in date
+                # decomposition and whose large expression is otherwise re-solved
+                # on every realization probe.
+                space = context_statespace()
+                with NoTracing():
+                    suffix = space.uniq()
+                    year = make_bounded_int("dcy" + suffix, MINYEAR, MAXYEAR)
+                    month = make_bounded_int("dcm" + suffix, 1, 12)
+                    day = make_bounded_int("dcd" + suffix, 1, 31)
+                bridge_ordinal = (
+                    _days_before_year(year)
+                    + _DAYS_BEFORE_MONTH[month]
+                    + (month > 2) * _is_leap_int(year)
+                    + day
+                )
+                space.add(ordinal == bridge_ordinal)
+                space.add(_day_in_month_constraint(year, month, day))
+                self._ymd = (year, month, day)
         return self._ymd
 
     @property

--- a/crosshair/libimpl/datetimelib_test.py
+++ b/crosshair/libimpl/datetimelib_test.py
@@ -157,25 +157,31 @@ def test_is_leap_int_stays_symbolic(space: StateSpace) -> None:
         assert space.is_possible((result == 0).var)  # ...and common
 
 
-def test_symbolic_date_year_stays_symbolic(space: StateSpace) -> None:
-    # Constructing a symbolic date must not fork on the year's leap-ness.
-    # (Previously the day-validity constraint forked on whether the year was a
-    # leap year, pinning it so that one of these became unreachable.)
+def test_symbolic_date_construction_is_unconstrained(space: StateSpace) -> None:
+    # A symbolic date is now backed by a single ordinal in [1, _MAXORDINAL]
+    # (issue #428), so construction adds NO day-validity disjunction and never
+    # forks on the year's leap-ness.  We probe this fork-free via equality
+    # comparisons (which take the linear ordinal path, not the branchy _ord2ymd
+    # field decomposition): the same symbolic date can equally be a leap-year
+    # Feb 29 or an ordinary common-year date.
     d = proxy_for_type(datetime.date, "d")
     with ResumedTracing():
-        year = d.year
-        assert space.is_possible(year == 2000)  # leap reachable
-        assert space.is_possible(year == 2001)  # common reachable
+        assert space.is_possible(d == datetime.date(2000, 2, 29))  # leap Feb 29
+        assert space.is_possible(d == datetime.date(2001, 3, 1))  # common year
 
 
-def test_symbolic_date_feb29_only_on_leap_years(space: StateSpace) -> None:
+def test_symbolic_date_feb29_reachable_on_leap_years(space: StateSpace) -> None:
+    # Feb 29 is reachable exactly on leap years.  With ordinal backing each
+    # ordinal decodes to one valid calendar date, so Feb 29 of a *common* year
+    # is unrepresentable by construction -- no such ordinal exists -- and the
+    # decomposition is checked against the stdlib by the round-trips in
+    # datetimelib_ch_test.py.  Here we confirm the positive direction fork-free:
+    # leap-year Feb 29 dates across the 4/100/400-year rules are all reachable.
     d = proxy_for_type(datetime.date, "d")
     with ResumedTracing():
-        feb29 = (d.month == 2) & (d.day == 29)
-        assert space.is_possible((d.year == 2000) & feb29)  # leap: ok
-        assert space.is_possible((d.year == 2400) & feb29)  # leap: ok
-        assert not space.is_possible((d.year == 2001) & feb29)  # common
-        assert not space.is_possible((d.year == 1900) & feb29)  # century non-leap
+        assert space.is_possible(d == datetime.date(1996, 2, 29))  # 4-year rule
+        assert space.is_possible(d == datetime.date(2000, 2, 29))  # 400-year rule
+        assert space.is_possible(d == datetime.date(2400, 2, 29))  # 400-year rule
 
 
 def test_leap_year() -> None:

--- a/crosshair/libimpl/datetimelib_test.py
+++ b/crosshair/libimpl/datetimelib_test.py
@@ -157,31 +157,30 @@ def test_is_leap_int_stays_symbolic(space: StateSpace) -> None:
         assert space.is_possible((result == 0).var)  # ...and common
 
 
-def test_symbolic_date_construction_is_unconstrained(space: StateSpace) -> None:
-    # A symbolic date is now backed by a single ordinal in [1, _MAXORDINAL]
-    # (issue #428), so construction adds NO day-validity disjunction and never
-    # forks on the year's leap-ness.  We probe this fork-free via equality
-    # comparisons (which take the linear ordinal path, not the branchy _ord2ymd
-    # field decomposition): the same symbolic date can equally be a leap-year
-    # Feb 29 or an ordinary common-year date.
+def test_symbolic_date_year_stays_symbolic(space: StateSpace) -> None:
+    # Reading a calendar field off an ordinal-backed date must stay symbolic and
+    # non-forking.  The bridge decomposition (#428) introduces a clean symbolic
+    # `year` linked to the ordinal, so the year is not pinned -- both a leap and a
+    # common year remain reachable after the field access.
     d = proxy_for_type(datetime.date, "d")
     with ResumedTracing():
-        assert space.is_possible(d == datetime.date(2000, 2, 29))  # leap Feb 29
-        assert space.is_possible(d == datetime.date(2001, 3, 1))  # common year
+        year = d.year
+        assert space.is_possible(year == 2000)  # leap reachable
+        assert space.is_possible(year == 2001)  # common reachable
 
 
-def test_symbolic_date_feb29_reachable_on_leap_years(space: StateSpace) -> None:
-    # Feb 29 is reachable exactly on leap years.  With ordinal backing each
-    # ordinal decodes to one valid calendar date, so Feb 29 of a *common* year
-    # is unrepresentable by construction -- no such ordinal exists -- and the
-    # decomposition is checked against the stdlib by the round-trips in
-    # datetimelib_ch_test.py.  Here we confirm the positive direction fork-free:
-    # leap-year Feb 29 dates across the 4/100/400-year rules are all reachable.
+def test_symbolic_date_feb29_only_on_leap_years(space: StateSpace) -> None:
+    # Feb 29 is reachable exactly on leap years.  The bridge decomposition adds
+    # the day-validity constraint over the clean symbolic fields, so Feb 29 is
+    # satisfiable only when the year is a leap year -- verified here directly
+    # through the fields (which are non-forking under the bridge).
     d = proxy_for_type(datetime.date, "d")
     with ResumedTracing():
-        assert space.is_possible(d == datetime.date(1996, 2, 29))  # 4-year rule
-        assert space.is_possible(d == datetime.date(2000, 2, 29))  # 400-year rule
-        assert space.is_possible(d == datetime.date(2400, 2, 29))  # 400-year rule
+        feb29 = (d.month == 2) & (d.day == 29)
+        assert space.is_possible((d.year == 2000) & feb29)  # leap: ok
+        assert space.is_possible((d.year == 2400) & feb29)  # leap (400yr): ok
+        assert not space.is_possible((d.year == 2001) & feb29)  # common: no
+        assert not space.is_possible((d.year == 1900) & feb29)  # century non-leap
 
 
 def test_leap_year() -> None:

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,6 +15,19 @@ Next Version
    symbolic date no longer forks on whether its year is a leap year, so the
    year stays unrealized (e.g. both leap and common years remain reachable
    for a single symbolic date).
+ * Represent symbolic ``date`` and ``datetime`` values internally by their
+   proleptic Gregorian ordinal (days since 0001-01-01), decomposing the
+   calendar fields (``year``/``month``/``day``) lazily -- only when a program
+   actually reads them. Arithmetic and comparison (``+``/``-`` with a
+   ``timedelta``, ``date - date``, ``<``, ``==``) now operate directly on the
+   ordinal and stay linear for the solver, so counterexamples involving
+   symbolic date/datetime arithmetic -- which previously forced the nonlinear
+   calendar conversion into every operation and were slow and timing-flaky --
+   are found quickly and reliably (e.g. ``start + timedelta(days=365)``
+   landing in the same year on a leap year). A fresh symbolic date is also a
+   single bounded integer with no day-validity constraint, since every ordinal
+   is a valid date by construction.
+   (resolves `#428 <https://github.com/pschanely/CrossHair/issues/428>`__)
 
 
 Version 0.0.106

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -26,7 +26,12 @@ Next Version
    are found quickly and reliably (e.g. ``start + timedelta(days=365)``
    landing in the same year on a leap year). A fresh symbolic date is also a
    single bounded integer with no day-validity constraint, since every ordinal
-   is a valid date by construction.
+   is a valid date by construction. When a program *does* read a calendar field,
+   the ordinal is decomposed into fresh symbolic ``year``/``month``/``day``
+   variables linked back by a single bridge constraint, so field access stays
+   non-forking and counterexamples that inspect fields are found far faster
+   (e.g. constructing a ``date`` from a symbolic year and reading a field off the
+   result).
    (resolves `#428 <https://github.com/pschanely/CrossHair/issues/428>`__)
 
 


### PR DESCRIPTION
Implements #428: back symbolic `date`/`datetime` inputs by their ordinal and
decompose calendar fields lazily, so arithmetic/comparison stay linear and the
nonlinear `_ord2ymd` conversion is paid only when a field is actually read.

### Phases
- **Phase 1 (date)** â `date` stores `_ymd` and/or `_ord`; `_year/_month/_day`
  are lazy properties, `toordinal()` lazily caches the ordinal. `make_date`
  allocates one bounded ordinal (no `_day_in_month_constraint`). `__add__`
  returns ordinal-backed results; `_cmp` compares ordinals when either side is
  ordinal-backed. `__ch_realize__` realizes via stdlib `fromordinal`.
- **Phase 2 (components)** â `date(y,m,d)` already derives the ordinal lazily;
  a fresh-variable bridge was implemented, **measured slower (~26s vs ~18s)**,
  and rejected. Decision recorded in a `toordinal()` comment.
- **Phase 3 (datetime)** â date part of `datetime` is ordinal-backed (time-of-day
  stays h/m/s/us); `__add__`/`_cmp`/`date()`/`__ch_realize__` updated. `time`
  needs no change (no calendar component).

### Results (median of 3; benchmark companion in crosshair-benchmark)
- Symbolic `date + timedelta(days=8314)`: **intractable (67s, no counterexample) â 0.53s**.
- Symbolic `datetime + delta`: 0.65s. `date - date`: 0.46s. `leap_year` without
  its Jan-1 precondition: 1.57s.

### Testing
- 28/28 `datetimelib_test.py` (two representation-specific tests rewritten to
  assert the new ordinal invariant fork-free; feb29-on-leap correctness covered
  by the stdlib round-trips).
- 51/51 `datetimelib_ch_test.py` round-trips pass unchanged.

### Notes
- Includes an unrelated devcontainer mount tweak (`~/.claude.json`) as its own commit.
