### PR TITLE
Fix misnumbered list in --per_path_timeout help text

### DIFF
--- a/crosshair/main.py
+++ b/crosshair/main.py
@@ -395,11 +395,11 @@ def command_line_parser() -> argparse.ArgumentParser:
             If unspecified:
             1. CrossHair will timeout each path at the square root of
                `--per_condition_timeout`, if specified.
-            3. Otherwise, it will timeout each path at a number of seconds
+            2. Otherwise, it will timeout each path at a number of seconds
                equal to `--max_uninteresting_iterations`, unless it is
                explicitly set to zero.
                (NOTE: `--max_uninteresting_iterations` is 5 by default)
-            2. Otherwise, it will not use any per-path timeout.
+            3. Otherwise, it will not use any per-path timeout.
 """
             ),
         )

--- a/doc/source/contracts.rst
+++ b/doc/source/contracts.rst
@@ -197,11 +197,11 @@ It is more customizable than ``watch`` and produces machine-readable output.
                             If unspecified:
                             1. CrossHair will timeout each path at the square root of
                                `--per_condition_timeout`, if specified.
-                            3. Otherwise, it will timeout each path at a number of seconds
+                            2. Otherwise, it will timeout each path at a number of seconds
                                equal to `--max_uninteresting_iterations`, unless it is
                                explicitly set to zero.
                                (NOTE: `--max_uninteresting_iterations` is 5 by default)
-                            2. Otherwise, it will not use any per-path timeout.
+                            3. Otherwise, it will not use any per-path timeout.
       --per_condition_timeout FLOAT
                             Maximum CPU seconds to spend checking execution paths for one condition (process CPU time, not wall-clock)
       --analysis_kind KIND  Kind of contract to check.

--- a/doc/source/cover.rst
+++ b/doc/source/cover.rst
@@ -132,11 +132,11 @@ How do I try it?
                             If unspecified:
                             1. CrossHair will timeout each path at the square root of
                                `--per_condition_timeout`, if specified.
-                            3. Otherwise, it will timeout each path at a number of seconds
+                            2. Otherwise, it will timeout each path at a number of seconds
                                equal to `--max_uninteresting_iterations`, unless it is
                                explicitly set to zero.
                                (NOTE: `--max_uninteresting_iterations` is 5 by default)
-                            2. Otherwise, it will not use any per-path timeout.
+                            3. Otherwise, it will not use any per-path timeout.
       --per_condition_timeout FLOAT
                             Maximum CPU seconds to spend checking execution paths for one condition (process CPU time, not wall-clock)
 

--- a/doc/source/diff_behavior.rst
+++ b/doc/source/diff_behavior.rst
@@ -94,11 +94,11 @@ How do I try it?
                             If unspecified:
                             1. CrossHair will timeout each path at the square root of
                                `--per_condition_timeout`, if specified.
-                            3. Otherwise, it will timeout each path at a number of seconds
+                            2. Otherwise, it will timeout each path at a number of seconds
                                equal to `--max_uninteresting_iterations`, unless it is
                                explicitly set to zero.
                                (NOTE: `--max_uninteresting_iterations` is 5 by default)
-                            2. Otherwise, it will not use any per-path timeout.
+                            3. Otherwise, it will not use any per-path timeout.
       --per_condition_timeout FLOAT
                             Maximum CPU seconds to spend checking execution paths for one condition (process CPU time, not wall-clock)
 


### PR DESCRIPTION
## What

The `--per_path_timeout` fallback list in the CLI help text was numbered **1, 3, 2** instead of **1, 2, 3**. This made the help confusing because item "3" appeared before item "2", suggesting the wrong evaluation order to anyone reading the flag docs.

```
If unspecified:
1. CrossHair will timeout each path at the square root of
   `--per_condition_timeout`, if specified.
3. Otherwise, ...   <-- was 3, should be 2
...
2. Otherwise, it will not use any per-path timeout.  <-- was 2, should be 3
```

## Fix

- Corrected the numbering in `crosshair/main.py` (the source of truth for the help string)
- Updated the three `doc/source/*.rst` files (`contracts.rst`, `cover.rst`, `diff_behavior.rst`) that embed the rendered `--help` output, so they stay in sync

## Verification

Ran `python -m crosshair check --help` locally after the fix and confirmed the list now reads 1, 2, 3 in the expected order.