### PR TITLE
Fix Python 3.15 CI failures (differential suite, base64, decimal)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,12 +7,16 @@ FROM mcr.microsoft.com/devcontainers/base:trixie
 # nodejs + npm are here (not left to the claude-code feature) because on trixie
 # the feature installs node without npm, so `npm install -g` fails; providing
 # both up front makes the feature skip its own Node install.
+# libmpdec-dev: Python 3.15 unbundled libmpdec, so the C `_decimal` extension is
+# only built when a system libmpdec (>= 2.5.0) is present; without it, `decimal`
+# silently falls back to the pure-Python `_pydecimal`, which CrossHair targets
+# less completely. Providing it keeps built interpreters using C `_decimal`.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
         build-essential curl git \
         libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
         libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
-        libffi-dev liblzma-dev \
+        libffi-dev liblzma-dev libmpdec-dev \
         nodejs npm \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,7 +49,8 @@
   },
   // Installs Claude Code automatically inside the container
   "features": {
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   // Persists Claude sessions/credentials (host bind) and shell history (named
   // volume, so it survives rebuilds without depending on a host file existing).

--- a/crosshair/behavior_compare.py
+++ b/crosshair/behavior_compare.py
@@ -366,6 +366,7 @@ DIFFERENTIAL_SKIP: Dict[str, str] = {
     # builtins that aren't pure value transforms (identity / code / names / I/O)
     "builtins.id": "identity, not a value",
     "builtins.__import__": "imports a module; not a value transform",
+    "builtins.__lazy_import__": "[3.15+] lazily imports a module; not a value transform",
     "builtins.compile": "compiles source; output isn't value-comparable",
     "builtins.exec": "executes code for side effects",
     "builtins.eval": "evaluates a symbolic code string -- not meaningful",

--- a/crosshair/fuzz_core_test.py
+++ b/crosshair/fuzz_core_test.py
@@ -59,6 +59,7 @@ KNOWN_FAILURES = {
     "bytearray.insert": "symbolic bytearray.insert skips the byte-range check (no ValueError)",
     "bytearray.__setitem__": "symbolic bytearray[i]=v raises IndexError vs concrete ValueError (no byte-range check)",
     "bytearray.resize": "[3.14+] resize() is new in 3.14 and unmodeled on SymbolicByteArray -> AttributeError",
+    "bytearray.take_bytes": "[3.15+] take_bytes() is new in 3.15 and unmodeled on SymbolicByteArray -> AttributeError",
 }
 
 # Ops the differential can't meaningfully check (order-dependent / incomparable /

--- a/crosshair/libimpl/binascii_test.py
+++ b/crosshair/libimpl/binascii_test.py
@@ -65,3 +65,33 @@ def test_base64_encode(space, input_bytes, newline):
             binascii.b2a_base64, (input_bytes,), kw, detach_path=False
         )
     assert concrete_result == symbolic_result
+
+
+# b2a_base64 gained wrapcol/padded/alphabet keywords in 3.15 (base64.b64encode &
+# friends now route through them), so power those paths.
+@pytest.mark.skipif(
+    sys.version_info < (3, 15), reason="wrapcol/padded/alphabet are new in 3.15"
+)
+@pytest.mark.parametrize("wrapcol", [0, 4, 5, 8, 76])
+@pytest.mark.parametrize("padded", [True, False])
+@pytest.mark.parametrize(
+    "alphabet",
+    [
+        None,  # default alphabet
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",  # urlsafe
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@$",  # altchars
+    ],
+)
+def test_base64_encode_315_kwargs(space, wrapcol, padded, alphabet):
+    input_bytes = b"\xc2\xe3k" * 9 + b"\xff"  # spans several wrap lines, uneven tail
+    kw = {"wrapcol": wrapcol, "padded": padded}
+    if alphabet is not None:
+        kw["alphabet"] = alphabet
+    concrete_result = summarize_execution(
+        binascii.b2a_base64, (input_bytes,), kw, detach_path=False
+    )
+    with ResumedTracing():
+        symbolic_result = summarize_execution(
+            binascii.b2a_base64, (input_bytes,), kw, detach_path=False
+        )
+    assert concrete_result == symbolic_result

--- a/crosshair/libimpl/binasciilib.py
+++ b/crosshair/libimpl/binasciilib.py
@@ -9,6 +9,13 @@ from crosshair.util import name_of_type
 _ORD_OF_NEWLINE = ord("\n")
 _ORD_OF_EQUALS = ord("=")
 
+# The standard base64 alphabet (6-bit value -> output character).  Named
+# binascii.BASE64_ALPHABET in 3.15+, but we keep our own copy so the default
+# argument works on older Pythons too.
+_STD_BASE64_ALPHABET = (
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+)
+
 
 def _bit_chunk_iter(
     seq: Iterable[int], input_bit_size: int, output_bit_size: int
@@ -85,7 +92,6 @@ _DECODE_MAPPER_BASE64_STRICT = partial(
     error_type=binascii.Error,
     error_message="Only base64 data is allowed",
 )
-_ENCODE_MAPPER_BASE64 = partial(_remap, _ENCODE_BASE64_MAP)
 
 
 def make_bytes(arg: object) -> Union[bytes, bytearray, memoryview]:
@@ -102,17 +108,56 @@ def make_bytes(arg: object) -> Union[bytes, bytearray, memoryview]:
         )
 
 
-def _b2a_base64(data, /, *, newline=True):  # encode
+def _encode_map_from_alphabet(alphabet) -> Dict[Tuple[int, int], int]:
+    """Build a ``_remap`` table (6-bit value range -> output char code) for a
+    custom base64 ``alphabet``.  Consecutive values whose characters are also
+    consecutive are collapsed into a single range so the mapping stays a small
+    set of arithmetic offsets -- which keeps it symbolic-friendly, exactly like
+    the standard ``_ENCODE_BASE64_MAP``."""
+    alphabet = bytes(alphabet)
+    if len(alphabet) != 64:
+        raise ValueError("alphabet must have length 64")
+    table = {}
+    v = 0
+    while v < 64:
+        start = v
+        while v + 1 < 64 and alphabet[v + 1] == alphabet[start] + (v + 1 - start):
+            v += 1
+        table[(start, v)] = alphabet[start]
+        v += 1
+    return table
+
+
+def _b2a_base64(
+    data, /, *, newline=True, wrapcol=0, padded=True, alphabet=_STD_BASE64_ALPHABET
+):  # encode
     if not isinstance(data, _ALL_BYTES_TYPES):
         raise TypeError(
             f"a bytes-like object is required, not '{name_of_type(type(data))}'"
         )
-    output_ints, _padding_count = _ENCODE_MAPPER_BASE64(
-        _bit_chunk_iter(data, input_bit_size=8, output_bit_size=6)
+    if alphabet is _STD_BASE64_ALPHABET or bytes(alphabet) == _STD_BASE64_ALPHABET:
+        encode_map = _ENCODE_BASE64_MAP
+    else:
+        encode_map = _encode_map_from_alphabet(alphabet)
+    output_ints, _padding_count = _remap(
+        encode_map, _bit_chunk_iter(data, input_bit_size=8, output_bit_size=6)
     )
-    spillover = len(output_ints) % 4
-    if spillover > 0:
-        output_ints.extend([_ORD_OF_EQUALS for _ in range(4 - spillover)])
+    if padded:
+        spillover = len(output_ints) % 4
+        if spillover > 0:
+            output_ints.extend([_ORD_OF_EQUALS for _ in range(4 - spillover)])
+    if wrapcol and output_ints:
+        # 3.15+: insert a newline after every `wrapcol` output characters.
+        # CPython first rounds the width down to a whole number of 4-char groups
+        # (minimum 4) and never emits a trailing wrap-newline; see
+        # Modules/binascii.c:binascii_b2a_base64_impl.
+        width = 4 if wrapcol < 4 else (wrapcol // 4) * 4
+        wrapped = []
+        for idx, ch in enumerate(output_ints):
+            if idx and idx % width == 0:
+                wrapped.append(_ORD_OF_NEWLINE)
+            wrapped.append(ch)
+        output_ints = wrapped
     if newline:
         output_ints.append(_ORD_OF_NEWLINE)
     return SymbolicBytes(output_ints)

--- a/crosshair/libimpl/decimallib.py
+++ b/crosshair/libimpl/decimallib.py
@@ -5246,6 +5246,24 @@ def make_function_with_mapped_args(fn):
 
 
 def make_registrations():
+    import _pydecimal
+
+    # Our Decimal shim reimplements _pydecimal in a symbolic-friendly way, but is
+    # written and validated against the C `_decimal` extension.  When the
+    # interpreter instead falls back to the pure-Python `_pydecimal` (builds
+    # without a system libmpdec -- e.g. Python 3.15, which unbundled it), the
+    # shim's *concrete* behavior no longer matches the `decimal` actually
+    # running: e.g. our constructor validates its context argument eagerly, like
+    # C `_decimal`, whereas `_pydecimal` does not.  Reasoning about a program
+    # with a model that disagrees with its real runtime is unsound, so we
+    # register nothing.  `decimal` then runs unpatched: concrete Decimal values
+    # behave exactly like the real module, and a *symbolic* Decimal argument
+    # degrades to CrosshairUnsupported (we can't build a symbolic proxy without
+    # the registration), so that path is skipped rather than mismodeled.
+    if real_decimal.Decimal is _pydecimal.Decimal:
+        debug("Pure-Python _pydecimal is active; not modeling decimal (see comment)")
+        return
+
     # "DecimalTuple",  # do I want this?
     register_patch(real_decimal.Decimal, lambda *a, **kw: Decimal(*a, **kw))
     register_type(real_decimal.Decimal, _make_decimal)

--- a/crosshair/libimpl/decimallib_ch_test.py
+++ b/crosshair/libimpl/decimallib_ch_test.py
@@ -3,6 +3,7 @@ import sys
 from decimal import BasicContext, Decimal, ExtendedContext, localcontext
 from typing import Union
 
+import _pydecimal
 import pytest  # type: ignore
 
 from crosshair.behavior_compare import (
@@ -11,6 +12,15 @@ from crosshair.behavior_compare import (
     compare_returns,
 )
 from crosshair.core_and_libs import MessageType, analyze_function, run_checkables
+
+# CrossHair models decimal only against the C `_decimal` extension.  On builds
+# where `decimal` falls back to the pure-Python `_pydecimal` (no system
+# libmpdec -- e.g. Python 3.15 unbundled it), CrossHair leaves decimal
+# unpatched, so its symbolic support isn't present to test.
+pytestmark = pytest.mark.skipif(
+    Decimal is _pydecimal.Decimal,
+    reason="decimal is unmodeled when the pure-Python _pydecimal is active",
+)
 
 
 def _binary_op_under_context(ctx, op):

--- a/crosshair/libimpl/decimallib_test.py
+++ b/crosshair/libimpl/decimallib_test.py
@@ -6,12 +6,22 @@ from decimal import (
     localcontext,
 )
 
+import _pydecimal
 import pytest
 
 from crosshair.core import proxy_for_type, standalone_statespace
 from crosshair.libimpl.decimallib import Decimal as PyDecimal
 from crosshair.tracers import NoTracing
 from crosshair.util import debug
+
+# CrossHair models decimal only against the C `_decimal` extension.  On builds
+# where `decimal` falls back to the pure-Python `_pydecimal` (no system
+# libmpdec -- e.g. Python 3.15 unbundled it), CrossHair leaves decimal
+# unpatched, so its symbolic support isn't present to test.
+pytestmark = pytest.mark.skipif(
+    Decimal is _pydecimal.Decimal,
+    reason="decimal is unmodeled when the pure-Python _pydecimal is active",
+)
 
 
 def test_mixed_decimal_addition() -> None:

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -16,6 +16,12 @@ Next Version
  * Begin Python 3.15 support, including ``struct``, ``re``, ``copy``,
    ``base64``, and ``unicodedata`` behavior changes in the standard library.
    (towards `#437 <https://github.com/pschanely/CrossHair/issues/437>`__)
+ * Skip modeling ``decimal`` when the C ``_decimal`` extension is unavailable and
+   the interpreter falls back to the pure-Python ``_pydecimal`` (e.g. Python
+   3.15, which unbundled libmpdec, built without a system copy). CrossHair's
+   ``Decimal`` shim mirrors the C extension, so modeling it against a different
+   runtime could be unsound; concrete decimal code is unaffected, but symbolic
+   ``Decimal`` arguments are unsupported on such builds.
  * Fix lexicographic ordering comparisons (``<``, ``<=``, ``>``, ``>=``) for
    symbolic lists and tuples. Symbolic lists previously raised a spurious
    ``TypeError`` for ``<=``/``>``/``>=`` (only ``<`` worked), because the

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -13,8 +13,8 @@ Next Version
    tuple-of-prefixes form) is now realized before being handed to the underlying
    comparison. On Python 3.12+ the buffer protocol masked the issue, so only
    earlier versions were affected.
- * Begin Python 3.15 support, including ``struct``, ``re``, ``copy``, and
-   ``unicodedata`` behavior changes in the standard library.
+ * Begin Python 3.15 support, including ``struct``, ``re``, ``copy``,
+   ``base64``, and ``unicodedata`` behavior changes in the standard library.
    (towards `#437 <https://github.com/pschanely/CrossHair/issues/437>`__)
  * Fix lexicographic ordering comparisons (``<``, ``<=``, ``>``, ``>=``) for
    symbolic lists and tuples. Symbolic lists previously raised a spurious


### PR DESCRIPTION
Follow-up to #434, addressing the 10 failures surfaced by the 3.15-dev CI job. All 10 are resolved; verified on a local 3.15.0b3 build (both with and without the C `_decimal` extension).

## Commits

- **Classify two new-in-3.15 builtins** — `bytearray.take_bytes` (xfail, like the 3.14 `bytearray.resize` gap) and `builtins.__lazy_import__` (differential-skip, like `__import__`). The differential fuzzer enumerates every builtin/method, so both newcomers started failing.

- **Support 3.15's new `binascii.b2a_base64` keyword arguments** — 3.15 gave `b2a_base64` `wrapcol`/`padded`/`alphabet` and rerouted `base64.encodebytes`/`b64encode`/`urlsafe_b64encode` through them, so every base64 *encode* path raised `TypeError: unexpected keyword argument 'wrapcol'`. The patch now implements all three (the `wrapcol` newline algorithm and `alphabet` remap were checked exhaustively against the real interpreter), keeping the mapping symbolic-friendly.

- **`devcontainer`: install `libmpdec-dev`** — Python 3.15 unbundled libmpdec, so the C `_decimal` extension only builds against a system copy. Without it, `decimal` silently falls back to pure-Python `_pydecimal`. Installing the dev package keeps built interpreters on C `_decimal`, matching properly-provisioned CPython.

- **Don't model `decimal` when the pure-Python `_pydecimal` is active** — CrossHair's `Decimal` shim mirrors the C `_decimal` extension, so on libmpdec-less builds it diverged from the runtime actually in use (strict-vs-lenient constructor validation, `int()` on a symbolic coefficient). Rather than model it unsoundly, `make_registrations` now registers no decimal patches in that case: concrete decimal code still runs, symbolic `Decimal` args become unsupported. This also drops the `patch_equivalence[Decimal-*]` params (they iterate `_PATCH_REGISTRATIONS`) and skips the two decimal test modules on such builds.

- **`devcontainer`: add the GitHub CLI feature** — installs `gh` in the container (unrelated to 3.15, bundled here for convenience).

## Verification

- **C `_decimal` present** (3.13, and a 3.15.0b3 rebuilt with `libmpdec-dev`): full decimal support runs and passes; no regressions.
- **`_decimal` absent** (CI's 3.15): decimal patches drop, `patch_equivalence` collects 0 Decimal params, decimal test modules skip; base64 and builtin classifications hold.

Note: CI's 3.15 job is `continue-on-error`, and its hosted-toolcache interpreter currently lacks `_decimal`, so the decline-to-model path is what keeps it green there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9V78EaWcUtDKJF7Z6MNN4