### PR TITLE
Support the base64 module's new Python 3.15 binascii keyword arguments

### DIFF
--- a/crosshair/libimpl/base64_ch_test.py
+++ b/crosshair/libimpl/base64_ch_test.py
@@ -1,0 +1,61 @@
+import base64
+import sys
+
+import pytest
+
+from crosshair.behavior_compare import compare_results
+from crosshair.core import analyze_function, run_checkables
+from crosshair.statespace import MessageType
+
+# The base64 module is powered entirely by the binascii patches.  These checks
+# exercise it at the module level (the binascii tests only call the functions
+# directly), which is the coverage gap that let the 3.15 keyword-argument
+# regression slip past.
+
+
+def check_b64encode(byts: bytes):
+    """post: _"""
+    return compare_results(base64.b64encode, byts)
+
+
+def check_b64encode_altchars(byts: bytes):
+    """post: _"""
+    return compare_results(lambda b: base64.b64encode(b, altchars=b"-_"), byts)
+
+
+def check_b64decode(byts: bytes):
+    """post: _"""
+    return compare_results(base64.b64decode, byts)
+
+
+def check_b64_roundtrip(byts: bytes):
+    """post: _"""
+    return compare_results(lambda b: base64.b64decode(base64.b64encode(b)), byts)
+
+
+def check_urlsafe_b64encode(byts: bytes):
+    """post: _"""
+    return compare_results(base64.urlsafe_b64encode, byts)
+
+
+def check_urlsafe_roundtrip(byts: bytes):
+    """post: _"""
+    return compare_results(
+        lambda b: base64.urlsafe_b64decode(base64.urlsafe_b64encode(b)), byts
+    )
+
+
+def check_encodebytes(byts: bytes):
+    """post: _"""
+    return compare_results(base64.encodebytes, byts)
+
+
+# This is the only real test definition.
+# It runs crosshair on each of the "check" functions defined above.
+@pytest.mark.parametrize("fn_name", [fn for fn in dir() if fn.startswith("check_")])
+def test_builtin(fn_name: str) -> None:
+    this_module = sys.modules[__name__]
+    fn = getattr(this_module, fn_name)
+    messages = run_checkables(analyze_function(fn))
+    errors = [m for m in messages if m.state > MessageType.PRE_UNSAT]
+    assert errors == [], [(m.state, m.message) for m in errors]

--- a/crosshair/libimpl/binascii_ch_test.py
+++ b/crosshair/libimpl/binascii_ch_test.py
@@ -19,6 +19,24 @@ def check_a2b_base64(byts: bytes, strict_mode: bool):
     return compare_results(binascii.a2b_base64, byts, **kw)
 
 
+def check_a2b_base64_unpadded(byts: bytes):
+    """post: _"""
+    # 3.15 added ``padded``; older versions always require padding.
+    kw = {"padded": False} if sys.version_info >= (3, 15) else {}
+    return compare_results(binascii.a2b_base64, byts, **kw)
+
+
+def check_a2b_base64_alphabet(byts: bytes):
+    """post: _"""
+    # 3.15 added a custom decode ``alphabet``; fall back to the standard one on
+    # older versions so the check stays meaningful everywhere.
+    if sys.version_info >= (3, 15):
+        return compare_results(
+            binascii.a2b_base64, byts, alphabet=binascii.URLSAFE_BASE64_ALPHABET
+        )
+    return compare_results(binascii.a2b_base64, byts)
+
+
 # This is the only real test definition.
 # It runs crosshair on each of the "check" functions defined above.
 @pytest.mark.parametrize("fn_name", [fn for fn in dir() if fn.startswith("check_")])

--- a/crosshair/libimpl/binasciilib.py
+++ b/crosshair/libimpl/binasciilib.py
@@ -1,9 +1,9 @@
 import binascii
-from functools import partial
 from typing import Dict, Iterable, Tuple, Union
 
-from crosshair.core import register_patch
+from crosshair.core import deep_realize, register_patch
 from crosshair.libimpl.builtinslib import _ALL_BYTES_TYPES, SymbolicBytes
+from crosshair.tracers import NoTracing
 from crosshair.util import name_of_type
 
 _ORD_OF_NEWLINE = ord("\n")
@@ -85,14 +85,6 @@ _DECODE_BASE64_MAP = {
 }
 _ENCODE_BASE64_MAP = _reverse_map(_DECODE_BASE64_MAP)
 
-_DECODE_MAPPER_BASE64 = partial(_remap, _DECODE_BASE64_MAP)
-_DECODE_MAPPER_BASE64_STRICT = partial(
-    _remap,
-    _DECODE_BASE64_MAP,
-    error_type=binascii.Error,
-    error_message="Only base64 data is allowed",
-)
-
 
 def make_bytes(arg: object) -> Union[bytes, bytearray, memoryview]:
     if isinstance(arg, (bytes, bytearray, memoryview)):
@@ -163,24 +155,58 @@ def _b2a_base64(
     return SymbolicBytes(output_ints)
 
 
-def _a2b_base64(data, /, *, strict_mode: bool = False):
+def _a2b_base64(
+    data,
+    /,
+    *,
+    strict_mode: bool = False,
+    padded: bool = True,
+    alphabet=_STD_BASE64_ALPHABET,
+    ignorechars=b"",
+    canonical: bool = False,
+):  # decode
+    # 3.15+ forwards padded/alphabet/ignorechars/canonical through the base64
+    # module; older Pythons never pass them, so the extra keywords keep defaults
+    # that reproduce the pre-3.15 behavior exactly.
+    if canonical or ignorechars:
+        # Rare strict-validation paths (RFC 4648 canonical padding bits, and
+        # skip-these-characters filtering).  Defer to the real implementation on
+        # realized data; the common paths below stay fully symbolic.
+        with NoTracing():
+            real_alphabet = bytes(deep_realize(alphabet))
+            kwargs: dict = {"strict_mode": strict_mode, "padded": padded}
+            if real_alphabet != _STD_BASE64_ALPHABET:
+                kwargs["alphabet"] = real_alphabet
+            if ignorechars:
+                kwargs["ignorechars"] = bytes(deep_realize(ignorechars))
+            if canonical:
+                kwargs["canonical"] = True
+            return binascii.a2b_base64(bytes(deep_realize(data)), **kwargs)
     data = make_bytes(data)
-    input_ints, padding_count = (
-        _DECODE_MAPPER_BASE64_STRICT if strict_mode else _DECODE_MAPPER_BASE64
-    )(data)
+    if alphabet is _STD_BASE64_ALPHABET or bytes(alphabet) == _STD_BASE64_ALPHABET:
+        decode_map = _DECODE_BASE64_MAP
+    else:
+        decode_map = _reverse_map(_encode_map_from_alphabet(alphabet))
+    input_ints, padding_count = _remap(
+        decode_map,
+        data,
+        error_type=binascii.Error if strict_mode else None,
+        error_message="Only base64 data is allowed" if strict_mode else None,
+    )
 
     data_char_count = len(input_ints)
     uneven = data_char_count % 4 != 0
     if uneven:
         if data_char_count % 4 == 1:
             raise binascii.Error(
-                f"Invalid base64-encoded string: number of data characters ({len(input_ints)}) cannot be 1 more than a multiple of 4"
+                f"Invalid base64-encoded string: number of data characters ({data_char_count}) cannot be 1 more than a multiple of 4"
             )
-        expected_padding = 4 - (data_char_count % 4)
-        if padding_count < expected_padding:
-            raise binascii.Error("Incorrect padding")
-        elif strict_mode and padding_count > expected_padding:
-            raise binascii.Error("Excess data after padding")
+        if padded:
+            expected_padding = 4 - (data_char_count % 4)
+            if padding_count < expected_padding:
+                raise binascii.Error("Incorrect padding")
+            elif strict_mode and padding_count > expected_padding:
+                raise binascii.Error("Excess data after padding")
     output_ints = [
         byt for byt in _bit_chunk_iter(input_ints, input_bit_size=6, output_bit_size=8)
     ]


### PR DESCRIPTION
## Summary

Python 3.15 expanded the `binascii` base64 signatures and the `base64` module now forwards the new keyword arguments, which CrossHair's patches rejected — so base64 raised `TypeError` under symbolic analysis on 3.15.

The **encode** half (`b2a_base64`: `wrapcol` / `padded` / `alphabet`) landed separately in d2a7711211c161443a914bbc2842200172a680b8. **This PR (rebased onto that work) is now the matching decode half.**

## Changes

- **`binasciilib.py`** — `_a2b_base64` now accepts the four new 3.15 decode keywords that `base64.b64decode` / `urlsafe_b64decode` forward (`padded`, `alphabet`, `ignorechars`, `canonical`). The defaults reproduce pre-3.15 behavior byte-for-byte, so ≤3.14 is unaffected by construction (no version-gating needed).
  - `padded` and custom `alphabet` are implemented **symbolically**, reusing the encode side's `_encode_map_from_alphabet` + `_reverse_map` to build the inverse decode map.
  - `canonical` (RFC 4648 padding-bit validation) and non-empty `ignorechars` are rare strict-validation paths and **defer** to the real implementation on realized data, keeping the common paths fully symbolic.
  - Removes the now-unused `_DECODE_MAPPER_BASE64*` partials.
- **`base64_ch_test.py`** (new) — base64-module-level symbolic checks (`b64encode`/`b64decode` incl. altchars, round-trips, urlsafe, `encodebytes`). This closes the coverage gap that let the regression slip past: the existing `binascii` tests only call the functions directly, never through the `base64` module.
- **`binascii_ch_test.py`** — direct symbolic `a2b_base64` checks for the new `padded` / custom `alphabet` decode keywords.

## Testing

Verified against a local CPython 3.15.0b3 build:
- `base64_ch_test` + `binascii_ch_test` + `binascii_test` = **87 passed**; black/isort clean.
- A concrete/symbolic differential over the new decode keywords (`padded`, custom `alphabet`, `canonical`, `ignorechars`) shows **no mismatches**.
- Also green on 3.13.

Relates to #437 (Python 3.15 support) and #289 (base64/binascii).

🤖 Generated with [Claude Code](https://claude.com/claude-code)