### PR TITLE
Bump dev tooling (black 26, isort 8, mypy 2, pytest 9); drop 3.8/3.9 from testing

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -38,8 +38,9 @@ jobs:
           # Skip tests:
           # * linuxes don't have corresponding z3 binary builds
           # * 3.13+ in win32, which has a numpy build error rn
-          # * 3.8 which can't run our current version of mypy
-          CIBW_TEST_SKIP: "*-*linux_{i686,aarch64,ppc64le,s390x} *-musllinux* cp3{13,14}-win* cp38*"
+          # * 3.8/3.9 can't install the [dev] extra (our dev tooling requires
+          #   >=3.10); we still build+ship these wheels, just don't test them.
+          CIBW_TEST_SKIP: "*-*linux_{i686,aarch64,ppc64le,s390x} *-musllinux* cp3{13,14}-win* cp38* cp39*"
         uses: pypa/cibuildwheel@v3.2.0
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/test_crosshair.yml
+++ b/.github/workflows/test_crosshair.yml
@@ -24,8 +24,9 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         python-version: [
-          # "3.8",  (our current version of mypy doesn't support 3.8)
-          "3.9",
+          # 3.8 and 3.9 aren't tested: our dev tooling (black, isort, mypy,
+          # pytest) requires >=3.10 so the [dev] extra won't install. The
+          # runtime package still supports them (see wheels + classifiers).
           "3.10",
           "3.11",
           "3.12",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/python/black
-    rev: 25.9.0  # synchronize this version number with pyproject.toml
+    rev: 26.5.1  # synchronize this version number with pyproject.toml
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
@@ -19,11 +19,11 @@ repos:
           - "--show-source"
           - "--statistics"
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.5  # synchronize this version number with pyproject.toml
+    rev: 8.0.1  # synchronize this version number with pyproject.toml
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.1  # synchronize this version number with pyproject.toml
+    rev: v2.1.0  # synchronize this version number with pyproject.toml
     hooks:
       - id: mypy
   - repo: local

--- a/crosshair/auditwall.py
+++ b/crosshair/auditwall.py
@@ -59,7 +59,7 @@ def inside_module(modules: Iterable[ModuleType]) -> bool:
 
 
 def check_open(event: str, args: Tuple) -> None:
-    (filename_or_descriptor, mode, flags) = args
+    filename_or_descriptor, mode, flags = args
     if filename_or_descriptor in ("/dev/null", "nul"):
         # (no-op writes on unix/windows)
         return
@@ -72,7 +72,7 @@ def check_open(event: str, args: Tuple) -> None:
 
 def check_msvcrt_open(event: str, args: Tuple) -> None:
     print(args)
-    (handle, flags) = args
+    handle, flags = args
     if flags & _BLOCKED_OPEN_FLAGS:
         raise SideEffectDetected(
             f'We\'ve blocked a file writing operation on "{handle}". '

--- a/crosshair/codeconfig_test.py
+++ b/crosshair/codeconfig_test.py
@@ -105,12 +105,10 @@ def test_collection_options() -> None:
 
 DIRECTIVES_TREE = {
     "pkg1": {
-        "__init__.py": textwrap.dedent(
-            """\
+        "__init__.py": textwrap.dedent("""\
             # crosshair: off
             # crosshair: per_condition_timeout=42
-            """
-        ),
+            """),
         "pkg2": {
             "pkg3": {
                 "__init__.py": "# crosshair: max_iterations=5",

--- a/crosshair/condition_parser.py
+++ b/crosshair/condition_parser.py
@@ -100,7 +100,7 @@ def strip_comment_line(line: str) -> str:
 
 
 def get_doc_lines(thing: object) -> Iterable[Tuple[int, str]]:
-    _filename, line_num, lines = sourcelines(thing)  # type:ignore
+    _filename, line_num, lines = sourcelines(thing)  # type: ignore
     if not lines:
         return
     try:
@@ -128,11 +128,11 @@ def get_doc_lines(thing: object) -> Iterable[Tuple[int, str]]:
     started = False
     for idx, line in candidates:
         if not started:
-            (line, replaced) = OPEN_RE.subn("", line)
+            line, replaced = OPEN_RE.subn("", line)
             if replaced:
                 started = True
         if started:
-            (line, replaced) = CLOSE_RE.subn("", line)
+            line, replaced = CLOSE_RE.subn("", line)
             yield (line_num + idx, line)
             if replaced:
                 return
@@ -657,7 +657,7 @@ class Pep316Parser(ConcreteConditionParser):
         fn_and_sig = ctxfn.get_callable()
         if fn_and_sig is None:
             return None
-        (fn, sig) = fn_and_sig
+        fn, sig = fn_and_sig
         filename, first_fn_lineno, _lines = sourcelines(fn)
         if isinstance(fn, types.BuiltinFunctionType):
             return Conditions(fn, fn, [], [], frozenset(), sig, frozenset(), [])
@@ -743,7 +743,7 @@ class IcontractParser(ConcreteConditionParser):
         fn_and_sig = ctxfn.get_callable()
         if fn_and_sig is None:
             return None
-        (fn, sig) = fn_and_sig
+        fn, sig = fn_and_sig
 
         checker = icontract._checkers.find_checker(func=fn)  # type: ignore
         contractless_fn = fn  # type: ignore
@@ -947,7 +947,7 @@ class DealParser(ConcreteConditionParser):
         fn_and_sig = ctxfn.get_callable()
         if fn_and_sig is None:
             return None
-        (fn, sig) = fn_and_sig
+        fn, sig = fn_and_sig
 
         contracts = list(deal.introspection.get_contracts(fn))
         if not contracts:
@@ -1054,7 +1054,7 @@ class AssertsParser(ConcreteConditionParser):
         fn_and_sig = ctxfn.get_callable()
         if fn_and_sig is None:
             return None
-        (fn, sig) = fn_and_sig
+        fn, sig = fn_and_sig
         # TODO replace this guard with package-level configuration?
         if (
             getattr(fn, "__module__", False)
@@ -1117,7 +1117,7 @@ class RegisteredContractsParser(ConcreteConditionParser):
     def get_fn_conditions(self, ctxfn: FunctionInfo) -> Optional[Conditions]:
         fn_and_sig = ctxfn.get_callable()
         if fn_and_sig is not None:
-            (fn, sig) = fn_and_sig
+            fn, sig = fn_and_sig
             sigs = [sig]
             contract = get_contract(fn)
             if not contract:

--- a/crosshair/core.py
+++ b/crosshair/core.py
@@ -727,7 +727,7 @@ def proxy_for_type(
 
         # special cases
         if isinstance(typ, type) and issubclass(typ, enum.Enum):
-            enum_values = list(typ)  # type:ignore
+            enum_values = list(typ)  # type: ignore
             if not enum_values:
                 raise IgnoreAttempt("No values for enum")
             for enum_value in enum_values[:-1]:
@@ -1418,9 +1418,13 @@ def explore_paths(
             model_check_timeout=per_path_timeout / 2,
             search_root=search_root,
         )
-        with condition_parser(
-            options.analysis_kind
-        ), Patched(), COMPOSITE_TRACER, NoTracing(), StateSpaceContext(space):
+        with (
+            condition_parser(options.analysis_kind),
+            Patched(),
+            COMPOSITE_TRACER,
+            NoTracing(),
+            StateSpaceContext(space),
+        ):
             try:
                 pre_args = gen_args(sig)
                 args = deepcopyext(pre_args, CopyMode.REGULAR, {})
@@ -1526,7 +1530,7 @@ def attempt_call(
             debug("Ignored exception in precondition.", efilter.analysis)
             return efilter.analysis
         elif efilter.user_exc is not None:
-            (user_exc, tb) = efilter.user_exc
+            user_exc, tb = efilter.user_exc
             formatted_tb = tb.format()
             debug(
                 "Exception attempting to meet precondition",
@@ -1558,7 +1562,7 @@ def attempt_call(
         debug("Ignored exception in function.", efilter.analysis)
         return efilter.analysis
     elif efilter.user_exc is not None:
-        (e, tb) = efilter.user_exc
+        e, tb = efilter.user_exc
         detail = name_of_type(type(e)) + ": " + str(e)
         tb_desc = tb.format()
         frame_filename, frame_lineno = frame_summary_for_fn(conditions.src_fn, tb)
@@ -1612,7 +1616,7 @@ def attempt_call(
         debug("Ignored exception in postcondition.", efilter.analysis)
         return efilter.analysis
     elif efilter.user_exc is not None:
-        (e, tb) = efilter.user_exc
+        e, tb = efilter.user_exc
         detail = name_of_type(type(e)) + ": " + str(e)
         with ResumedTracing():
             space.detach_path(e)

--- a/crosshair/core_test.py
+++ b/crosshair/core_test.py
@@ -659,7 +659,7 @@ def test_does_not_report_with_actual_repr():
         """post: False"""
         return foo.size()
 
-    (actual, expected) = check_messages(
+    actual, expected = check_messages(
         analyze_function(f),
         state=MessageType.POST_FAIL,
         message="false when calling f(BiggerCat()) " "(which returns 2)",
@@ -883,7 +883,7 @@ def test_specs_complete():
         """post: _"""
         return get_natural_number()
 
-    (actual, expected) = check_messages(
+    actual, expected = check_messages(
         analyze_function(f),
         state=MessageType.POST_FAIL,
         message="false when calling f() "

--- a/crosshair/diff_behavior.py
+++ b/crosshair/diff_behavior.py
@@ -138,9 +138,12 @@ def diff_behavior(
     debug("Resolved signature:", sig1)
     all_diffs: List[BehaviorDiff] = []
     half1, half2 = options.split_limits(0.5)
-    with condition_parser(
-        options.analysis_kind
-    ), Patched(), COMPOSITE_TRACER, NoTracing():
+    with (
+        condition_parser(options.analysis_kind),
+        Patched(),
+        COMPOSITE_TRACER,
+        NoTracing(),
+    ):
         # We attempt both orderings of functions. This helps by:
         # (1) avoiding code path explosions in one of the functions
         # (2) using both signatures (in case they differ)
@@ -161,7 +164,7 @@ def diff_behavior(
     while all_diffs:
         scorer = diff_scorer(opcodeset1, opcodeset2)
         selection = max(all_diffs, key=scorer)
-        (num_opcodes, _) = scorer(selection)
+        num_opcodes, _ = scorer(selection)
         debug("Considering input", selection.args, " num opcodes=", num_opcodes)
         if num_opcodes == 0:
             break
@@ -204,7 +207,7 @@ def diff_behavior_with_signature(
             output = None
             try:
                 with ResumedTracing():
-                    (verification_status, output) = run_iteration(
+                    verification_status, output = run_iteration(
                         fn1, fn2, sig, space, exception_equivalence
                     )
             except IgnoreAttempt:

--- a/crosshair/dynamic_typing.py
+++ b/crosshair/dynamic_typing.py
@@ -161,7 +161,7 @@ def unify(
             arg_type = args[0] if args else object
             writes = {}
             sub_bindings = bindings.new_child(writes)
-            if unify(Sequence[arg_type], recv_type, sub_bindings):  # type:ignore
+            if unify(Sequence[arg_type], recv_type, sub_bindings):  # type: ignore
                 bindings.update(writes)
                 return True
             if args[-1] == ...:
@@ -172,7 +172,7 @@ def unify(
             arg_type = args[0]
             writes = {}
             sub_bindings = bindings.new_child(writes)
-            if unify(value_type, Sequence[arg_type], sub_bindings):  # type:ignore
+            if unify(value_type, Sequence[arg_type], sub_bindings):  # type: ignore
                 bindings.update(writes)
                 return True
             value_type = tuple
@@ -195,8 +195,8 @@ def unify(
         vargs = arg_getter(value_type)
         rargs = arg_getter(recv_type)
         if issubclass(rorigin, collections.abc.Callable):  # type: ignore
-            (vcallargs, vcallreturn) = vargs
-            (rcallargs, rcallreturn) = rargs
+            vcallargs, vcallreturn = vargs
+            rcallargs, rcallreturn = rargs
             if not unify(vcallreturn, rcallreturn, bindings):
                 return False
             return unify_callable_args(vcallargs, rcallargs, bindings)
@@ -232,7 +232,7 @@ if sys.version_info >= (3, 9):
         if not hasattr(pytype, "__args__"):
             return pytype
         newargs: List = []
-        for arg in pytype.__args__:  # type:ignore
+        for arg in pytype.__args__:  # type: ignore
             newargs.append(realize(arg, bindings))
         pytype_origin = origin_of(pytype)
         if pytype_origin in (
@@ -250,12 +250,12 @@ else:
         if not hasattr(pytype, "__args__"):
             return pytype
         newargs: List = []
-        for arg in pytype.__args__:  # type:ignore
+        for arg in pytype.__args__:  # type: ignore
             newargs.append(realize(arg, bindings))
         # print('realizing pytype', repr(pytype), 'newargs', repr(newargs))
         pytype_origin = origin_of(pytype)
         if not hasattr(pytype_origin, "_name"):
-            pytype_origin = getattr(typing, pytype._name)  # type:ignore
+            pytype_origin = getattr(typing, pytype._name)  # type: ignore
         if pytype_origin is Callable:  # Callable args get flattened
             newargs = [newargs[:-1], newargs[-1]]
         return pytype_origin.__getitem__(tuple(newargs))

--- a/crosshair/examples/PEP316/correct_code/arith.py
+++ b/crosshair/examples/PEP316/correct_code/arith.py
@@ -50,7 +50,7 @@ def smallest_two(numbers: Tuple[int, ...]) -> Tuple[Optional[int], Optional[int]
     """
     if len(numbers) == 1:
         return (numbers[0], None)
-    (smallest, second) = smallest_two(numbers[1:])
+    smallest, second = smallest_two(numbers[1:])
     n = numbers[0]
     if smallest is None or n < smallest:
         return (n, smallest)

--- a/crosshair/examples/check_examples_test.py
+++ b/crosshair/examples/check_examples_test.py
@@ -135,7 +135,9 @@ def run_on_file(pth: Path, overwrite: bool) -> bool:
     sys.version_info < (3, 8),
     reason="only test 3rd party libs under new python versions",
 )
-@pytest.mark.parametrize("path", find_examples(), ids=lambda p: "_".join(p.parts[-3:]))
+@pytest.mark.parametrize(
+    "path", list(find_examples()), ids=lambda p: "_".join(p.parts[-3:])
+)
 def test_examples(path: Path):
     # TODO: "unable to meet precondition" and non-deterministic problems aren't
     # surfaced. Reconsider.

--- a/crosshair/examples/icontract/correct_code/arith.py
+++ b/crosshair/examples/icontract/correct_code/arith.py
@@ -41,7 +41,7 @@ def smallest_two(numbers: Tuple[int, ...]) -> Tuple[Optional[int], Optional[int]
     """Find the two smallest numbers."""
     if len(numbers) == 1:
         return (numbers[0], None)
-    (smallest, second) = smallest_two(numbers[1:])
+    smallest, second = smallest_two(numbers[1:])
     n = numbers[0]
     if smallest is None or n < smallest:
         return (n, smallest)

--- a/crosshair/fnutil.py
+++ b/crosshair/fnutil.py
@@ -55,7 +55,7 @@ def fn_globals(fn: Callable) -> Dict[str, object]:
         if closure_vars.nonlocals:
             return {**closure_vars.nonlocals, **getattr(fn, "__globals__", {})}
     if hasattr(fn, "__globals__"):
-        return fn.__globals__  # type:ignore
+        return fn.__globals__  # type: ignore
     return builtins.__dict__
 
 
@@ -279,7 +279,7 @@ def load_by_qualname(name: str) -> Union[type, FunctionInfo]:
 
 
 def _contains_line(entity: object, filename: str, linenum: int):
-    (cur_filename, start, lines) = sourcelines(entity)
+    cur_filename, start, lines = sourcelines(entity)
     end = start + len(lines)
     try:
         return samefile(filename, cur_filename) and start <= linenum <= end

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -561,7 +561,9 @@ def numeric_binop_internal(op: BinFn, a: Number, b: Number):
             _BIN_OPS[(op, a_type, b_type)] = _MISSING
     if binfn is _MISSING:
         return NotImplemented
-    with ResumedTracing():  # TODO: <-- can we instead selectively resume? Am I only doing this to satisfy the binop tracing check?
+    with (
+        ResumedTracing()
+    ):  # TODO: <-- can we instead selectively resume? Am I only doing this to satisfy the binop tracing check?
         return binfn(op, a, b)
 
 
@@ -857,7 +859,7 @@ def setup_binops():
         with NoTracing():
             if isinstance(b, SymbolicInt):
                 # Have `a` be symbolic, if possible
-                (a, b) = (b, a)
+                a, b = (b, a)
 
             # Check whether we can interpret the mask as a mod operation:
             b = realize(b)
@@ -1869,13 +1871,13 @@ class SymbolicDict(SymbolicDictOrSet, collections.abc.Mapping):
         return z3.And(self._len() == otherlen, comparison_smt_array == self._arr())
 
     def __eq__(self, other):
-        (self_arr, self_len) = self.var
+        self_arr, self_len = self.var
         has_heapref = is_heapref_sort(self.var[0].sort().domain()) or is_heapref_sort(
             self.var[0].sort().range()
         )
         if not has_heapref:
             if isinstance(other, SymbolicDict):
-                (other_arr, other_len) = other.var
+                other_arr, other_len = other.var
                 return SymbolicBool(
                     z3.And(self_len == other_len, self_arr == other_arr)
                 )
@@ -2035,9 +2037,9 @@ class SymbolicFrozenSet(SymbolicDictOrSet, FrozenSetBase):
         return deep_realize(self).__hash__()
 
     def __eq__(self, other):
-        (self_arr, self_len) = self.var
+        self_arr, self_len = self.var
         if isinstance(other, SymbolicFrozenSet):
-            (other_arr, other_len) = other.var
+            other_arr, other_len = other.var
             if other_arr.sort() == self_arr.sort():
                 # TODO: this is wrong for HeapRef sets (which could customize __eq__)
                 return SymbolicBool(
@@ -2240,7 +2242,7 @@ def process_slice_vs_bounded_len(
 ) -> Union[int, Tuple[int, int]]:
     ret = flip_slice_vs_bounded_len(i, bounded_len)
     if isinstance(ret, tuple):
-        (start, stop) = ret
+        start, stop = ret
         return clip_range_to_bounded_len(start, stop, bounded_len)
     return ret
 
@@ -2342,7 +2344,7 @@ class SymbolicArrayBasedUniformTuple(SymbolicSequence):
         with NoTracing():
             if self is other:
                 return True
-            (self_arr, self_len) = self.var
+            self_arr, self_len = self.var
             if isinstance(other, SymbolicArrayBasedUniformTuple):
                 # TODO: Can these be HeapRefs? If so, we're only doing identity checks:
                 return SymbolicBool(
@@ -2453,7 +2455,7 @@ class SymbolicArrayBasedUniformTuple(SymbolicSequence):
             with ResumedTracing():
                 idx_or_pair = process_slice_vs_bounded_len(i, self._len_int)
             if isinstance(idx_or_pair, tuple):
-                (start, stop) = idx_or_pair
+                start, stop = idx_or_pair
                 with ResumedTracing():
                     return SliceView.slice(self, start, stop)
             else:
@@ -3615,7 +3617,7 @@ class AnySymbolicStr(AbcString):
         elif old == "":
             return new + self[:1] + self[1:].replace(old, new, count - 1)
 
-        (prefix, match, suffix) = self.partition(old)
+        prefix, match, suffix = self.partition(old)
         if not match:
             return self
         return prefix + new + suffix.replace(old, new, count - 1)
@@ -3925,7 +3927,7 @@ class LazyIntSymbolicStr(AnySymbolicStr, CrossHairValue):
     def __contains__(self, other):
         if len(other) == 0:
             return True
-        (_, match, _) = self.partition(other)
+        _, match, _ = self.partition(other)
         return match != ""
 
     def __eq__(self, other):
@@ -4104,9 +4106,9 @@ class LazyIntSymbolicStr(AnySymbolicStr, CrossHairValue):
                     return max(start, 0)
         else:
             if from_right:
-                (prefix, match, _) = LazyIntSymbolicStr.rpartition(matchstr, substr)
+                prefix, match, _ = LazyIntSymbolicStr.rpartition(matchstr, substr)
             else:
-                (prefix, match, _) = LazyIntSymbolicStr.partition(matchstr, substr)
+                prefix, match, _ = LazyIntSymbolicStr.partition(matchstr, substr)
             if match == "":
                 return -1
             return start + len(prefix)
@@ -4816,7 +4818,7 @@ def _dict(arg=_MISSING, **kwargs) -> Union[dict, ShellMutableMap]:
         for pair in arg:  # NOTE: `arg` can be an iterator; scan only once
             if len(pair) != 2:
                 raise ValueError
-            (key, val) = pair
+            key, val = pair
             if not is_hashable(key):
                 raise ValueError
             all_items.append(pair)
@@ -4860,7 +4862,7 @@ def _format(obj: object, format_spec: str = "") -> Union[str, AnySymbolicStr]:
 def _getattr(obj: object, name: str, default=_MISSING) -> object:
     with NoTracing():
         if isinstance(name, AnySymbolicStr):
-            fork_on_useful_attr_names(obj, name)  # type:ignore
+            fork_on_useful_attr_names(obj, name)  # type: ignore
             name = realize(name)
         if default is _MISSING:
             return getattr(obj, name)
@@ -4871,7 +4873,7 @@ def _getattr(obj: object, name: str, default=_MISSING) -> object:
 def _hasattr(obj: object, name: str) -> bool:
     with NoTracing():
         if isinstance(name, AnySymbolicStr):
-            fork_on_useful_attr_names(obj, name)  # type:ignore
+            fork_on_useful_attr_names(obj, name)  # type: ignore
             name = realize(name)
         return hasattr(obj, name)
 

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -546,7 +546,7 @@ def test_mismatched_types() -> None:
         """
         return x + y  # type: ignore
 
-    (actual, expected) = check_exec_err(f, "TypeError: unsupported operand type")
+    actual, expected = check_exec_err(f, "TypeError: unsupported operand type")
     assert actual == expected
 
 
@@ -1133,7 +1133,7 @@ def test_str_index_err() -> None:
         return s1.index(s2)
 
     # index() raises ValueError when a match isn't found:
-    (actual, expected) = check_exec_err(f, "ValueError")
+    actual, expected = check_exec_err(f, "ValueError")
     assert actual == expected
 
 
@@ -2067,7 +2067,7 @@ def test_list____getitem___error() -> None:
         """
         return ls[idx]
 
-    (actual, expected) = check_exec_err(f, "IndexError")
+    actual, expected = check_exec_err(f, "IndexError")
     assert actual == expected
 
 
@@ -2076,7 +2076,7 @@ def test_list____getitem___type_error() -> None:
         """post: True"""
         return ls[0.0:]  # type: ignore
 
-    (actual, expected) = check_exec_err(f, "TypeError")
+    actual, expected = check_exec_err(f, "TypeError")
     assert actual == expected
 
 
@@ -2279,7 +2279,7 @@ def test_list___delitem___type_error() -> None:
         """
         del ls[1.0]  # type: ignore
 
-    (actual, expected) = check_exec_err(f, "TypeError")
+    actual, expected = check_exec_err(f, "TypeError")
     assert actual == expected
 
 
@@ -2288,7 +2288,7 @@ def test_list___delitem___out_of_bounds() -> None:
         """post: True"""
         del ls[1]
 
-    (actual, expected) = check_exec_err(f, "IndexError")
+    actual, expected = check_exec_err(f, "IndexError")
     assert actual == expected
 
 
@@ -2317,7 +2317,7 @@ def test_list_comparison_type_error() -> None:
         """post: True"""
         return a <= b  # type: ignore
 
-    (actual, expected) = check_exec_err(f, "TypeError")
+    actual, expected = check_exec_err(f, "TypeError")
     assert actual == expected
 
 
@@ -3066,7 +3066,7 @@ def test_set_copy(space):
     x = proxy_for_type(Set[int], "x")
     with ResumedTracing():
         space.add(len(x) == 1)
-        (y, z) = copy.deepcopy((x, x))
+        y, z = copy.deepcopy((x, x))
         assert not space.is_possible(len(y) != 1)
         assert not space.is_possible(list(x)[0] != list(y)[0])
 
@@ -3646,7 +3646,7 @@ def test_list_index_on_concrete() -> None:
         """post: True"""
         return [0, 1, 2].index(i)
 
-    (actual, expected) = check_exec_err(f, "ValueError:")
+    actual, expected = check_exec_err(f, "ValueError:")
     assert actual == expected
 
 

--- a/crosshair/libimpl/codecslib.py
+++ b/crosshair/libimpl/codecslib.py
@@ -27,7 +27,7 @@ class RealizingCodecInfo(codecs.CodecInfo):
 
 def _decode(obj, encoding="utf-8", errors="strict"):
     errors = realize(errors)
-    (out, _len_consumed) = _getdecoder(encoding)(obj, errors)
+    out, _len_consumed = _getdecoder(encoding)(obj, errors)
     return out
 
 
@@ -36,7 +36,7 @@ def _encode(obj, encoding="utf-8", errors="strict"):
         errors = realize(errors)
         if "\x00" in errors:
             raise ValueError
-    (out, _len_consumed) = _getencoder(encoding)(obj, errors)
+    out, _len_consumed = _getencoder(encoding)(obj, errors)
     return out
 
 

--- a/crosshair/libimpl/decimallib.py
+++ b/crosshair/libimpl/decimallib.py
@@ -3211,7 +3211,7 @@ class Decimal(CrossHairValue):
             return _raise_error_in_ctx(context, InvalidOperation)
 
         # fill to context.prec
-        (opa, opb) = self._fill_logical(context, self._int, other._int)
+        opa, opb = self._fill_logical(context, self._int, other._int)
 
         # make the operation, and clean starting zeroes
         result = "".join([str(int(a) & int(b)) for a, b in zip(opa, opb)])
@@ -3234,7 +3234,7 @@ class Decimal(CrossHairValue):
             return _raise_error_in_ctx(context, InvalidOperation)
 
         # fill to context.prec
-        (opa, opb) = self._fill_logical(context, self._int, other._int)
+        opa, opb = self._fill_logical(context, self._int, other._int)
 
         # make the operation, and clean starting zeroes
         result = "".join([str(int(a) | int(b)) for a, b in zip(opa, opb)])
@@ -3251,7 +3251,7 @@ class Decimal(CrossHairValue):
             return _raise_error_in_ctx(context, InvalidOperation)
 
         # fill to context.prec
-        (opa, opb) = self._fill_logical(context, self._int, other._int)
+        opa, opb = self._fill_logical(context, self._int, other._int)
 
         # make the operation, and clean starting zeroes
         result = "".join([str(int(a) ^ int(b)) for a, b in zip(opa, opb)])
@@ -3557,8 +3557,8 @@ class Decimal(CrossHairValue):
 
     def __ch_realize__(self):
         with ResumedTracing():
-            (sign, digits, exponent) = self.as_tuple()
-            (sign, digits, exponent) = (
+            sign, digits, exponent = self.as_tuple()
+            sign, digits, exponent = (
                 realize(sign),
                 deep_realize(digits),
                 realize(exponent),

--- a/crosshair/libimpl/importliblib_test.py
+++ b/crosshair/libimpl/importliblib_test.py
@@ -6,22 +6,18 @@ from crosshair.test_util import simplefs
 
 DYNAMIC_IMPORT = {
     "__init__.py": "",
-    "outer.py": textwrap.dedent(
-        """\
+    "outer.py": textwrap.dedent("""\
         def outerfn(x: int) -> int:
             ''' post: _ == x '''
             from .innerx import innerfn
             return innerfn(x)
-        """
-    ),
-    "innerx.py": textwrap.dedent(
-        """
+        """),
+    "innerx.py": textwrap.dedent("""
         from crosshair.tracers import is_tracing
         assert not is_tracing()
         def innerfn(x: int) -> int:
             return x
-        """
-    ),
+        """),
 }
 
 

--- a/crosshair/libimpl/relib.py
+++ b/crosshair/libimpl/relib.py
@@ -134,7 +134,7 @@ def single_char_mask(
     Returns a list of valid codepoint or codepoint ranges if it can find them, or raises
     ReUnhandled if such an expression cannot be determined.
     """
-    (op, arg) = parsed
+    op, arg = parsed
     isascii = re.ASCII & flags
     if op in (LITERAL, NOT_LITERAL):
         if re.IGNORECASE & flags:
@@ -218,7 +218,7 @@ class _MatchPart:
         groups = self._groups
         for idx, span in enumerate(groups):
             if span is not None:
-                (span_start, span_end) = span
+                span_start, span_end = span
                 with ResumedTracing():
                     if span_start == span_end:
                         if span_start < start:
@@ -227,7 +227,7 @@ class _MatchPart:
                             groups[idx] = (end, end)
 
     def isempty(self):
-        (start, end) = self._groups[0]
+        start, end = self._groups[0]
         return _traced_binop(end, operator.le, start)
 
     def __bool__(self):
@@ -492,9 +492,9 @@ def _internal_match_patterns(
         smt_ch = SymbolicInt._coerce_to_smt_sort(char)
         return fork_on(mask.smt_matches(smt_ch), 1)
 
-    (op, arg) = pattern
+    op, arg = pattern
     if op in (MIN_REPEAT, MAX_REPEAT):
-        (min_repeat, max_repeat, subpattern) = arg
+        min_repeat, max_repeat, subpattern = arg
         if max_repeat < min_repeat:
             return None
         reps = 0
@@ -608,7 +608,7 @@ def _internal_match_patterns(
                 at_boundary_expr = z3.Not(at_boundary_expr)
             return fork_on(at_boundary_expr, 0)
     elif op in (ASSERT, ASSERT_NOT):
-        (direction_int, subpattern) = arg
+        direction_int, subpattern = arg
         positive_look = op == ASSERT
         if direction_int == 1:
             matched = _internal_match_patterns(
@@ -631,7 +631,7 @@ def _internal_match_patterns(
             top_patterns[1:], flags, string, offset, allow_empty, ord=ord, chr=chr
         )
     elif op is SUBPATTERN:
-        (groupnum, _a, _b, subpatterns) = arg
+        groupnum, _a, _b, subpatterns = arg
         if (_a, _b) != (0, 0):
             raise ReUnhandled("unsupported subpattern args")
         new_top = (
@@ -643,7 +643,7 @@ def _internal_match_patterns(
             new_top, flags, string, offset, allow_empty, ord=ord, chr=chr
         )
     elif op is _END_GROUP_MARKER:
-        (group_num, begin) = arg
+        group_num, begin = arg
         match = continue_matching(_MatchPart([(offset, offset)]))
         if match is None:
             return None
@@ -851,7 +851,7 @@ def _search(
 
 
 def _sub(self, repl, string, count=0):
-    (result, _) = _subn(self, repl, string, count)
+    result, _ = _subn(self, repl, string, count)
     return result
 
 
@@ -884,7 +884,7 @@ def _subn(
         remaining = string[match.end() + 1 :]
     else:
         remaining = string[match.end() :]
-    (result_suffix, suffix_replacements) = _subn(self, repl, remaining, count - 1)
+    result_suffix, suffix_replacements = _subn(self, repl, remaining, count - 1)
     return (result_prefix + result_suffix, suffix_replacements + 1)
 
 

--- a/crosshair/main.py
+++ b/crosshair/main.py
@@ -110,15 +110,13 @@ def command_line_parser() -> argparse.ArgumentParser:
         type=str,
         nargs="+",
         metavar="EVENT",
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
         Allow specific side-effects. See the list of audit events at:
         https://docs.python.org/3/library/audit_events.html
         You may specify colon-delimited event arguments to narrow the unblock, e.g.:
             --unblock subprocess.Popen:echo
         Finally, `--unblock EVERYTHING` will disable all side-effect detection.
-        """
-        ),
+        """),
     )
     parser = argparse.ArgumentParser(
         prog="crosshair", description="CrossHair Analysis Tool"
@@ -129,8 +127,7 @@ def command_line_parser() -> argparse.ArgumentParser:
         help="Analyze a file or function",
         parents=[common],
         formatter_class=argparse.RawTextHelpFormatter,
-        description=textwrap.dedent(
-            """\
+        description=textwrap.dedent("""\
         The check command looks for counterexamples that break contracts.
 
         It outputs machine-readable messages in this format on stdout:
@@ -140,8 +137,7 @@ def command_line_parser() -> argparse.ArgumentParser:
             0 : No counterexamples are found
             1 : Counterexample(s) have been found
             2 : Other error
-        """
-        ),
+        """),
     )
     check_parser.add_argument(
         "--report_all",
@@ -159,29 +155,25 @@ def command_line_parser() -> argparse.ArgumentParser:
         metavar="TARGET",
         type=str,
         nargs="+",
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
         A fully qualified module, class, or function, or
         a directory (which will be recursively analyzed), or
         a file path with an optional ":<line-number>" suffix.
         See https://crosshair.readthedocs.io/en/latest/contracts.html#targeting
-        """
-        ),
+        """),
     )
     search_parser = subparsers.add_parser(
         "search",
         help="Find arguments to make a function complete without error",
         parents=[common],
         formatter_class=argparse.RawTextHelpFormatter,
-        description=textwrap.dedent(
-            """\
+        description=textwrap.dedent("""\
         The search command finds arguments for a function that causes it to
         complete without error.
 
         Results (if any) are written to stdout in the form of a repr'd
         dictionary, mapping argument names to values.
-        """
-        ),
+        """),
     )
     search_parser.add_argument(
         "fn",
@@ -195,8 +187,7 @@ def command_line_parser() -> argparse.ArgumentParser:
         choices=OptimizationKind.__members__.values(),
         metavar="OPTIMIZATION_TYPE",
         default=OptimizationKind.SIMPLIFY,
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
         Controls what kind of arguments are produced.
         Optimization effectiveness will vary wildly depnding on the nature of
         the function.
@@ -205,32 +196,27 @@ def command_line_parser() -> argparse.ArgumentParser:
             none         : Output the first set of arguments found.
             minimize_int : Attempt to minimize an integer returned by the
                            function. Negative return values are ignored.
-        """
-        ),
+        """),
     )
     search_parser.add_argument(
         "--output_all_examples",
         action="store_true",
         default=False,
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
         When optimizing, output an example every time a new best score is discovered.
-        """
-        ),
+        """),
     )
     search_parser.add_argument(
         "--argument_formatter",
         metavar="FUNCTION",
         type=str,
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
         The (fully-qualified) name of a function for formatting produced
         arguments. If specified, crosshair will call this function instead of
         repr() when printing arguments to stdout.
         Your formatting function will be pased an `inspect.BoundArguments`
         instance. It should return a string.
-        """
-        ),
+        """),
     )
 
     watch_parser = subparsers.add_parser(
@@ -238,35 +224,29 @@ def command_line_parser() -> argparse.ArgumentParser:
         help="Continuously watch and analyze a directory",
         parents=[common],
         formatter_class=argparse.RawTextHelpFormatter,
-        description=textwrap.dedent(
-            """\
+        description=textwrap.dedent("""\
         The watch command continuously looks for contract counterexamples.
         Type Ctrl-C to stop this command.
-        """
-        ),
+        """),
     )
     watch_parser.add_argument(
         "directory",
         metavar="TARGET",
         type=str,
         nargs="+",
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
         File or directory to watch. Directories will be recursively analyzed.
         See https://crosshair.readthedocs.io/en/latest/contracts.html#targeting
-        """
-        ),
+        """),
     )
     diffbehavior_parser = subparsers.add_parser(
         "diffbehavior",
         formatter_class=argparse.RawTextHelpFormatter,
         help="Find differences in the behavior of two functions",
-        description=textwrap.dedent(
-            """\
+        description=textwrap.dedent("""\
         Find differences in the behavior of two functions.
         See https://crosshair.readthedocs.io/en/latest/diff_behavior.html
-            """
-        ),
+            """),
         parents=[common],
     )
     diffbehavior_parser.add_argument(
@@ -287,26 +267,22 @@ def command_line_parser() -> argparse.ArgumentParser:
         type=ExceptionEquivalenceType,
         default=ExceptionEquivalenceType.TYPE_AND_MESSAGE,
         choices=ExceptionEquivalenceType.__members__.values(),
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
             Decide how to treat exceptions, while searching for a counter-example.
             `ALL` treats all exceptions as equivalent,
             `SAME_TYPE`, considers matches on the type.
             `TYPE_AND_MESSAGE` matches for the same type and message.
-            """
-        ),
+            """),
     )
     cover_parser = subparsers.add_parser(
         "cover",
         formatter_class=argparse.RawTextHelpFormatter,
         help="Generate inputs for a function, attempting to exercise different code paths",
-        description=textwrap.dedent(
-            """\
+        description=textwrap.dedent("""\
         Generates inputs to a function, hopefully getting good line, branch,
         and path coverage.
         See https://crosshair.readthedocs.io/en/latest/cover.html
-            """
-        ),
+            """),
         parents=[common],
     )
     cover_parser.add_argument(
@@ -314,14 +290,12 @@ def command_line_parser() -> argparse.ArgumentParser:
         metavar="TARGET",
         type=str,
         nargs="+",
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
         A fully qualified module, class, or function, or
         a directory (which will be recursively analyzed), or
         a file path with an optional ":<line-number>" suffix.
         See https://crosshair.readthedocs.io/en/latest/contracts.html#targeting
-        """
-        ),
+        """),
     )
     cover_parser.add_argument(
         "--example_output_format",
@@ -329,8 +303,7 @@ def command_line_parser() -> argparse.ArgumentParser:
         choices=ExampleOutputFormat.__members__.values(),
         metavar="FORMAT",
         default=ExampleOutputFormat.EVAL_EXPRESSION,
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
         Determines how to output examples.
             eval_expression     : [default] Output examples as expressions,
                                   suitable for eval()
@@ -338,8 +311,7 @@ def command_line_parser() -> argparse.ArgumentParser:
                                   dictionaries
             pytest              : Output examples as stub pytest tests
             argument_dictionary : Deprecated
-        """
-        ),
+        """),
     )
     cover_parser.add_argument(
         "--coverage_type",
@@ -347,8 +319,7 @@ def command_line_parser() -> argparse.ArgumentParser:
         choices=CoverageType.__members__.values(),
         metavar="TYPE",
         default=CoverageType.OPCODE,
-        help=textwrap.dedent(
-            """\
+        help=textwrap.dedent("""\
         Determines what kind of coverage to achieve.
             opcode : [default] Cover as many opcodes of the function as
                      possible. This is similar to "branch" coverage.
@@ -359,15 +330,13 @@ def command_line_parser() -> argparse.ArgumentParser:
                      to bound results.
                      Many path decisions are internal to CrossHair, so you may
                      see more duplicative-ness in the output than you'd expect.
-        """
-        ),
+        """),
     )
     for subparser in (check_parser, search_parser, diffbehavior_parser, cover_parser):
         subparser.add_argument(
             "--max_uninteresting_iterations",
             type=int,
-            help=textwrap.dedent(
-                """\
+            help=textwrap.dedent("""\
             Maximum number of consecutive iterations to run without making
             significant progress in exploring the codebase.
             (by default, 5 iterations, unless --per_condition_timeout is set)
@@ -379,8 +348,7 @@ def command_line_parser() -> argparse.ArgumentParser:
             Use a small integer (3-5) for fast but weak analysis.
             Values in the hundreds or thousands may be appropriate if you
             intend to run CrossHair for hours.
-            """
-            ),
+            """),
         )
 
     for subparser in (check_parser, search_parser, diffbehavior_parser, cover_parser):
@@ -388,8 +356,7 @@ def command_line_parser() -> argparse.ArgumentParser:
             "--per_path_timeout",
             type=float,
             metavar="FLOAT",
-            help=textwrap.dedent(
-                """\
+            help=textwrap.dedent("""\
             Maximum CPU seconds to spend checking one execution path.
             (wall-clock may be longer)
             If unspecified:
@@ -400,8 +367,7 @@ def command_line_parser() -> argparse.ArgumentParser:
                explicitly set to zero.
                (NOTE: `--max_uninteresting_iterations` is 5 by default)
             3. Otherwise, it will not use any per-path timeout.
-"""
-            ),
+"""),
         )
         subparser.add_argument(
             "--per_condition_timeout",
@@ -417,12 +383,10 @@ def command_line_parser() -> argparse.ArgumentParser:
         help="Start a server, speaking the Language Server Protocol",
         parents=[common],
         formatter_class=argparse.RawTextHelpFormatter,
-        description=textwrap.dedent(
-            f"""\
+        description=textwrap.dedent(f"""\
             Many IDEs support the Language Server Protocol (LSP).
             CrossHair can produce various results and analysis through LSP.
-            """
-        ),
+            """),
     )
 
     for subparser in (check_parser, watch_parser, lsp_server_parser):
@@ -430,8 +394,7 @@ def command_line_parser() -> argparse.ArgumentParser:
             "--analysis_kind",
             type=analysis_kind,
             metavar="KIND",
-            help=textwrap.dedent(
-                """\
+            help=textwrap.dedent("""\
             Kind of contract to check.
             By default, the PEP316, deal, and icontract kinds are all checked.
             Multiple kinds (comma-separated) may be given.
@@ -440,8 +403,7 @@ def command_line_parser() -> argparse.ArgumentParser:
                 PEP316     : check PEP316 contracts (docstring-based)
                 icontract  : check icontract contracts (decorator-based)
                 deal       : check deal contracts (decorator-based)
-            """
-            ),
+            """),
         )
     return parser
 
@@ -713,7 +675,7 @@ def checked_load(
 def diffbehavior(
     args: argparse.Namespace, options: AnalysisOptions, stdout: TextIO, stderr: TextIO
 ) -> int:
-    (fn_name1, fn_name2) = (args.fn1, args.fn2)
+    fn_name1, fn_name2 = (args.fn1, args.fn2)
     fn1 = checked_fn_load(fn_name1, stderr)
     fn2 = checked_fn_load(fn_name2, stderr)
     exception_equivalence = args.exception_equivalence
@@ -812,7 +774,7 @@ def cover(
         elif example_output_format == ExampleOutputFormat.EVAL_EXPRESSION:
             output_eval_exression_paths(fn, paths, stdout, stderr)
         elif example_output_format == ExampleOutputFormat.PYTEST:
-            (cur_imports, cur_lines) = output_pytest_paths(fn, paths)
+            cur_imports, cur_lines = output_pytest_paths(fn, paths)
             imports |= cur_imports
             # imports.add(f"import {fn.__qualname__}")
             lines.extend(cur_lines)

--- a/crosshair/main_test.py
+++ b/crosshair/main_test.py
@@ -73,25 +73,20 @@ def call_diffbehavior(fn1: str, fn2: str) -> Tuple[int, List[str]]:
     return retcode, lines
 
 
-SIMPLE_FOO = {
-    "foo.py": """
+SIMPLE_FOO = {"foo.py": """
 def foofn(x: int) -> int:
   ''' post: _ == x '''
   return x + 1
-"""
-}
+"""}
 
-FOO_CLASS = {
-    "foo.py": """
+FOO_CLASS = {"foo.py": """
 class Fooey:
   def incr(self, x: int) -> int:
     ''' post: _ == x '''
     return x + 1
-"""
-}
+"""}
 
-ASSERT_BASED_FOO = {
-    "foo.py": """
+ASSERT_BASED_FOO = {"foo.py": """
 def foofn(x: int) -> int:
   ''' :raises KeyError: when input is 999 '''
   assert x >= 100
@@ -100,11 +95,9 @@ def foofn(x: int) -> int:
       raise KeyError
   assert x != 101
   return x
-"""
-}
+"""}
 
-FOO_WITH_CONFIRMABLE_AND_PRE_UNSAT = {
-    "foo.py": """
+FOO_WITH_CONFIRMABLE_AND_PRE_UNSAT = {"foo.py": """
 def foo_confirmable(x: int) -> int:
   ''' post: _ > x '''
   return x + 1
@@ -114,11 +107,9 @@ def foo_pre_unsat(x: int) -> int:
   post: True
   '''
   return x
-"""
-}
+"""}
 
-FOO_STATIC_AND_CLASSMETHODS = {
-    "foo.py": """
+FOO_STATIC_AND_CLASSMETHODS = {"foo.py": """
 class Fooey:
   @staticmethod
   def static_incr(x: int) -> int:
@@ -129,8 +120,7 @@ class Fooey:
     ''' post: _ == x '''
     assert cls == Fooey
     return x + 1
-"""
-}
+"""}
 
 OUTER_INNER = {
     "outer": {
@@ -163,17 +153,14 @@ class Second():
 DIRECTIVES_TREE = {
     "outerpkg": {
         "__init__.py": "# crosshair: off",
-        "outermod.py": textwrap.dedent(
-            """\
+        "outermod.py": textwrap.dedent("""\
             def fn1():
                 assert True
                 raise Exception
-            """
-        ),
+            """),
         "innerpkg": {
             "__init__.py": "# crosshair: on",
-            "innermod.py": textwrap.dedent(
-                """\
+            "innermod.py": textwrap.dedent("""\
                 # crosshair: off
                 def fn2():
                     # crosshair: on
@@ -182,8 +169,7 @@ DIRECTIVES_TREE = {
                 def fn3():
                     assert True
                     raise Exception
-                """
-            ),
+                """),
         },
     }
 }
@@ -254,7 +240,7 @@ def test_no_args_prints_usage(root):
 def test_assert_mode_e2e(root, capsys: pytest.CaptureFixture[str]):
     simplefs(root, ASSERT_BASED_FOO)
     exitcode = unwalled_main(["check", str(root / "foo.py"), "--analysis_kind=asserts"])
-    (out, err) = capsys.readouterr()
+    out, err = capsys.readouterr()
     assert err == ""
     assert re.search(
         r"foo.py\:8\: error\: AssertionError\:  when calling foofn\(100\)", out
@@ -266,7 +252,7 @@ def test_assert_mode_e2e(root, capsys: pytest.CaptureFixture[str]):
 def test_assert_without_checkable(root, capsys: pytest.CaptureFixture[str]):
     simplefs(root, SIMPLE_FOO)
     exitcode = unwalled_main(["check", str(root / "foo.py"), "--analysis_kind=asserts"])
-    (out, err) = capsys.readouterr()
+    out, err = capsys.readouterr()
     assert (
         err
         == "WARNING: Targets found, but contain no checkable functions.\nHINT: Ensure that your functions to analyze lead with assert statements.\n"
@@ -317,7 +303,7 @@ def test_report_confirmation(root):
 def test_cover_static_and_classmethods(root: Path, capsys: pytest.CaptureFixture[str]):
     simplefs(root, FOO_STATIC_AND_CLASSMETHODS)
     ret = unwalled_main(["cover", str(root / "foo.py")])
-    (out, err) = capsys.readouterr()
+    out, err = capsys.readouterr()
     assert err == ""
     assert out == "static_incr(0)\nclassmethod_incr(Fooey, 0)\n"
     assert ret == 0
@@ -374,8 +360,7 @@ def test_check_circular_with_guard(root):
 
 
 def test_check_not_deterministic(root) -> None:
-    NOT_DETERMINISTIC_FOO = {
-        "foo.py": """
+    NOT_DETERMINISTIC_FOO = {"foo.py": """
 _GLOBAL_THING = [42]
 
 def wonky_foo(i: int) -> int:
@@ -389,8 +374,7 @@ _GLOBAL_THING = [True]
 def regular_foo(i: int) -> int:
     '''post: True'''
     return i
-"""
-    }
+"""}
     simplefs(root, NOT_DETERMINISTIC_FOO)
     with add_to_pypath(root):
         retcode, lines, errlines = call_check([str(root / "foo.py")])
@@ -427,14 +411,12 @@ def test_diff_behavior_same(root):
 def test_diff_behavior_different(root):
     simplefs(
         root,
-        {
-            "foo.py": """
+        {"foo.py": """
 def add(x: int, y: int) -> int:
   return x + y
 def faultyadd(x: int, y: int) -> int:
   return 42 if (x, y) == (10, 10) else x + y
-"""
-        },
+"""},
     )
     with add_to_pypath(root):
         retcode, lines = call_diffbehavior("foo.add", "foo.faultyadd")

--- a/crosshair/path_cover_test.py
+++ b/crosshair/path_cover_test.py
@@ -100,12 +100,10 @@ def test_path_cover_exception_example() -> None:
 def test_path_cover_symbolic_exception_message() -> None:
     paths = list(path_cover(symbolic_exception_example, OPTS, CoverageType.OPCODE))
     _imports, lines = output_pytest_paths(_symbolic_exception_example, paths)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         def test__symbolic_exception_example():
             with pytest.raises(ValueError, match='foo\\'bar"baz'):
-                _symbolic_exception_example('foo\\'bar"baz')"""
-    )
+                _symbolic_exception_example('foo\\'bar"baz')""")
     assert expected in "\n".join(lines)
 
 

--- a/crosshair/pathing_oracle.py
+++ b/crosshair/pathing_oracle.py
@@ -80,7 +80,7 @@ class CoveragePathingOracle(AbstractPathingOracle):
         options = list(summarized_positions.items())
         options.sort(key=lambda pair: visits[pair[0]])
         chosen_index = int((root._random.random() ** 2.5) * num_positions)
-        (loc, exprs) = options[chosen_index]
+        loc, exprs = options[chosen_index]
         for expr in exprs.keys():
             if expr >= 0:
                 tweaks[expr] += 1
@@ -128,7 +128,7 @@ class CoveragePathingOracle(AbstractPathingOracle):
                 if isinstance(next_node, DetachedPathNode):
                     break
                 if step + 1 < len(path):
-                    (is_positive, root_expr) = node.normalized_expr
+                    is_positive, root_expr = node.normalized_expr
                     expr_signature = (
                         self.internalize(root_expr)
                         if is_positive

--- a/crosshair/simplestructs.py
+++ b/crosshair/simplestructs.py
@@ -205,7 +205,7 @@ class SimpleDict(MapBase):
     def popitem(self):
         if not self.contents_:
             raise KeyError
-        (k, v) = self.contents_.pop()
+        k, v = self.contents_.pop()
         return (k, v)
 
     def copy(self):

--- a/crosshair/statespace.py
+++ b/crosshair/statespace.py
@@ -1022,7 +1022,7 @@ class StateSpace:
                     debug("  Traceback: ", ch_stack())
                     debug(" *** End Not Deterministic Debug *** ")
                     raise NotDeterministic
-                (chosen, _, next_node) = node.choose(
+                chosen, _, next_node = node.choose(
                     self, probability_true=choice_conformity
                 )
                 self.choices_made.append(node)

--- a/crosshair/tools/check_help_in_doc.py
+++ b/crosshair/tools/check_help_in_doc.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 """Check that the help snippets in the doc coincide with the actual output."""
+
 import argparse
 import os
 import pathlib

--- a/crosshair/tracers.py
+++ b/crosshair/tracers.py
@@ -147,7 +147,7 @@ class TracingModule:
         info = call_stack_info(frame, opcodenum)
         if info is None:
             return None
-        (fn_idx, target, kwargs_idx) = info
+        fn_idx, target, kwargs_idx = info
         if target is None:
             target = NULL_POINTER
         target, binding_target = normalize_call_target(

--- a/crosshair/unicode_categories.py
+++ b/crosshair/unicode_categories.py
@@ -132,8 +132,8 @@ class CharMask:
         result = CharMask([])
         for myidx in range(len(myparts)):
             for otheridx in range(len(otherparts)):
-                (mymin, mymax) = self.bounds_at(myidx)
-                (omin, omax) = other.bounds_at(otheridx)
+                mymin, mymax = self.bounds_at(myidx)
+                omin, omax = other.bounds_at(otheridx)
                 result.maybe_add_bounds(max(mymin, omin), min(mymax, omax))
         return result
 

--- a/crosshair/util.py
+++ b/crosshair/util.py
@@ -205,7 +205,7 @@ def sourcelines(thing: object) -> Tuple[str, int, Tuple[str, ...]]:
     if ret is None:
         try:
             filename = getsourcefile(thing)  # type: ignore
-            (lines, start_line) = getsourcelines(thing)  # type: ignore
+            lines, start_line = getsourcelines(thing)  # type: ignore
         except (OSError, TypeError):
             pass
         ret = (filename, start_line, tuple(lines))

--- a/crosshair/util_test.py
+++ b/crosshair/util_test.py
@@ -123,9 +123,12 @@ def test_eval_friendly_repr():
     from crosshair.opcode_intercept import FormatValueInterceptor
     from crosshair.tracers import COMPOSITE_TRACER, NoTracing, PushedModule
 
-    with COMPOSITE_TRACER, PushedModule(PatchingModule()), PushedModule(
-        FormatValueInterceptor()
-    ), NoTracing():
+    with (
+        COMPOSITE_TRACER,
+        PushedModule(PatchingModule()),
+        PushedModule(FormatValueInterceptor()),
+        NoTracing(),
+    ):
         # Class
         assert eval_friendly_repr(Color) == "Color"
         # Pure-python method:

--- a/crosshair/watcher.py
+++ b/crosshair/watcher.py
@@ -122,7 +122,7 @@ class PoolWorkerShell(threading.Thread):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        (stdout, _stderr) = self.proc.communicate(b"")
+        stdout, _stderr = self.proc.communicate(b"")
         if stdout:
             last_line = stdout.splitlines()[-1]  # (in case of spurious print()s)
             self.results.put(deserialize(last_line))
@@ -138,7 +138,7 @@ def pool_worker_main() -> None:
             os.nice(10)  # type: ignore
         set_debug(False)
         engage_auditwall(DEFAULT_OPTIONS.overlay(item[1]).unblock)
-        (stats, messages) = pool_worker_process_item(item)
+        stats, messages = pool_worker_process_item(item)
         output: WorkItemOutput = (filename, stats, messages)
         print(serialize(output))
     except BaseException as e:
@@ -174,7 +174,7 @@ class Pool:
 
     def _prune_workers(self, curtime: float) -> None:
         for worker, item in self._workers:
-            (_, _, deadline) = item
+            _, _, deadline = item
             if worker.is_alive() and curtime > deadline and worker.proc is not None:
                 debug("Killing worker over deadline", worker)
                 worker.proc.terminate()
@@ -262,7 +262,7 @@ class Watcher:
         while pool.is_working():
             result = pool.get_result(timeout=1.0)
             if result is not None:
-                (_, counters, messages) = result
+                _, counters, messages = result
                 yield (counters, messages)
                 if pool.has_result():
                     continue

--- a/crosshair/watcher_test.py
+++ b/crosshair/watcher_test.py
@@ -26,46 +26,36 @@ def rewind_modules():
             del sys.modules[name]
 
 
-BUGGY_FOO = {
-    "foo.py": """
+BUGGY_FOO = {"foo.py": """
 def foofn(x: int) -> int:
   ''' post: _ == x '''
   print("this print does not confuse the watcher")
   return x + 1
-"""
-}
+"""}
 
-CORRECT_FOO = {
-    "foo.py": """
+CORRECT_FOO = {"foo.py": """
 def foofn(x: int) -> int:
   ''' post: _ == 1 + x '''
   return x + 1
-"""
-}
+"""}
 
-BAD_SYNTAX_FOO = {
-    "foo.py": """
+BAD_SYNTAX_FOO = {"foo.py": """
 def foofn(x: int) -> int:
   ''' post: _ == x '''
   return $ x + 1
-"""
-}
+"""}
 
-CHATTY_FOO = {
-    "foo.py": """
+CHATTY_FOO = {"foo.py": """
 from subprocess import Popen
 def foofn(x: int) -> int:
   ''' post: _ == x '''
   Popen(['echo', 'hello']).communicate()
   return x
-"""
-}
+"""}
 
-EMPTY_BAR = {
-    "bar.py": """
+EMPTY_BAR = {"bar.py": """
 # Nothing here
-"""
-}
+"""}
 
 
 def test_added_file(tmp_path: Path):

--- a/crosshair/z3util.py
+++ b/crosshair/z3util.py
@@ -45,13 +45,13 @@ def z3IntVal(x: int) -> z3.IntNumRef:
 
 def z3Or(*exprs):
     # return z3.Or(*exprs)
-    (args, sz) = _to_ast_array(exprs)
+    args, sz = _to_ast_array(exprs)
     return BoolRef(Z3_mk_or(ctx.ref(), sz, args), ctx)
 
 
 def z3And(*exprs):
     # return z3.And(*exprs)
-    (args, sz) = _to_ast_array(exprs)
+    args, sz = _to_ast_array(exprs)
     return BoolRef(Z3_mk_and(ctx.ref(), sz, args), ctx)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,18 +40,21 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# NOTE: the runtime package still supports Python >=3.8, but the dev tooling
+# below (black, isort, mypy, pytest) requires >=3.10, so contributing to
+# CrossHair requires Python 3.10 or newer.
 dev = [
     "autodocsumm>=0.2.2,<1",
-    "black==25.11.0",  # sync this with .pre-commit-config.yaml
+    "black==26.5.1",  # sync this with .pre-commit-config.yaml
     "deal>=4.13.0",
     "hypothesis>=6.0.0",  # input generation for crosshair.inputgen / fuzz_core_test
     "icontract>=2.4.0",
-    "isort==5.11.5",  # sync this with .pre-commit-config.yaml
-    "mypy==1.18.1",  # sync this with .pre-commit-config.yaml
+    "isort==8.0.1",  # sync this with .pre-commit-config.yaml
+    "mypy==2.1.0",  # sync this with .pre-commit-config.yaml
     "numpy==1.24.0; python_version < '3.12'",
     "numpy==2.3.3; python_version >= '3.12'",
     "pre-commit~=4.3",
-    "pytest==8.3.5",
+    "pytest==9.1.1",
     "pytest-xdist==3.8.0",
     "setuptools",
     "sphinx>=3.4.3",


### PR DESCRIPTION
Consolidates the four failing dependabot bumps (#441–#444), which all failed for the same reason: the new tool versions require Python `>=3.10`, but CrossHair still tested and built for 3.9, so the `3.9` test job and the cp39 wheel builds failed at install.

## Key insight
Only the `[dev]` extra requires 3.10+ — the runtime package does not. So rather than dropping 3.8/3.9 outright, this preserves runtime support and only drops them from *testing*.

## Changes
- **Bumps** (`pyproject.toml`): black `25.11.0`→`26.5.1`, isort `5.11.5`→`8.0.1`, mypy `1.18.1`→`2.1.0`, pytest `8.3.5`→`9.1.1`.
- **pre-commit revs** bumped in lockstep with `pyproject.toml` (black/isort/mypy).
- **Runtime support for 3.8/3.9 kept**: `requires-python = ">=3.8"`, trove classifiers, and cp38/cp39 wheels are still built and shipped.
- **Testing dropped only where dev tooling is the blocker**: `3.9` removed from the `test_crosshair` matrix; wheel *tests* skip `cp38*`/`cp39*` (extends the pre-existing cp38 skip, which was there for the same reason). Wheels themselves still build.
- **black 26 reformat**: 30 files reformatted by black 26's new stable style (purely cosmetic — mostly stripping redundant parens around tuple-unpack targets).
- **pytest 9 fix**: a generator passed to `pytest.mark.parametrize` is wrapped in `list()`, clearing a new `PytestRemovedIn10Warning`.
- Added a `pyproject.toml` note that contributing requires Python 3.10+.

## Validation
`pre-commit run --all-files` passes every hook at the new tool versions; the smoke suite passes under pytest 9.1.1.

Supersedes #441, #442, #443, #444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9V78EaWcUtDKJF7Z6MNN4