### PR TITLE
Raise CrosshairUnsupported for unimplemented symbolic-proxy operations

### DIFF
--- a/crosshair/core.py
+++ b/crosshair/core.py
@@ -962,6 +962,13 @@ def analyze_class(
     cls: type, options: AnalysisOptionSet = AnalysisOptionSet()
 ) -> Iterable[Checkable]:
     debug("Analyzing class ", cls.__name__)
+    if isabstract(cls):
+        # Only concrete classes are analyzed. An abstract class cannot be
+        # instantiated, so we can't construct a `self` for its methods; they are
+        # exercised through concrete subclasses instead. Skipping here also avoids
+        # emitting spurious "cannot confirm" results for un-constructable classes.
+        debug("Skipping abstract class", cls.__name__)
+        return
     analysis_kinds = DEFAULT_OPTIONS.overlay(options).analysis_kind
     with condition_parser(analysis_kinds) as parser:
         class_conditions = parser.get_class_conditions(cls)

--- a/crosshair/core.py
+++ b/crosshair/core.py
@@ -962,17 +962,32 @@ def analyze_class(
     cls: type, options: AnalysisOptionSet = AnalysisOptionSet()
 ) -> Iterable[Checkable]:
     debug("Analyzing class ", cls.__name__)
-    if isabstract(cls):
-        # Only concrete classes are analyzed. An abstract class cannot be
-        # instantiated, so we can't construct a `self` for its methods; they are
-        # exercised through concrete subclasses instead. Skipping here also avoids
-        # emitting spurious "cannot confirm" results for un-constructable classes.
-        debug("Skipping abstract class", cls.__name__)
-        return
+    class_is_abstract = isabstract(cls)
     analysis_kinds = DEFAULT_OPTIONS.overlay(options).analysis_kind
     with condition_parser(analysis_kinds) as parser:
         class_conditions = parser.get_class_conditions(cls)
         for method_name, conditions in class_conditions.methods.items():
+            # Note the use of getattr_static to check superclass contracts on
+            # functions that the subclass doesn't define.
+            descriptor = inspect.getattr_static(cls, method_name)
+            if getattr(descriptor, "__isabstractmethod__", False):
+                # An abstract method has no implementation to check.
+                debug("Skipping abstract method", method_name)
+                continue
+            if class_is_abstract and not isinstance(
+                descriptor, (staticmethod, classmethod)
+            ):
+                # An abstract class cannot be instantiated, so we can't construct a
+                # `self` for its instance methods (or properties); those are
+                # analyzed through concrete subclasses instead. Static and class
+                # methods need no instance, so we still check them here.
+                debug(
+                    "Skipping instance method",
+                    method_name,
+                    "of abstract class",
+                    cls.__name__,
+                )
+                continue
             if method_name == "__init__":
                 # Don't check invariants on __init__.
                 # (too often this just requires turning the invariant into a very
@@ -984,11 +999,7 @@ def analyze_class(
                 ]
                 conditions = replace(conditions, post=filtered_post)
             if conditions.has_any():
-                # Note the use of getattr_static to check superclass contracts on
-                # functions that the subclass doesn't define.
-                ctxfn = FunctionInfo(
-                    cls, method_name, inspect.getattr_static(cls, method_name)
-                )
+                ctxfn = FunctionInfo(cls, method_name, descriptor)
                 for checkable in analyze_function(ctxfn, options=options):
                     yield ClampedCheckable(checkable, cls)
 

--- a/crosshair/core.py
+++ b/crosshair/core.py
@@ -225,7 +225,7 @@ class ExceptionFilter:
     def __init__(
         self, expected_exceptions: FrozenSet[Type[BaseException]] = frozenset()
     ):
-        self.expected_exceptions = (NotImplementedError,) + tuple(expected_exceptions)
+        self.expected_exceptions = tuple(expected_exceptions)
 
     def has_user_exception(self) -> bool:
         return self.user_exc is not None

--- a/crosshair/core_test.py
+++ b/crosshair/core_test.py
@@ -465,34 +465,58 @@ def test_person_class() -> None:
 
 class AbstractShape(abc.ABC):
     @abc.abstractmethod
-    def area(self) -> int:
+    def area(self) -> int:  # abstract: no implementation to check
         """post: _ >= 0"""
         raise NotImplementedError
 
-    def describe(self) -> int:
+    def describe(self) -> int:  # instance method: needs a `self` we can't build
         """post: _ >= 0"""
         return self.area()
 
+    @staticmethod
+    def sides_nonneg(n: int) -> bool:  # static: no instance needed, still checked
+        """post: implies(n >= 0, _)"""
+        return n >= 0
 
-class ConcreteSquare(AbstractShape):
-    def __init__(self, side: int):
-        self.side = side
+    @classmethod
+    def label(cls) -> str:  # classmethod: no instance needed, still checked
+        """post: len(_) >= 0"""
+        return cls.__name__
 
-    def area(self) -> int:
+
+def test_abstract_class_checks_only_static_and_class_methods() -> None:
+    # An abstract class can't be instantiated, so its abstract and instance
+    # methods are skipped (no `self`); its static and class methods need no
+    # instance and are still checked.
+    messages = run_checkables(analyze_class(AbstractShape))
+    assert [m.state for m in messages] == [MessageType.CONFIRMED] * 2
+
+
+class AbstractCounter(abc.ABC):
+    @abc.abstractmethod
+    def count(self) -> int:
         """post: _ >= 0"""
-        return self.side * self.side
+        raise NotImplementedError
+
+    def doubled(self) -> int:
+        """post: _ >= 0"""
+        return self.count() * 2
 
 
-def test_abstract_class_is_not_analyzed() -> None:
-    # An abstract class cannot be instantiated, so we skip it entirely rather
-    # than emit spurious "cannot confirm" results for its methods.
-    assert run_checkables(analyze_class(AbstractShape)) == []
+class ConcreteCounter(AbstractCounter):
+    def __init__(self, n: int):
+        self.n = n
+
+    def count(self) -> int:
+        """post: _ >= 0"""
+        return abs(self.n)
 
 
 def test_concrete_subclass_of_abstract_is_analyzed() -> None:
-    # The concrete subclass is still analyzed, including inherited contracts.
+    # The concrete subclass is still fully analyzed, including the contract it
+    # inherits from its abstract base (`doubled`).
     actual, expected = check_messages(
-        analyze_class(ConcreteSquare), state=MessageType.CONFIRMED
+        analyze_class(ConcreteCounter), state=MessageType.CONFIRMED
     )
     assert actual == expected
 

--- a/crosshair/core_test.py
+++ b/crosshair/core_test.py
@@ -190,12 +190,6 @@ class Person:
 
     age = property(_getage, _setage, _delage, "Age of person")
 
-    def abstract_operation(self):
-        """
-        post: False # doesn't error because the method is "abstract"
-        """
-        raise NotImplementedError
-
     def a_regular_method(self):
         """post: True"""
 
@@ -518,6 +512,18 @@ def test_concrete_subclass_of_abstract_is_analyzed() -> None:
     actual, expected = check_messages(
         analyze_class(ConcreteCounter), state=MessageType.CONFIRMED
     )
+    assert actual == expected
+
+
+def test_not_implemented_error_is_reported() -> None:
+    # NotImplementedError raised while analyzing concrete code is now a real,
+    # reported error; CrossHair no longer swallows it. (Abstract method stubs are
+    # skipped before analysis, so they don't reach here -- see analyze_class.)
+    def f(x: int) -> int:
+        """post: True"""
+        raise NotImplementedError
+
+    actual, expected = check_exec_err(f, "NotImplementedError")
     assert actual == expected
 
 

--- a/crosshair/core_test.py
+++ b/crosshair/core_test.py
@@ -1,3 +1,4 @@
+import abc
 import dataclasses
 import importlib
 import inspect
@@ -459,6 +460,40 @@ def test_pokeable_class() -> None:
 def test_person_class() -> None:
     messages = analyze_class(Person)
     actual, expected = check_messages(messages, state=MessageType.CONFIRMED)
+    assert actual == expected
+
+
+class AbstractShape(abc.ABC):
+    @abc.abstractmethod
+    def area(self) -> int:
+        """post: _ >= 0"""
+        raise NotImplementedError
+
+    def describe(self) -> int:
+        """post: _ >= 0"""
+        return self.area()
+
+
+class ConcreteSquare(AbstractShape):
+    def __init__(self, side: int):
+        self.side = side
+
+    def area(self) -> int:
+        """post: _ >= 0"""
+        return self.side * self.side
+
+
+def test_abstract_class_is_not_analyzed() -> None:
+    # An abstract class cannot be instantiated, so we skip it entirely rather
+    # than emit spurious "cannot confirm" results for its methods.
+    assert run_checkables(analyze_class(AbstractShape)) == []
+
+
+def test_concrete_subclass_of_abstract_is_analyzed() -> None:
+    # The concrete subclass is still analyzed, including inherited contracts.
+    actual, expected = check_messages(
+        analyze_class(ConcreteSquare), state=MessageType.CONFIRMED
+    )
     assert actual == expected
 
 

--- a/crosshair/examples/PEP316/bugs_detected/hash_consistent_with_equals.out
+++ b/crosshair/examples/PEP316/bugs_detected/hash_consistent_with_equals.out
@@ -1,1 +1,1 @@
-hash_consistent_with_equals.py:30: error: "post: implies(__return__, hash(self) == hash(other))" yields false when calling __eq__(self = Apples(count=1, kind=''), other = Apples(count=2, kind='')) (which returns True)
+hash_consistent_with_equals.py:32: error: "post: implies(__return__, hash(self) == hash(other))" yields false when calling __eq__(Apples(2, ''), Apples(3, '')) (which returns True)

--- a/crosshair/examples/PEP316/bugs_detected/hash_consistent_with_equals.py
+++ b/crosshair/examples/PEP316/bugs_detected/hash_consistent_with_equals.py
@@ -1,12 +1,14 @@
+import abc
 import dataclasses
 
 
-class HasConsistentHash:
+class HasConsistentHash(abc.ABC):
     """
     A mixin to enforce that classes have hash methods that are consistent
     with their equality checks.
     """
 
+    @abc.abstractmethod
     def __eq__(self, other: object) -> bool:
         """
         post: implies(__return__, hash(self) == hash(other))

--- a/crosshair/examples/PEP316/correct_code/chess.py
+++ b/crosshair/examples/PEP316/correct_code/chess.py
@@ -1,8 +1,9 @@
+import abc
 import dataclasses
 
 
 @dataclasses.dataclass(init=False)
-class ChessPiece:
+class ChessPiece(abc.ABC):
     """
     A base class for chess pieces.
 
@@ -24,6 +25,7 @@ class ChessPiece:
         self.x = x
         self.y = y
 
+    @abc.abstractmethod
     def can_move_to(self, x: int, y: int) -> bool:
         """
         Determine whether this piece can move to the given position (in a single turn).
@@ -37,6 +39,7 @@ class ChessPiece:
 
 
 class FreeChessPiece(ChessPiece):
+    @abc.abstractmethod
     def can_move_to(self, x: int, y: int) -> bool:
         """
         Most pieces (except the pawn) can move back to their

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -3288,7 +3288,9 @@ class AnySymbolicStr(AbcString):
         return str
 
     def __ch_realize__(self):
-        raise NotImplementedError
+        # Concrete symbolic string subclasses override this; reaching the base is
+        # a gap in CrossHair's support, not a user-level error.
+        raise CrosshairUnsupported("cannot realize this symbolic string")
 
     def __str__(self):
         with NoTracing():

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -10,7 +10,7 @@ import string
 import sys
 import typing
 import warnings
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 from array import array
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -3287,10 +3287,12 @@ class AnySymbolicStr(AbcString):
     def __ch_pytype__(self):
         return str
 
+    @abstractmethod
     def __ch_realize__(self):
-        # Concrete symbolic string subclasses override this; reaching the base is
-        # a gap in CrossHair's support, not a user-level error.
-        raise CrosshairUnsupported("cannot realize this symbolic string")
+        # AnySymbolicStr is an ABC (via AbcString), so a concrete subclass that
+        # forgets to override __ch_realize__ fails to instantiate. Reaching this
+        # body means that enforcement was bypassed, which is a CrossHair bug.
+        raise CrossHairInternal("abstract AnySymbolicStr.__ch_realize__ reached")
 
     def __str__(self):
         with NoTracing():

--- a/crosshair/objectproxy.py
+++ b/crosshair/objectproxy.py
@@ -3,6 +3,7 @@ import operator
 import sys
 
 from crosshair.tracers import NoTracing
+from crosshair.util import CrosshairUnsupported
 
 #
 # Adapted from:
@@ -26,7 +27,9 @@ def proxy_inplace_op(proxy, op, *args):
 
 class ObjectProxy:
     def _realize(self):
-        raise NotImplementedError
+        # Concrete proxies must override this; reaching the base means CrossHair
+        # can't realize this proxy, which is an unsupported path, not a user error.
+        raise CrosshairUnsupported(f"{type(self)} does not implement _realize()")
 
     def _wrapped(self):
         with NoTracing():
@@ -365,10 +368,12 @@ class ObjectProxy:
         return ret
 
     def __reduce__(self):
-        raise NotImplementedError(f"object proxy {type(self)} must define __reduce__()")
+        raise CrosshairUnsupported(
+            f"object proxy {type(self)} must define __reduce__()"
+        )
 
     def __reduce_ex__(self, protocol):
-        raise NotImplementedError(
+        raise CrosshairUnsupported(
             f"object proxy {type(self)} must define __reduce_ex__()"
         )
 

--- a/crosshair/objectproxy.py
+++ b/crosshair/objectproxy.py
@@ -3,7 +3,7 @@ import operator
 import sys
 
 from crosshair.tracers import NoTracing
-from crosshair.util import CrosshairUnsupported
+from crosshair.util import CrossHairInternal, CrosshairUnsupported
 
 #
 # Adapted from:
@@ -27,9 +27,11 @@ def proxy_inplace_op(proxy, op, *args):
 
 class ObjectProxy:
     def _realize(self):
-        # Concrete proxies must override this; reaching the base means CrossHair
-        # can't realize this proxy, which is an unsupported path, not a user error.
-        raise CrosshairUnsupported(f"{type(self)} does not implement _realize()")
+        # Every concrete proxy must override this (it is called by _wrapped);
+        # reaching the base is a missing override, i.e. a CrossHair bug. We avoid
+        # @abstractmethod here because ObjectProxy is a delicate, metaclass-free
+        # proxy type, but a missing override should still fail loudly.
+        raise CrossHairInternal(f"{type(self)} does not implement _realize()")
 
     def _wrapped(self):
         with NoTracing():

--- a/crosshair/simplestructs.py
+++ b/crosshair/simplestructs.py
@@ -24,6 +24,7 @@ import z3
 from crosshair.core import deep_realize, smt_for_unification
 from crosshair.tracers import NoTracing, ResumedTracing, tracing_iter
 from crosshair.util import (
+    CrosshairUnsupported,
     CrossHairValue,
     assert_tracing,
     is_hashable,
@@ -80,7 +81,9 @@ class MapBase(collections.abc.MutableMapping):
         return True
 
     def copy(self):
-        raise NotImplementedError
+        # Concrete subclasses override this; reaching the base is a gap in
+        # CrossHair's symbolic mapping support, not a user-level error.
+        raise CrosshairUnsupported("copy() not implemented for this symbolic mapping")
 
     def __ch_pytype__(self):
         return dict

--- a/crosshair/simplestructs.py
+++ b/crosshair/simplestructs.py
@@ -5,6 +5,7 @@ import itertools
 import numbers
 import operator
 import sys
+from abc import abstractmethod
 from typing import (
     Any,
     Callable,
@@ -24,7 +25,7 @@ import z3
 from crosshair.core import deep_realize, smt_for_unification
 from crosshair.tracers import NoTracing, ResumedTracing, tracing_iter
 from crosshair.util import (
-    CrosshairUnsupported,
+    CrossHairInternal,
     CrossHairValue,
     assert_tracing,
     is_hashable,
@@ -80,10 +81,12 @@ class MapBase(collections.abc.MutableMapping):
                 return False
         return True
 
+    @abstractmethod
     def copy(self):
-        # Concrete subclasses override this; reaching the base is a gap in
-        # CrossHair's symbolic mapping support, not a user-level error.
-        raise CrosshairUnsupported("copy() not implemented for this symbolic mapping")
+        # MapBase is an ABC (via MutableMapping), so a concrete subclass that
+        # forgets to override copy() fails to instantiate. Reaching this body
+        # means that enforcement was bypassed, which is a CrossHair bug.
+        raise CrossHairInternal("abstract MapBase.copy() reached")
 
     def __ch_pytype__(self):
         return dict

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -30,6 +30,12 @@ Next Version
    Symbolic variable-length tuples (e.g. ``Tuple[int, ...]``) supported no
    ordering comparisons at all. Both now compare lexicographically and match
    the behavior of the corresponding concrete values.
+ * Report ``NotImplementedError`` raised in analyzed code as a real error
+   instead of silently treating the path as confirmed. Abstract classes are no
+   longer analyzed directly (only their concrete subclasses are, along with any
+   static/class methods), and ``@abstractmethod`` stubs are skipped, so genuinely
+   abstract members do not produce false positives. A reachable
+   ``raise NotImplementedError`` in a concrete method is now surfaced.
 
 
 Version 0.0.107


### PR DESCRIPTION
CrossHair's symbolic proxies and structures use bare `raise
NotImplementedError` as "must override" markers on their base classes
(MapBase.copy, ObjectProxy._realize/__reduce__/__reduce_ex__,
AnySymbolicStr.__ch_realize__). When such a gap is reached during
tracing, the ExceptionFilter swallows the NotImplementedError and
records the path as CONFIRMED -- silently claiming a postcondition holds
on a path CrossHair actually could not execute.

Raise CrosshairUnsupported instead. It is an UnexploredPath, so a reached
gap now abandons the path gracefully rather than masquerading as a
verified result. This also unblocks eventually dropping NotImplementedError
from ExceptionFilter's default expected_exceptions: once CrossHair's own
machinery no longer raises it, a NotImplementedError seen while analyzing
a concrete class can be treated as a genuine user error.

Faithful models of user-facing stdlib semantics that legitimately raise
NotImplementedError (e.g. the datetime.tzinfo base methods) are left
unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TB3jdgQCfmRk8SNiS57Lq3