### PR TITLE
Label grey support-map cells with a reason instead of dropping them

### DIFF
--- a/crosshair/tools/measure_support.py
+++ b/crosshair/tools/measure_support.py
@@ -587,11 +587,18 @@ def measure_op(
     (the op returns None -- likely an in-place mutator) and the receiver type is
     mutable, retry the mutation path: invert the post-call receiver state.
     ``example`` is a runnable crosshair-web source (or None).  Returns color "?"
-    when nothing is drivable, and None when nothing could be synthesized.
+    (with a reason) when nothing is drivable or synthesizable; only returns None
+    when nothing at all could be attempted (no synthesizable call is now itself a
+    labeled "?" so it renders as an explained grey cell rather than a bare gap).
     """
     cands = _synth_candidates(typ, method, module)
-    if not cands:
-        return None
+    if not cands:  # no drivable call -- label it so the grey cell explains itself
+        reason = (
+            "no signature: skipped dunder"
+            if method in SKIP_DUNDERS
+            else "no signature: no synthesizable call"
+        )
+        return ("?", reason, None)
     # Keep the builtin seedkey byte-identical (it feeds the fuzz seed); qualify it
     # with the module only for stdlib classes (where names can collide).
     seedkey = (
@@ -624,16 +631,18 @@ def measure_op(
 
 
 def measure_func(module: str, func: str) -> Optional[Tuple[str, str, Optional[str]]]:
-    """(color, verdict, example) for a module-level function, or None if nothing
-    could be synthesized / it isn't in this runtime."""
+    """(color, verdict, example) for a module-level function.  A function that is
+    typeshed-known but absent from this runtime, or that has no synthesizable call,
+    now returns a labeled "?" (an explained grey cell) rather than None -- so these
+    show up in the JSON and reconcile with the on-screen grey count."""
     try:  # latest typeshed may stub functions absent from the running interpreter
         if not hasattr(importlib.import_module(module), func):
-            return None
+            return ("?", "not in runtime: absent from interpreter", None)
     except Exception:
-        return None
+        return ("?", "not in runtime: module import failed", None)
     cands = _func_candidate_sigs(module, func)
     if not cands:
-        return None
+        return ("?", "no signature: no synthesizable call", None)
     seedkey = f"{module}.{func}"
     if seedkey in _NOT_A_VALUE_FUNCTION:
         return ("?", "not a pure value function", None)
@@ -662,7 +671,8 @@ def measure_func(module: str, func: str) -> Optional[Tuple[str, str, Optional[st
         if color != "?":
             return (color, verdict, demo)
         deferred = (color, verdict, None)
-    return deferred
+    # every candidate raised while resolving arguments -> no drivable call at all
+    return deferred or ("?", "no signature: no resolvable arguments", None)
 
 
 def func_surface(module: str) -> List[str]:


### PR DESCRIPTION
## Summary

The support treemap (`measure_support.py` → `generate_treemap.py`) greys a cell in two situations: the op's JSON record has `color:"?"`, **or** the op has *no record at all* (the renderer falls back to grey). The second case was a blind spot — those cells were mis-tallied as worker "skips," carried no reason, and were indistinguishable from a genuinely crashed/timed-out worker.

This PR (Tier 1 of a planned effort) makes `measure_op`/`measure_func` return a **labeled** `("?", <reason>, None)` record instead of `None` whenever an op has no drivable call. Now:

- every grey cell explains itself (the verdict renders as hover text — **no renderer change needed**),
- the JSON is complete,
- the run's `defer(?)` tally reconciles with the on-screen grey count,
- `res is None` cleanly means **only** a crashed/timed-out worker.

### New reason labels
- `measure_op`: `no signature: skipped dunder`, `no signature: no synthesizable call`
- `measure_func`: `not in runtime: absent from interpreter`, `not in runtime: module import failed`, `no signature: no synthesizable call`, `no signature: no resolvable arguments` (all-candidates-fail-to-resolve tail)

Smoke-tested: `int.__class__ → ("?", "no signature: skipped dunder")`, a bogus function → `"not in runtime: absent from interpreter"`, real ops (`math.gcd → green`) unchanged.

## Findings — full grey-cell catalog

Ran `surface` + `funcs` + `methods` (`--jobs 4`) after the change. The reconciliation is visible in the tallies: `defer(?)` rose to 43 / 315 / 912 while `skipped` collapsed to 1 / 4 / 6.

**1270 grey cells total, by reason:**

| Reason | Count | % | Category |
|---|--:|--:|---|
| `no signature: no synthesizable call` | **663** | 52% | newly labeled |
| `no valid input found` | **415** | 33% | already labeled |
| `not in runtime: absent from interpreter` | 65 | 5% | newly labeled |
| `output not comparable` | 58 | 5% | already labeled |
| `no signature: skipped dunder` | 39 | 3% | newly labeled |
| `nondeterministic output` | 15 | 1% | already labeled |
| `couldn't run` | 12 | 1% | already labeled |
| `not a pure value function` | 3 | <1% | already labeled |

Per-map grey/total: **surface** 43/439 · **funcs** 315/676 · **methods** 912/1364.

**767 cells (60% of all grey) were previously invisible** — mis-tallied as worker skips and dropped from the JSON. They now carry a reason.

### Reading the dominant buckets
- **`no synthesizable call` (663, biggest lever)** — typeshed gives a signature but no drivable call comes out (operator form needs an arg the sig doesn't supply, or `_resolve_arg`/`_ann` raised for every candidate). Sample: `array.array.__add__/__lt__/__or__`, `array.array.fromfile/tofile`, `ast.copy_location/dump/iter_child_nodes`. Splits into genuinely-not-synthesizable (I/O, AST node graphs) vs. fuzzer-gaps we could close (numeric-array operators look very fixable).
- **`no valid input found` (415)** — the call *is* synthesizable but 12 fuzz examples across sizes 1–5 never produced a valid, non-degenerate input. `array.array` dominates again → a `crosshair.inputgen` strategy-coverage gap, not a measurement bug.
- **`not in runtime: absent` (65)** — pure noise: typeshed re-exports (`overload`, `final`, `type_check_only`, `disjoint_base`) leaking through `_module_funcs`. Arguably shouldn't be on the map at all.

## Next steps (not in this PR)
- [ ] **Tier 2:** thread a reason through the worker layer so genuine skips write `{"color":"?","verdict":"skipped: timeout 90s" / "crashed"}` records, distinguishing timeout (SIGKILL past `_PER_TASK_TIMEOUT`) from worker-loop crash. Fully reconciles the tally.
- [ ] **Filter typeshed re-export noise** (`overload`/`final`/`type_check_only`/`disjoint_base`/…) out of the funcs surface — easy ~65-cell win.
- [ ] **Close `array.array` fuzzer gaps** in `crosshair.inputgen` — it's the single biggest concentration across both `no synthesizable call` and `no valid input found`.
- [ ] **Per-module/type reason breakdown** to pinpoint where the fuzzer gaps concentrate beyond `array`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017khpHqbNNZWmY4kA3ToRhp
