### PR TITLE
Reclaim grey support-map cells: label, construct, mutate, and resolve

### DIFF
--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -526,11 +526,34 @@ def _stub_class(name: str, module: str = "builtins", _depth: int = 0) -> Optiona
     return None
 
 
+def _base_ref(base: Any, default_mod: str) -> Optional[Tuple[str, str]]:
+    """(base_class_name, module_to_resolve_it_in) for a base-class AST node.
+
+    A bare ``Name`` (``class Fraction(Rational)``) resolves in the current class's
+    module (and _stub_class follows any re-export from there).  A dotted
+    ``Attribute`` (``class RegexFlag(enum.IntFlag)``) resolves its final attr in the
+    *qualifier* module -- ``enum`` here, ``os.path`` for ``os.path.X`` -- so bases
+    imported as ``import enum`` (not ``from enum import IntFlag``) still follow to
+    where the class is actually defined instead of dead-ending in the child module."""
+    if isinstance(base, _ast.Name):
+        return (base.id, default_mod)
+    if isinstance(base, _ast.Attribute):
+        parts = []
+        node: Any = base.value
+        while isinstance(node, _ast.Attribute):
+            parts.append(node.attr)
+            node = node.value
+        if isinstance(node, _ast.Name):
+            parts.append(node.id)
+            return (base.attr, ".".join(reversed(parts)))
+    return None
+
+
 def _class_chain(cls_name: str, module: str = "builtins") -> List[Any]:
     """Typeshed MRO for cls_name: derived-first class NameInfos, following declared
-    bases by name (subscripts stripped), with ``object`` always last.  ``module`` is
-    the class's owning module; base names are resolved in the module where each
-    class is actually found (so cross-module bases resolve)."""
+    bases (subscripts stripped), with ``object`` always last.  ``module`` is the
+    class's owning module; each base resolves in the module named by its qualifier
+    (dotted bases) or the module where the current class was found (bare names)."""
     chain: List[Any] = []
     seen: Set[str] = set()
 
@@ -545,11 +568,9 @@ def _class_chain(cls_name: str, module: str = "builtins") -> List[Any]:
         chain.append(ni)
         for b in ni.ast.bases:
             base = b.value if isinstance(b, _ast.Subscript) else b
-            bname = (
-                base.id if isinstance(base, _ast.Name) else getattr(base, "attr", None)
-            )
-            if bname and bname not in ("Generic", "Protocol"):
-                visit(bname, found_mod)
+            ref = _base_ref(base, found_mod)
+            if ref and ref[0] not in ("Generic", "Protocol"):
+                visit(*ref)
 
     visit(cls_name, module)
     if "object" not in seen:
@@ -799,6 +820,20 @@ def _ann(s: str) -> Any:
             if not name or name in ns:
                 raise
             ns[name] = importlib.import_module(name)
+        except AttributeError:
+            # The leading name resolved to the WRONG object -- ANN_NS derives from
+            # vars(typing), which carries typing's deprecated submodule aliases
+            # (typing.re, typing.io), so "re.RegexFlag" hits typing.re (no RegexFlag)
+            # instead of the stdlib re.  Rebind the leading name to the real module
+            # and retry; bail if it's already real or not an importable module.
+            head = s.split("[", 1)[0].split(".", 1)[0]
+            try:
+                real = importlib.import_module(head)
+            except ImportError:
+                raise
+            if ns.get(head) is real:
+                raise
+            ns[head] = real
     return eval(s, ns)
 
 

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -800,8 +800,11 @@ def _candidate_sigs(
 ) -> List[List[Tuple[str, str, Tuple[Any, ...]]]]:
     """Candidate signatures per typeshed overload of typ.method (see _overload_sigs).
     ``module`` is the type's owning module; for a non-builtin class the receiver
-    carries no element-TypeVar binds and arg annotations resolve against ``module``."""
-    binds = RECV.get(typ, (f"{module}.{typ.__name__}", {}))[1]
+    carries no element-TypeVar binds and arg annotations resolve against ``module``.
+    ``Self`` binds to the receiver's own annotation, so methods taking another
+    instance (ipaddress ``subnet_of(other: Self)``, ...) become drivable."""
+    recv_ann, recv_binds = RECV.get(typ, (f"{module}.{typ.__name__}", {}))
+    binds = {"Self": recv_ann, **recv_binds}
     return _overload_sigs(
         _method_overloads(typ, method, module), binds, module, ("self",)
     )

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -80,10 +80,12 @@ OP_DUNDERS = [
 
 
 def surface(typ: type) -> List[str]:
+    # Public methods only: drop every underscore-prefixed name -- both dunders (the
+    # operators we want are re-added from OP_DUNDERS below) and single-underscore
+    # privates (`_check_int_address`, `_ip_int_from_string`, ...), which are internal
+    # implementation details typeshed doesn't annotate and aren't part of the surface.
     methods = [
-        n
-        for n in dir(typ)
-        if not n.startswith("__") and callable(getattr(typ, n, None))
+        n for n in dir(typ) if not n.startswith("_") and callable(getattr(typ, n, None))
     ]
     return sorted(methods) + [n for n in OP_DUNDERS if hasattr(typ, n)]
 
@@ -642,6 +644,10 @@ _NAME_MAP = {
     "SupportsRound": "int",
     "SupportsRichComparison": "int",
     "SupportsRichComparisonT": "int",
+    "_SupportsComparison": "int",
+    "_SupportsInversion": "int",
+    "SupportsAdd": "int",
+    "SupportsRAdd": "int",
     "_HashableT": "int",
     "Hashable": "int",
     "_MultiplicableT1": "int",
@@ -656,12 +662,18 @@ _NAME_MAP = {
     "_T2": "int",
     "_KT": "int",
     "_VT": "int",
+    "_K": "int",
+    "_V": "int",
     "_T_co": "int",
     "_T_contra": "int",
-    # string / buffer families
+    # string / buffer / path families
     "AnyStr": "str",
     "StrOrLiteralStr": "str",
+    "AnyOrLiteralStr": "str",
     "StrPath": "str",
+    "StrOrBytesPath": "str",
+    "FileDescriptorOrPath": "str",
+    "PathLike": "str",
     "_AsciiBuffer": "bytes",
     "WriteableBuffer": "bytes",
 }
@@ -702,7 +714,15 @@ def _map_ann(node: Any, binds: Dict[str, str]) -> str:
         )
         sl = node.slice
         elts = sl.elts if isinstance(sl, _ast.Tuple) else [sl]
-        if base in ("Iterable", "Sequence", "Collection", "list", "List"):
+        if base in (
+            "Iterable",
+            "Sequence",
+            "Collection",
+            "MutableSequence",
+            "Container",
+            "list",
+            "List",
+        ):
             return f"List[{_map_ann(elts[0], binds)}]"
         if base in (
             "set",
@@ -734,6 +754,13 @@ def _map_ann(node: Any, binds: Dict[str, str]) -> str:
                 if isinstance(c, _ast.Constant) and c.value is not None:
                     return _map_ann(_ast.Name(id=type(c.value).__name__), binds)
             raise _Unsupported("Literal")
+        # a subscripted scalar protocol/TypeVar (SupportsAbs[_T], PathLike[AnyStr],
+        # _SupportsInversion[_T_co], ...): the element type doesn't change how we
+        # fuzz it, so fall back to the base name's scalar mapping.
+        if base in binds:
+            return binds[base]
+        if base in _NAME_MAP:
+            return _NAME_MAP[base]
         raise _Unsupported(base)
     raise _Unsupported(type(node).__name__)
 

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -908,6 +908,29 @@ def _module_alias_annstr(module: str) -> Dict[str, str]:
     if module not in _ALIAS_ANNSTR:
         resolved: Dict[str, str] = {}
         _ALIAS_ANNSTR[module] = resolved
+        # Seed with the module's own public classes, so a bare-Name arg referring to
+        # a sibling type (datetime.date taking `timedelta`/`datetime`, decimal /
+        # ipaddress / fractions methods taking their peers, ...) resolves to a
+        # qualified, fuzzable annotation.  Module-scoped (folded into binds only when
+        # resolving THIS module's args), so it doesn't pollute the global _NAME_MAP;
+        # over-broad is safe, since fuzz-validation drops any candidate that can't run.
+        # Also lets the alias pass below chain private aliases (_Date = date, ...).
+        try:
+            mod = importlib.import_module(module)
+        except Exception:
+            mod = None
+        if mod is not None:
+            for cname, cni in _stub_names(module).items():
+                # Skip names _NAME_MAP already handles: it deliberately simplifies
+                # some builtins (object/memoryview -> int/bytes) to keep fuzzing
+                # cheap, and seeding "builtins.object" here would override that and
+                # feed arbitrary heavy objects into every Iterable[object] arg.
+                if cname in _NAME_MAP or cname.startswith("_"):
+                    continue
+                if isinstance(cni.ast, _ast.ClassDef) and isinstance(
+                    getattr(mod, cname, None), type
+                ):
+                    resolved[cname] = f"{module}.{cname}"
         raw: Dict[str, Any] = {}
         for name, ni in _stub_names(module).items():
             node = ni.ast

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -186,6 +186,179 @@ ANN_NS = vars(typing) | {
 }
 
 
+# ---------------------------------------------------------------------------
+# Explicit construction strategies for stdlib types Hypothesis's from_type can't
+# build.  from_type falls back to builds(cls), which needs an introspectable
+# signature or annotated fields.  C-extension types hide their signature
+# (inspect.signature(array.array) raises "no signature found for builtin type")
+# and the stdlib namedtuples expose fields but carry no annotations (ParseResult,
+# DecimalTuple, struct_time), so builds() calls the constructor with zero
+# arguments and raises.  Without a strategy for the receiver, every method of such
+# a type measures as an empty "no valid input found" grey cell -- and no number of
+# fuzz attempts ever helps, because the strategy can't be built in the first place.
+# sized() consults this registry before its from_type fallback, so both the
+# support map and valid_inputs() get real receivers.  Each factory takes the size
+# n so the constructed value grows with the sweep.
+# ---------------------------------------------------------------------------
+def _small_ints(n: int) -> "st.SearchStrategy[int]":
+    return st.integers(min_value=-(10**n), max_value=10**n)
+
+
+def _array_strategy(n: int) -> "st.SearchStrategy[Any]":
+    import array
+
+    signed = st.integers(min_value=-100, max_value=100)  # fits the narrowest ('b')
+    unsigned = st.integers(min_value=0, max_value=200)  # fits the narrowest ('B')
+    codes = {
+        "b": signed,
+        "h": signed,
+        "i": signed,
+        "l": signed,
+        "q": signed,
+        "B": unsigned,
+        "H": unsigned,
+        "I": unsigned,
+        "L": unsigned,
+        "Q": unsigned,
+        "f": st.floats(allow_nan=False, allow_infinity=False, width=32),
+        "d": st.floats(allow_nan=False, allow_infinity=False),
+    }
+
+    def make(code: str) -> "st.SearchStrategy[Any]":
+        return st.lists(codes[code], min_size=n, max_size=n).map(
+            lambda xs: array.array(code, xs)
+        )
+
+    return st.sampled_from(list(codes)).flatmap(make)
+
+
+def _struct_time_strategy(n: int) -> "st.SearchStrategy[Any]":
+    import time
+
+    return st.tuples(
+        st.integers(1970, 2038),
+        st.integers(1, 12),
+        st.integers(1, 28),
+        st.integers(0, 23),
+        st.integers(0, 59),
+        st.integers(0, 61),
+        st.integers(0, 6),
+        st.integers(1, 366),
+        st.integers(-1, 1),
+    ).map(time.struct_time)
+
+
+def _decimaltuple_strategy(n: int) -> "st.SearchStrategy[Any]":
+    from decimal import DecimalTuple  # (sign, digits, exponent)
+
+    return st.builds(
+        DecimalTuple,
+        st.sampled_from((0, 1)),
+        st.lists(st.integers(0, 9), min_size=1, max_size=max(n, 1)).map(tuple),
+        st.integers(min_value=-(n + 1), max_value=n + 1),
+    )
+
+
+def _namedtuple_strategy(cls: type, elem: Any) -> Any:
+    """A factory building ``cls`` from one ``elem(n)`` strategy per field -- for the
+    stdlib namedtuples (urllib.parse results) whose unannotated fields defeat builds().
+    """
+
+    def factory(n: int) -> "st.SearchStrategy[Any]":
+        return st.builds(cls, *[elem(n) for _ in cls._fields])  # type: ignore[attr-defined]
+
+    return factory
+
+
+def _deque_strategy(n: int) -> "st.SearchStrategy[Any]":
+    from collections import deque
+
+    return st.lists(_small_ints(1), min_size=n, max_size=n).map(deque)
+
+
+def _userlist_strategy(n: int) -> "st.SearchStrategy[Any]":
+    from collections import UserList
+
+    return st.lists(_small_ints(1), min_size=n, max_size=n).map(UserList)
+
+
+def _userstring_strategy(n: int) -> "st.SearchStrategy[Any]":
+    from collections import UserString
+
+    return st.text(min_size=n, max_size=n).map(UserString)
+
+
+def _dict_map_strategy(ctor: Any) -> Any:
+    """A factory building ``ctor(dict)`` -- for OrderedDict/UserDict/Counter/ChainMap,
+    all of which accept a single mapping positional argument."""
+
+    def factory(n: int) -> "st.SearchStrategy[Any]":
+        return st.dictionaries(
+            _small_ints(1), _small_ints(1), min_size=n, max_size=n
+        ).map(ctor)
+
+    return factory
+
+
+def _defaultdict_strategy(n: int) -> "st.SearchStrategy[Any]":
+    from collections import defaultdict  # first arg must be a callable default_factory
+
+    return st.dictionaries(_small_ints(1), _small_ints(1), min_size=n, max_size=n).map(
+        lambda d: defaultdict(int, d)
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def _type_strategies() -> Dict[type, Any]:
+    import array
+    from collections import (
+        ChainMap,
+        Counter,
+        OrderedDict,
+        UserDict,
+        UserList,
+        UserString,
+        defaultdict,
+        deque,
+    )
+    from decimal import DecimalTuple
+    from time import struct_time
+    from urllib.parse import (
+        DefragResult,
+        DefragResultBytes,
+        ParseResult,
+        ParseResultBytes,
+        SplitResult,
+        SplitResultBytes,
+    )
+
+    def text(n: int) -> "st.SearchStrategy[Any]":
+        return st.text(max_size=max(n, 1))
+
+    def binary(n: int) -> "st.SearchStrategy[Any]":
+        return st.binary(max_size=max(n, 1))
+
+    return {
+        array.array: _array_strategy,
+        deque: _deque_strategy,
+        UserList: _userlist_strategy,
+        UserString: _userstring_strategy,
+        OrderedDict: _dict_map_strategy(OrderedDict),
+        UserDict: _dict_map_strategy(UserDict),
+        Counter: _dict_map_strategy(Counter),
+        ChainMap: _dict_map_strategy(ChainMap),
+        defaultdict: _defaultdict_strategy,
+        struct_time: _struct_time_strategy,
+        DecimalTuple: _decimaltuple_strategy,
+        ParseResult: _namedtuple_strategy(ParseResult, text),
+        SplitResult: _namedtuple_strategy(SplitResult, text),
+        DefragResult: _namedtuple_strategy(DefragResult, text),
+        ParseResultBytes: _namedtuple_strategy(ParseResultBytes, binary),
+        SplitResultBytes: _namedtuple_strategy(SplitResultBytes, binary),
+        DefragResultBytes: _namedtuple_strategy(DefragResultBytes, binary),
+    }
+
+
 def sized(ann: Any, n: int) -> "st.SearchStrategy[Any]":
     origin = typing.get_origin(ann)
     if ann is int:
@@ -217,6 +390,10 @@ def sized(ann: Any, n: int) -> "st.SearchStrategy[Any]":
     if origin in (dict, typing.Dict):
         a = typing.get_args(ann) or (int, int)
         return st.dictionaries(sized(a[0], 1), sized(a[1], 1), min_size=n, max_size=n)
+    if isinstance(ann, type):  # stdlib types from_type can't construct (see registry)
+        factory = _type_strategies().get(ann)
+        if factory is not None:
+            return factory(n)
     return st.from_type(ann)
 
 

--- a/crosshair/tools/measure_support.py
+++ b/crosshair/tools/measure_support.py
@@ -493,8 +493,6 @@ def _synth_candidates(
     return cands
 
 
-MUTABLE = (list, dict, set, bytearray)
-
 # Ops whose result is NOT a function of their declared arguments -- it's an
 # object identity / address.  CrossHair's inversion "confirms" no input yields
 # the (address-valued) output that one demonstrably does, which we'd misread as a
@@ -619,14 +617,19 @@ def measure_op(
         if color != "?":  # this candidate produced valid inputs -> trust it
             return (color, verdict, demo)
         deferred = (color, verdict, None)
-    if typ in MUTABLE:  # value path found nothing -> measure as an in-place mutator
-        for params, expr, header in cands:
-            color, verdict, demo = _sweep(
-                params, expr, header, module, seedkey, defer_on_norun=True, mut=True
-            )
-            if color != "?":
-                return (color, (verdict + " [mut]").strip(), demo)
-            deferred = (color, verdict, None)
+    # The value path found nothing (the op returns None) -> measure it as an
+    # in-place mutator, for EVERY type rather than a hardcoded mutable set.
+    # fuzz_valid_mut only keeps an input whose call actually changes the receiver
+    # (deepcopy pre/post compare), so an immutable type just yields no sample and
+    # keeps deferring -- the mutation detection IS the gate, so we don't maintain a
+    # separate list that would silently drop mutators of any unlisted type.
+    for params, expr, header in cands:
+        color, verdict, demo = _sweep(
+            params, expr, header, module, seedkey, defer_on_norun=True, mut=True
+        )
+        if color != "?":
+            return (color, (verdict + " [mut]").strip(), demo)
+        deferred = (color, verdict, None)
     return deferred
 
 

--- a/crosshair/tools/measure_support.py
+++ b/crosshair/tools/measure_support.py
@@ -943,14 +943,18 @@ STDLIB_MODULES = (
 
 
 def cmd_funcs(args: argparse.Namespace) -> None:
-    """Measure module-level (free) functions in the given stdlib modules."""
+    """Measure module-level (free) functions in the given stdlib modules.
+
+    Draws the surface from ``func_surface`` (not raw ``_module_funcs``) so the
+    measured set matches exactly what ``generate_treemap`` renders.  ``_module_funcs``
+    follows typeshed re-exports, which drags in typing/abc decorators the stubs
+    import but the runtime module never defines (``overload``, ``final``,
+    ``type_check_only``, ``disjoint_base``, ``abstractmethod`` -- 65 such cells across
+    the default corpus).  Those were measured as noise ``"?"`` records that never
+    appeared on the map; ``func_surface`` drops any name absent/uncallable at
+    runtime, so they no longer inflate the tally or the JSON."""
     modules = args.modules.split(",") if args.modules else STDLIB_MODULES
-    tasks = [
-        (module, name)
-        for module in modules
-        for name in sorted(_module_funcs(module))
-        if not name.startswith("_")
-    ]
+    tasks = [(module, name) for module in modules for name in func_surface(module)]
     _measure_cmd(args, tasks, _func_task, 36)
 
 

--- a/crosshair/tools/measure_support.py
+++ b/crosshair/tools/measure_support.py
@@ -587,11 +587,18 @@ def measure_op(
     (the op returns None -- likely an in-place mutator) and the receiver type is
     mutable, retry the mutation path: invert the post-call receiver state.
     ``example`` is a runnable crosshair-web source (or None).  Returns color "?"
-    when nothing is drivable, and None when nothing could be synthesized.
+    (with a reason) when nothing is drivable or synthesizable; only returns None
+    when nothing at all could be attempted (no synthesizable call is now itself a
+    labeled "?" so it renders as an explained grey cell rather than a bare gap).
     """
     cands = _synth_candidates(typ, method, module)
-    if not cands:
-        return None
+    if not cands:  # no drivable call -- label it so the grey cell explains itself
+        reason = (
+            "no signature: skipped dunder"
+            if method in SKIP_DUNDERS
+            else "no signature: no synthesizable call"
+        )
+        return ("?", reason, None)
     # Keep the builtin seedkey byte-identical (it feeds the fuzz seed); qualify it
     # with the module only for stdlib classes (where names can collide).
     seedkey = (
@@ -624,16 +631,18 @@ def measure_op(
 
 
 def measure_func(module: str, func: str) -> Optional[Tuple[str, str, Optional[str]]]:
-    """(color, verdict, example) for a module-level function, or None if nothing
-    could be synthesized / it isn't in this runtime."""
+    """(color, verdict, example) for a module-level function.  A function that is
+    typeshed-known but absent from this runtime, or that has no synthesizable call,
+    now returns a labeled "?" (an explained grey cell) rather than None -- so these
+    show up in the JSON and reconcile with the on-screen grey count."""
     try:  # latest typeshed may stub functions absent from the running interpreter
         if not hasattr(importlib.import_module(module), func):
-            return None
+            return ("?", "not in runtime: absent from interpreter", None)
     except Exception:
-        return None
+        return ("?", "not in runtime: module import failed", None)
     cands = _func_candidate_sigs(module, func)
     if not cands:
-        return None
+        return ("?", "no signature: no synthesizable call", None)
     seedkey = f"{module}.{func}"
     if seedkey in _NOT_A_VALUE_FUNCTION:
         return ("?", "not a pure value function", None)
@@ -662,7 +671,8 @@ def measure_func(module: str, func: str) -> Optional[Tuple[str, str, Optional[st
         if color != "?":
             return (color, verdict, demo)
         deferred = (color, verdict, None)
-    return deferred
+    # every candidate raised while resolving arguments -> no drivable call at all
+    return deferred or ("?", "no signature: no resolvable arguments", None)
 
 
 def func_surface(module: str) -> List[str]:


### PR DESCRIPTION
## Summary

Continues the support-map work from #452. It **includes #452's commit** (`ce559ef`, the Tier-1 "label grey cells with a reason" change) as its base and stacks eight more commits that actually *reclaim* those grey cells — cutting the total from **~1270 → 651 (−49%)**, and moving the remainder toward honest, by-design greys.

> Relationship to #452: this branch is a superset of #452. Merging this makes #452 redundant (or #452 can merge first and this rebases cleanly onto it — its one commit is the shared base).

## What each commit does

| Commit | Change | Effect |
|---|---|---|
| `ce559ef` | *(from #452)* label grey cells with a reason instead of dropping them | Tier-1 base |
| `ee5408c` | Filter typeshed re-export noise (`overload`/`final`/…) from the funcs surface | −65 noise cells |
| `e48b904` | Construction strategies for stdlib types `from_type` can't build (`array.array`, the `urllib.parse` namedtuples, `collections` containers, `DecimalTuple`, `struct_time`) | `no valid input found` 420 → ~216 |
| `19f2ebb` | Measure in-place mutators of **any** type instead of a hardcoded `MUTABLE` set (the mutation detector already existed; the static list only suppressed it) | +~91 container-mutator cells |
| `9ade1a5` | Fix two typeshed-resolution bugs: dotted base classes (`class RegexFlag(enum.IntFlag)`) and the `typing.re`/`typing.io` namespace collision | `re.RegexFlag` (~37) |
| `c4da003` | Bind `Self` so methods taking another instance resolve (`ipaddress` `subnet_of`/`supernet_of`/…) | ~36 cells |
| `c6a95e2` | Drop single-underscore private methods from the surface; resolve more argument annotations (subscripted protocols, `MutableSequence`/`Container`, path aliases) | −198 (`os.path`, `operator`, privates) |
| `e3954db` | Resolve sibling-type arguments within a module (datetime arithmetic/comparisons; generalizes to decimal/fractions/ipaddress) | ~40 cells |

## Where the greys went

- `no valid input found`: **420 → 184** (construction strategies + mutation-path generalization)
- `no signature: no synthesizable call`: **~663 → 325** (typeshed-resolution fixes + private-method filtering)
- The remaining 651 are increasingly *correct* greys: `output not comparable` (98, opaque digests/codecs), `skipped dunder` (39), `nondeterministic`/`not-a-value-function` (5) — ~142 that should stay grey — plus a scattered `no synthesizable call` tail (`operator` slice/callable args, `fractions`, `codecs`).

## A soundness bug this surfaced

Generalizing the mutation path lit up `array.array` mutators as false-"unsound" black cells. Investigation traced it to a real CrossHair bug — mutating a symbolic `array.array` then comparing it to a **concrete** `array.array` falsely confirms inequality (`list`/`deque` are fine). Filed as **#453** with a minimal repro; it's not addressed here.

## Testing

- `patch_equivalence_test` (8526+) and `fuzz_core_test` (386) pass on every commit.
- `black`, `isort`, `flake8`, `mypy` clean on the touched files.
- Each recovery was verified with real (un-stubbed) measurements landing genuine green/yellow/red verdicts (e.g. `array.array.count`→green, `posixpath.join`→green, `date.__add__`→green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011JgyHmgK4djQonjcbcgB9B)_