### PR TITLE
Unify operation classification into one auditable catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # CrossHair
 
 [![Join the chat on Discord](https://img.shields.io/discord/1346219754519789719?logo=discord&logoColor=white)](https://discord.gg/rUeTaYTWbb)
-[![Check status](https://github.com/pschanely/CrossHair/actions/workflows/check.yml/badge.svg?branch=main&event=push)](https://github.com/pschanely/CrossHair/actions?query=workflow%3ACheck+event%3Apush)
+[![Check status](https://github.com/pschanely/CrossHair/actions/workflows/test_crosshair.yml/badge.svg?branch=main&event=push)](https://github.com/pschanely/CrossHair/actions?query=workflow%3ACheck+event%3Apush)
 [![Downloads](https://static.pepy.tech/badge/crosshair-tool/week)](https://pepy.tech/project/crosshair-tool)
 
 An analysis tool for Python that blurs the line between testing and

--- a/crosshair/auditwall.py
+++ b/crosshair/auditwall.py
@@ -177,6 +177,7 @@ def make_handler(event: str) -> Callable[[str, Tuple], None]:
 
 _HANDLERS: Dict[str, Callable[[str, Tuple], None]] = {}
 _ENABLED = True
+_HOOK_INSTALLED = False
 
 
 def audithook(event: str, args: Tuple) -> None:
@@ -198,6 +199,32 @@ def opened_auditwall() -> Generator:
         yield
     finally:
         _ENABLED = True
+
+
+@contextmanager
+def enabled_auditwall() -> Generator:
+    """Enable the auditwall just for the duration of this context.
+
+    Installs the audit hook (with default, maximally-restrictive config) if it
+    isn't engaged yet, and restores the prior active state on exit -- so a wall
+    that was dormant (never engaged, or opened) stays dormant afterward, and one
+    already engaged (possibly with custom ``--unblock`` prefixes) keeps its config
+    untouched. Use this to police a short, self-contained region for side effects
+    (e.g. probing whether an operation reaches for I/O), without leaving the wall
+    active for surrounding work.
+
+    Deliberately takes no ``allow_prefixes``: reconfiguring the global handler
+    table isn't something a temporary scope can cleanly restore, so prefix config
+    is left to ``engage_auditwall`` at startup."""
+    global _ENABLED
+    was_active = _HOOK_INSTALLED and _ENABLED
+    if not _HOOK_INSTALLED:
+        engage_auditwall()
+    _ENABLED = True
+    try:
+        yield
+    finally:
+        _ENABLED = was_active
 
 
 def _make_prefix_based_handler(
@@ -242,11 +269,13 @@ def _update_special_handlers(allow_prefixes: Sequence[str]) -> None:
 
 
 def engage_auditwall(allow_prefixes: Sequence[str] = ()) -> None:
+    global _HOOK_INSTALLED
     if "EVERYTHING" in allow_prefixes:
         return
     _update_special_handlers(allow_prefixes)
     sys.dont_write_bytecode = True  # disable .pyc file writing
     sys.addaudithook(audithook)
+    _HOOK_INSTALLED = True
 
 
 def disable_auditwall() -> None:

--- a/crosshair/behavior_compare.py
+++ b/crosshair/behavior_compare.py
@@ -352,12 +352,6 @@ _UNSUPPORTED = object()  # pinned fine, but the op rejected the symbolic proxy
 _DIFF_MAX_PIN_ITERS = 80
 _DIFF_PIN_TIMEOUT = 10.0
 
-# (Operations the differential can't meaningfully check -- unordered-container
-# ordering, identity-eq / non-value-comparable output, reflection -- were listed
-# here as DIFFERENTIAL_SKIP.  They now live in the operation catalog's
-# ``not_value_function`` / ``side_effect`` classification: crosshair.inputgen's
-# NOT_VALUE_FUNCTION and SIDE_EFFECT_OVERRIDES, read off each ``Operation``.)
-
 
 @dataclass
 class Divergence:

--- a/crosshair/behavior_compare.py
+++ b/crosshair/behavior_compare.py
@@ -488,13 +488,16 @@ def run_differential(
     k: int = 3,
     seed: int = 0,
     max_pin_iters: int = _DIFF_MAX_PIN_ITERS,
+    seedkey: Optional[str] = None,
 ) -> DiffResult:
     """Drive one operation on up to ``k`` valid inputs, comparing a symbolic run
     (args pinned to the input) against a concrete run.  Returns a ``DiffResult``
     with the count of inputs actually driven and the first ``Divergence`` (or
     None if all matched).  ``max_pin_iters`` bounds the per-input pin search; use
     a small value when speed matters more than pinning every container shape (an
-    input that can't pin in budget is simply skipped).
+    input that can't pin in budget is simply skipped).  ``seedkey`` is the op's
+    catalog identity, forwarded to ``valid_inputs`` so a CUSTOM_INPUTS override
+    (e.g. aliased ``x is x``) applies.
 
     ``expr`` is eval'd over ``arg_names`` (plus ``eval_globals``); see
     ``crosshair.inputgen.op_call``/``func_call`` for building these."""
@@ -503,7 +506,11 @@ def run_differential(
     def applier(*vs):
         return eval(expr, dict(eval_globals), dict(zip(arg_names, vs)))
 
-    inputs = [t for t in valid_inputs(fn, k=k, seed=seed) if len(t) == len(arg_names)]
+    inputs = [
+        t
+        for t in valid_inputs(fn, k=k, seed=seed, seedkey=seedkey)
+        if len(t) == len(arg_names)
+    ]
     checked = 0
     unsupported = 0
     for vals in inputs:

--- a/crosshair/behavior_compare.py
+++ b/crosshair/behavior_compare.py
@@ -352,45 +352,11 @@ _UNSUPPORTED = object()  # pinned fine, but the op rejected the symbolic proxy
 _DIFF_MAX_PIN_ITERS = 80
 _DIFF_PIN_TIMEOUT = 10.0
 
-# Operations the differential CANNOT meaningfully check: their forward output
-# legitimately depends on unspecified iteration order, isn't value-comparable, or
-# the builtin isn't a pure value transform.  A divergence here is NOT a bug -- so
-# both the fuzz test (skips them) and the support measurement (won't color them
-# black from the differential) consult this list.  Keyed by "<type>.<method>" /
-# "<module>.<func>".
-DIFFERENTIAL_SKIP: Dict[str, str] = {
-    # repr/str of an unordered container -- element order in the string is arbitrary
-    "set.__repr__": "set repr element order is unspecified",
-    "frozenset.__repr__": "frozenset repr element order is unspecified",
-    "dict.__repr__": "dict repr order need not match between symbolic and concrete",
-    "set.__str__": "set str element order is unspecified",
-    "frozenset.__str__": "frozenset str element order is unspecified",
-    "dict.__str__": "dict str order need not match between symbolic and concrete",
-    # pop an arbitrary element -- which one is unspecified
-    "set.pop": "set.pop removes an arbitrary, unspecified element",
-    "dict.popitem": "dict.popitem removes an arbitrary, unspecified item",
-    # not value-comparable
-    "dict.values": "dict_values has identity equality; not value-comparable",
-    # builtins that aren't pure value transforms (identity / code / names / I/O)
-    "builtins.id": "identity, not a value",
-    "builtins.__import__": "imports a module; not a value transform",
-    "builtins.__lazy_import__": "[3.15+] lazily imports a module; not a value transform",
-    "builtins.compile": "compiles source; output isn't value-comparable",
-    "builtins.exec": "executes code for side effects",
-    "builtins.eval": "evaluates a symbolic code string -- not meaningful",
-    "builtins.getattr": "attribute access by (symbolic) name",
-    "builtins.setattr": "mutates an attribute by name",
-    "builtins.delattr": "deletes an attribute by name",
-    "builtins.hasattr": "attribute probe by name",
-    "builtins.input": "reads input (I/O)",
-    "builtins.open": "opens a file (I/O)",
-    "builtins.print": "writes output (I/O)",
-    "builtins.breakpoint": "enters the debugger",
-    "builtins.globals": "introspects the caller's namespace",
-    "builtins.locals": "introspects the caller's namespace",
-    "builtins.vars": "introspects an object's namespace",
-    "builtins.dir": "introspection; order/content not a pure value",
-}
+# (Operations the differential can't meaningfully check -- unordered-container
+# ordering, identity-eq / non-value-comparable output, reflection -- were listed
+# here as DIFFERENTIAL_SKIP.  They now live in the operation catalog's
+# ``not_value_function`` / ``side_effect`` classification: crosshair.inputgen's
+# NOT_VALUE_FUNCTION and SIDE_EFFECT_OVERRIDES, read off each ``Operation``.)
 
 
 @dataclass

--- a/crosshair/fuzz_core_test.py
+++ b/crosshair/fuzz_core_test.py
@@ -60,13 +60,21 @@ KNOWN_FAILURES = {
     "bytearray.__setitem__": "symbolic bytearray[i]=v raises IndexError vs concrete ValueError (no byte-range check)",
     "bytearray.resize": "[3.14+] resize() is new in 3.14 and unmodeled on SymbolicByteArray -> AttributeError",
     "bytearray.take_bytes": "[3.15+] take_bytes() is new in 3.15 and unmodeled on SymbolicByteArray -> AttributeError",
+    # Surfaced by the aliased `(x, x)` CUSTOM_INPUTS strategy: symbolic execution
+    # treats the two arguments as distinct objects, so `x is x` reads False (and
+    # `x is not x` True) where concrete Python says the opposite -- crosshair
+    # doesn't model that two parameters can be aliased.
+    "operator.is_": "symbolic `x is x` returns False (argument aliasing unmodeled)",
+    "operator.is_not": "symbolic `x is not x` returns True (argument aliasing unmodeled)",
 }
 
 
-def _check(label, call):
+def _check(label, call, seedkey):
     """Assert symbolic == concrete across this op's valid inputs."""
     fn, expr, names, eval_globals = call
-    result = run_differential(fn, expr, names, eval_globals, k=INPUTS_PER_OP)
+    result = run_differential(
+        fn, expr, names, eval_globals, k=INPUTS_PER_OP, seedkey=seedkey
+    )
     if result.checked == 0:
         pytest.skip(f"no drivable inputs for {label}")
     assert result.divergence is None, f"{label} diverges {result.divergence.describe()}"
@@ -115,4 +123,5 @@ def _catalog_params():
 @pytest.mark.parametrize("key", list(_catalog_params()))
 def test_op(key):
     """Symbolic-vs-concrete differential for one catalogued operation."""
-    _check(key, _CATALOG[key].call)
+    op = _CATALOG[key]
+    _check(key, op.call, op.seedkey)

--- a/crosshair/fuzz_core_test.py
+++ b/crosshair/fuzz_core_test.py
@@ -63,7 +63,11 @@ KNOWN_FAILURES = {
     # Surfaced by the aliased `(x, x)` CUSTOM_INPUTS strategy: symbolic execution
     # treats the two arguments as distinct objects, so `x is x` reads False (and
     # `x is not x` True) where concrete Python says the opposite -- crosshair
-    # doesn't model that two parameters can be aliased.
+    # doesn't model that two parameters can be aliased.  crosshair CAN alias values
+    # in some nested cases, but not yet at the top level (two separate parameters);
+    # when that lands, the differential harness must pin an aliased concrete input
+    # to a SHARED symbolic proxy (today run_symbolic_pinned pins each arg name to
+    # its own proxy) -- and these two xfails should then flip to passing.
     "operator.is_": "symbolic `x is x` returns False (argument aliasing unmodeled)",
     "operator.is_not": "symbolic `x is not x` returns True (argument aliasing unmodeled)",
 }

--- a/crosshair/fuzz_core_test.py
+++ b/crosshair/fuzz_core_test.py
@@ -22,8 +22,8 @@ by Python version and solver timing -- see the note there).
 import pytest
 
 import crosshair.core_and_libs  # noqa: F401  -- ensure patches/plugins load
-from crosshair.behavior_compare import DIFFERENTIAL_SKIP, run_differential
-from crosshair.inputgen import TYPES, _module_funcs, func_call, op_call, surface
+from crosshair.behavior_compare import run_differential
+from crosshair.inputgen import catalog
 
 # Inputs checked per operation (each pinned symbolic-vs-concrete).  Small for CI.
 INPUTS_PER_OP = 3
@@ -62,11 +62,6 @@ KNOWN_FAILURES = {
     "bytearray.take_bytes": "[3.15+] take_bytes() is new in 3.15 and unmodeled on SymbolicByteArray -> AttributeError",
 }
 
-# Ops the differential can't meaningfully check (order-dependent / incomparable /
-# not a pure value) live in behavior_compare.DIFFERENTIAL_SKIP, shared with support
-# measurement so neither flags them.
-EXCLUDED = DIFFERENTIAL_SKIP
-
 
 def _check(label, call):
     """Assert symbolic == concrete across this op's valid inputs."""
@@ -77,61 +72,47 @@ def _check(label, call):
     assert result.divergence is None, f"{label} diverges {result.divergence.describe()}"
 
 
-def _marks(label):
-    """Skip excluded ops; xfail known soundness bugs (non-strict: see
-    KNOWN_FAILURES -- reproduction varies by Python version / solver timing)."""
-    if label in EXCLUDED:
-        return [pytest.mark.skip(reason=EXCLUDED[label])]
-    if label in KNOWN_FAILURES:
-        return [pytest.mark.xfail(reason=KNOWN_FAILURES[label], strict=False)]
-    return []
+def _op_marks(op):
+    """Marks for one catalogued op.  Skip what we can't/shouldn't fuzz -- out of
+    scope (OS handle), a probe hazard (blocks/crashes), a side effect (real I/O),
+    or an op whose output isn't a comparable value function (order/identity/
+    reflection) -- and xfail known soundness gaps.  The skip reasons come straight
+    off the catalog's classification (crosshair.inputgen), the same fields the
+    support map reads.  Every NON-builtin op is gated behind ``--run-slow``: the
+    builtin surface is the fast CI gate; the stdlib surface is EXPLORATORY (failures
+    there are candidate soundness bugs to triage, not a gate)."""
+    marks = []
+    if op.out_of_scope:
+        marks.append(pytest.mark.skip(reason=f"out of scope: {op.out_of_scope}"))
+    elif op.probe_hazard:
+        marks.append(pytest.mark.skip(reason=f"probe hazard: {op.probe_hazard}"))
+    elif op.side_effect:
+        marks.append(pytest.mark.skip(reason=f"side effect: {op.side_effect}"))
+    elif op.not_value_function:
+        marks.append(
+            pytest.mark.skip(reason=f"not a value function: {op.not_value_function}")
+        )
+    elif op.seedkey in KNOWN_FAILURES:
+        marks.append(pytest.mark.xfail(reason=KNOWN_FAILURES[op.seedkey], strict=False))
+    if op.module != "builtins":
+        marks.append(pytest.mark.slow)
+    return marks
 
 
-def _builtin_type_ops():
-    for typ in TYPES:
-        for method in surface(typ):
-            label = f"{typ.__name__}.{method}"
-            if op_call(typ, method):
-                yield pytest.param(typ, method, id=label, marks=_marks(label))
+# Enumerate the ONE canonical surface (crosshair.inputgen.catalog) -- the same set
+# the support map measures, so the test and the map can't drift.  Static
+# classification only (probe=False): fast, and complete here since this pure
+# surface reaches for no live-probed side effects.  Keyed by the rendered key; the
+# test looks the Operation back up, so params stay picklable (xdist-safe).
+_CATALOG = {op.key: op for op in catalog(probe=False) if op.call is not None}
 
 
-def _builtin_func_ops():
-    for name in sorted(_module_funcs("builtins")):
-        label = f"builtins.{name}"
-        if func_call("builtins", name):
-            yield pytest.param(name, id=label, marks=_marks(label))
+def _catalog_params():
+    for key, op in _CATALOG.items():
+        yield pytest.param(key, id=key, marks=_op_marks(op))
 
 
-@pytest.mark.parametrize("typ,method", list(_builtin_type_ops()))
-def test_builtin_type_op(typ, method):
-    _check(f"{typ.__name__}.{method}", op_call(typ, method))
-
-
-@pytest.mark.parametrize("name", list(_builtin_func_ops()))
-def test_builtin_func_op(name):
-    _check(f"builtins.{name}", func_call("builtins", name))
-
-
-# Opt-in (``--run-slow``): the same differential over a broad set of pure stdlib
-# free functions.  EXPLORATORY -- not a CI gate and not curated into
-# KNOWN_FAILURES, so failures here are candidate soundness bugs to triage (the
-# support matrix already colors these; this confirms forward divergences).
-STDLIB_MODULES = (
-    "math cmath statistics fractions string textwrap unicodedata difflib shlex "
-    "html json base64 binascii quopri zlib hashlib hmac itertools functools "
-    "operator heapq bisect collections calendar colorsys fnmatch posixpath "
-    "urllib.parse ipaddress uuid struct ast graphlib codecs"
-).split()
-
-
-def _stdlib_func_ops():
-    for module in STDLIB_MODULES:
-        for name in sorted(_module_funcs(module)):
-            if not name.startswith("_") and func_call(module, name):
-                yield pytest.param(module, name, id=f"{module}.{name}")
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("module,name", list(_stdlib_func_ops()))
-def test_stdlib_func_op(module, name):
-    _check(f"{module}.{name}", func_call(module, name))
+@pytest.mark.parametrize("key", list(_catalog_params()))
+def test_op(key):
+    """Symbolic-vs-concrete differential for one catalogued operation."""
+    _check(key, _CATALOG[key].call)

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -1080,9 +1080,7 @@ _FUNC_ARG_STRATS = {
 #     independent draws never produce.
 # Each value is ``(specs, size) -> strategy-over-the-full-arg-tuple``; it may build
 # on the op's own per-arg ``specs`` (so it adapts to whatever arity a caller drives
-# the op with) or ignore them.  BOTH input paths consult this -- valid_inputs (the
-# differential) and the support sweep -- so a custom input is both tested and
-# performance-measured, not merely displayed.
+# the op with) or ignore them.
 
 
 def _roundtrip(
@@ -1385,48 +1383,34 @@ def func_surface(module: str) -> List[str]:
     return out
 
 
-# ---------------------------------------------------------------------------
-# the operation catalog: ONE uniform record per operation, so the support
-# measurement and the differential fuzz test cover the *same* set instead of
-# three hand-drifting module lists.  Classification decisions are moved FORWARD
-# into cataloging here, as five ORTHOGONAL facts per op:
-#   * skip_reason  -- statically not drivable: a dunder / no typeshed signature /
-#     operator arity gap.  Knowable from the op's shape; no execution.
-#   * out_of_scope -- statically unsupportable: takes an OS-layer handle (a file
-#     descriptor, ...) that CrossHair can never model -- we can inject a symbolic
-#     int at the Python layer, but the syscall behind it needs a REAL descriptor.
-#     Distinct from a side effect: a side effect COULD be supported one day.
-#   * not_value_function -- drivable, but its output isn't a deterministic,
-#     value-comparable function of the inputs (unordered-container ordering, an
-#     arbitrary popped element, an identity-eq result, reflection/introspection),
-#     so the forward differential can't judge it.  Static cases are hardcoded in
-#     NOT_VALUE_FUNCTION; runtime nondeterminism is caught at measure time by
-#     :func:`is_deterministic`.  (Formerly behavior_compare.DIFFERENTIAL_SKIP.)
-#   * side_effect  -- discovered by a CONCRETE auditwall probe: run the op once
-#     with the wall engaged; an audit event (open/subprocess/socket/...) fires
-#     BEFORE the effect, so we learn "this reaches for I/O" WITHOUT performing it.
-#     A neutral FACT, not a verdict: a future symbolic read()/urandom() (cf.
-#     symbolic time.time()) could make such an op supported.  The builtin I/O ops
-#     on the always-measured surface are hardcoded in SIDE_EFFECT_OVERRIDES so
-#     ``probe=False`` classifies them without a live probe.
-#   * probe_hazard -- the concrete probe can't be run: the op blocks (HANG) or
-#     crashes the interpreter (CRASH), so its nature is hardcoded, not observed.
-# The *dynamic* "unsupported" verdict (proxy intolerance / can't pin) still
-# belongs to the measurement pass -- it needs symbolic execution, which inputgen
-# neither does nor depends on.
-# ---------------------------------------------------------------------------
-
-
 @dataclass
 class Operation:
-    """One catalogued operation, uniform across builtin methods, stdlib class
-    methods, and module-level free functions.
+    """One catalogued operation -- a builtin method, a stdlib class method, or a
+    module-level free function -- with the classification both consumers read.
 
-    ``call`` is the drive spec every consumer shares -- ``(fn, expr, arg_names,
-    eval_globals)`` -- or None when the op isn't drivable.  ``seedkey`` is the
-    dotted identity (``"<owner>.<name>"``) used for the fuzz seed and static-set
-    lookups; ``key`` is the rendered form the support map / usage prior use.  The
-    five classification fields are orthogonal (see the module comment above)."""
+    ``call`` is the drive spec ``(fn, expr, arg_names, eval_globals)``, or None
+    when the op isn't drivable.  ``seedkey`` is the dotted identity
+    (``"<owner>.<name>"``); ``key`` is the rendered form.
+
+    At most one classification field is set: they are checked in this precedence
+    order and the first that applies wins.
+
+    * ``skip_reason`` -- statically not drivable: a dunder, no typeshed signature,
+      or an operator arity gap.
+    * ``out_of_scope`` -- takes an OS-layer handle (a file descriptor, a process
+      id, ...) that CrossHair can never model.
+    * ``not_value_function`` -- drivable, but its output isn't a deterministic,
+      value-comparable function of the inputs (unordered-container ordering, an
+      arbitrary popped element, an identity-eq result, reflection), so the forward
+      differential can't judge it.  Static cases are in :data:`NOT_VALUE_FUNCTION`;
+      runtime nondeterminism is caught at measure time by :func:`is_deterministic`.
+    * ``side_effect`` -- the op reaches for I/O: run concretely under the auditwall,
+      an audit event (open/subprocess/socket/...) fires before the effect happens.
+      Builtin I/O ops are in :data:`SIDE_EFFECT_OVERRIDES`; the rest a live probe
+      finds.
+    * ``probe_hazard`` -- the concrete probe can't run it: the op blocks (HANG) or
+      crashes the interpreter (CRASH).
+    """
 
     key: str
     seedkey: str
@@ -1456,18 +1440,6 @@ class Operation:
         return valid_inputs(
             self.call[0], k=k, seed=seed, size=size, seedkey=self.seedkey
         )
-
-
-def _static_skip_reason(
-    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
-) -> Optional[str]:
-    """Why this op is statically excluded from measurement, or None.  Knowable
-    from the op's shape -- no symbolic execution required.  (Identity ops like
-    ``id``/``is_`` are deliberately NOT excluded: they read as forward divergences,
-    which is honest -- opcode interception could one day model them.)"""
-    if call is None:  # SKIP_DUNDERS, no typeshed signature, or operator arity gap
-        return "no drivable signature"
-    return None
 
 
 # Parameter NAMES that denote an OS-layer handle.  typeshed annotates all of these
@@ -1584,10 +1556,8 @@ def is_deterministic(
 # Ops the concrete probe can't RUN -- they block or crash without the auditwall
 # catching them first, so their nature is hardcoded rather than observed.  seedkey
 # -> the probe_hazard reason.  Everything NOT listed (and not out_of_scope) is safe
-# to probe in-process; a new hazard surfaces as HANG/CRASH under a
-# ``probe="isolated"`` discovery pass (see :func:`probe_side_effect_isolated`),
-# which is how this list was built -- rerun it after a Python/typeshed bump.
-# (``os.closerange`` is absent: it takes fds, so ``out_of_scope`` catches it first.)
+# to probe in-process; a ``probe="isolated"`` pass surfaces a new hazard as
+# HANG/CRASH -- re-run one after a Python/typeshed bump to catch new ones.
 PROBE_HAZARD_OVERRIDES: Dict[str, str] = {
     # file-opening ops: block on a fuzzed path (the wall's ``open`` check only
     # blocks WRITE flags, so a read-mode open of a real path proceeds and hangs).
@@ -1597,9 +1567,6 @@ PROBE_HAZARD_OVERRIDES: Dict[str, str] = {
     "lzma.open": "opens a file (blocks the probe)",
     "codecs.open": "opens a file (blocks the probe)",
     "signal.sigwait": "blocks waiting for a signal",
-    # (``time.pthread_getcpuclockid`` used to live here -- it segfaults on a bogus
-    # thread id -- but its ``thread_id`` param now makes it out_of_scope, which
-    # short-circuits before we'd ever probe it.)
 }
 
 # probe_hazard values for an op whose concrete probe misbehaved -- each a signal to
@@ -1732,9 +1699,8 @@ def _classify(
     live-discovered side effects (empty on a curated surface, where the known I/O
     ops are already in SIDE_EFFECT_OVERRIDES); consumers enumerate cheaply without
     probing."""
-    skip = _static_skip_reason(call)
-    if skip is not None:
-        return (skip, None, None, None, None)
+    if call is None:  # not drivable: a dunder, no typeshed signature, or arity gap
+        return ("no drivable signature", None, None, None, None)
     oos = _out_of_scope_reason(call)
     if oos is not None:  # never modelable -> don't waste a probe on it
         return (None, oos, None, None, None)
@@ -1794,10 +1760,9 @@ def _func_op(module: str, name: str, probe: Any) -> Operation:
     )
 
 
-# The canonical operation surface -- the ONE definition both the support map and
-# the differential fuzz test enumerate, so their coverage can't drift.  Free
-# functions (incl. ``builtins`` for len/id/open/...) plus the public classes each
-# module defines (decimal.Decimal, datetime.date, ...); builtin TYPES come from the
+# The free-function modules of the canonical operation surface: builtins (len/id/
+# open/...) plus stdlib modules.  Public classes each module defines contribute
+# their methods (see CATALOG_METHOD_MODULES); builtin TYPES come from catalog()'s
 # ``types`` arg.
 CATALOG_FUNC_MODULES: Tuple[str, ...] = (
     "builtins",

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -26,7 +26,18 @@ import multiprocessing
 import sys
 import typing
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    cast,
+)
 
 from hypothesis import HealthCheck, given
 from hypothesis import seed as hyp_seed
@@ -1057,27 +1068,96 @@ _FUNC_ARG_STRATS = {
 # decoders/parsers whose valid input is best produced by running the
 # inverse encoder: (module, decoder) -> (enc_module, enc_func, base_kind).  The
 # decoder's primary (first) arg is fed enc(<fuzzed base data>).
-_ROUNDTRIP = {
-    ("base64", "b64decode"): ("base64", "b64encode", "bytes"),
-    ("base64", "standard_b64decode"): ("base64", "standard_b64encode", "bytes"),
-    ("base64", "urlsafe_b64decode"): ("base64", "urlsafe_b64encode", "bytes"),
-    ("base64", "b16decode"): ("base64", "b16encode", "bytes"),
-    ("base64", "b32decode"): ("base64", "b32encode", "bytes"),
-    ("base64", "b32hexdecode"): ("base64", "b32hexencode", "bytes"),
-    ("base64", "a85decode"): ("base64", "a85encode", "bytes"),
-    ("base64", "b85decode"): ("base64", "b85encode", "bytes"),
-    ("base64", "z85decode"): ("base64", "z85encode", "bytes"),
-    ("base64", "decodebytes"): ("base64", "encodebytes", "bytes"),
-    ("binascii", "a2b_hex"): ("binascii", "b2a_hex", "bytes"),
-    ("binascii", "unhexlify"): ("binascii", "hexlify", "bytes"),
-    ("binascii", "a2b_base64"): ("binascii", "b2a_base64", "bytes"),
-    ("json", "loads"): ("json", "dumps", "jsonable"),
-    ("ast", "literal_eval"): ("builtins", "repr", "jsonable"),
-    ("urllib.parse", "unquote"): ("urllib.parse", "quote", "str"),
-    ("urllib.parse", "unquote_plus"): ("urllib.parse", "quote_plus", "str"),
-    ("zlib", "decompress"): ("zlib", "compress", "bytes"),
-    ("gzip", "decompress"): ("gzip", "compress", "bytes"),
-    ("bz2", "decompress"): ("bz2", "compress", "bytes"),
+# --- custom per-op input strategies ---------------------------------------
+# A registry of WHOLE-TUPLE input strategies, keyed by seedkey, for ops where
+# independent per-arg fuzzing can't produce a useful input because the arguments
+# must be CORRELATED or ALIASED:
+#   * a decoder wants a valid ENCODED input (run the inverse encoder on fuzzed
+#     base data) -- the former _ROUNDTRIP, now :func:`_roundtrip` entries;
+#   * ``getattr(o, name)`` wants ``name`` to be an attribute OF ``o`` -- a random
+#     string is almost always an AttributeError;
+#   * ``x is x`` / ``x is not x`` needs the SAME object in both positions, which
+#     independent draws never produce.
+# Each value is ``(specs, size) -> strategy-over-the-full-arg-tuple``; it may build
+# on the op's own per-arg ``specs`` (so it adapts to whatever arity a caller drives
+# the op with) or ignore them.  BOTH input paths consult this -- valid_inputs (the
+# differential) and the support sweep -- so a custom input is both tested and
+# performance-measured, not merely displayed.
+
+
+def _roundtrip(
+    enc_module: str, enc_func: str, base_kind: str
+) -> Callable[[List[Any], int], "st.SearchStrategy[tuple]"]:
+    """A strategy builder that feeds a decoder a VALID encoded input: fuzz base
+    data, run ``enc_module.enc_func`` on it, pass that as the first argument, and
+    fuzz any remaining args normally."""
+
+    def build(specs: List[Any], n: int) -> "st.SearchStrategy[tuple]":
+        first = _arg_strategy(("roundtrip", enc_module, enc_func, base_kind), n)
+        rest = [_arg_strategy(s, n) for s in specs[1:]]
+        return st.tuples(first, *rest)
+
+    return build
+
+
+def _getattr_inputs(specs: List[Any], n: int) -> "st.SearchStrategy[tuple]":
+    """``getattr(o, name, ...)`` where ``name`` is a real (data) attribute of ``o``
+    -- so it exercises actual attribute access instead of raising AttributeError on
+    a fuzzed string.  Preserves the op's arity (any trailing ``default`` fuzzes
+    normally)."""
+    objs = st.one_of(
+        st.integers(), st.floats(allow_nan=False), st.complex_numbers(allow_nan=False)
+    )
+
+    def with_name(o: Any) -> "st.SearchStrategy[tuple]":
+        names = [
+            a
+            for a in dir(o)
+            if not a.startswith("_") and not callable(getattr(o, a, None))
+        ]
+        name_strat = st.sampled_from(names) if names else st.just("__class__")
+        rest = [_arg_strategy(s, n) for s in specs[2:]]
+        return st.tuples(st.just(o), name_strat, *rest)
+
+    return objs.flatmap(with_name)
+
+
+def _aliased_pair(specs: List[Any], n: int) -> "st.SearchStrategy[tuple]":
+    """``(x, x)`` -- the SAME object in both positions, to witness identity ops
+    (``x is x``).  Uses non-interned values (large ints / str / list) so identity
+    is meaningful (small ints and short strings may be cached)."""
+    vals = st.one_of(
+        st.integers(min_value=1000),
+        st.text(min_size=1, max_size=n),
+        st.lists(st.integers(), min_size=1, max_size=n),
+    )
+    return vals.map(lambda x: (x, x))
+
+
+CUSTOM_INPUTS: Dict[str, Callable[[List[Any], int], "st.SearchStrategy[tuple]"]] = {
+    "builtins.getattr": _getattr_inputs,
+    "operator.is_": _aliased_pair,
+    "operator.is_not": _aliased_pair,
+    "base64.b64decode": _roundtrip("base64", "b64encode", "bytes"),
+    "base64.standard_b64decode": _roundtrip("base64", "standard_b64encode", "bytes"),
+    "base64.urlsafe_b64decode": _roundtrip("base64", "urlsafe_b64encode", "bytes"),
+    "base64.b16decode": _roundtrip("base64", "b16encode", "bytes"),
+    "base64.b32decode": _roundtrip("base64", "b32encode", "bytes"),
+    "base64.b32hexdecode": _roundtrip("base64", "b32hexencode", "bytes"),
+    "base64.a85decode": _roundtrip("base64", "a85encode", "bytes"),
+    "base64.b85decode": _roundtrip("base64", "b85encode", "bytes"),
+    "base64.z85decode": _roundtrip("base64", "z85encode", "bytes"),
+    "base64.decodebytes": _roundtrip("base64", "encodebytes", "bytes"),
+    "binascii.a2b_hex": _roundtrip("binascii", "b2a_hex", "bytes"),
+    "binascii.unhexlify": _roundtrip("binascii", "hexlify", "bytes"),
+    "binascii.a2b_base64": _roundtrip("binascii", "b2a_base64", "bytes"),
+    "json.loads": _roundtrip("json", "dumps", "jsonable"),
+    "ast.literal_eval": _roundtrip("builtins", "repr", "jsonable"),
+    "urllib.parse.unquote": _roundtrip("urllib.parse", "quote", "str"),
+    "urllib.parse.unquote_plus": _roundtrip("urllib.parse", "quote_plus", "str"),
+    "zlib.decompress": _roundtrip("zlib", "compress", "bytes"),
+    "gzip.decompress": _roundtrip("gzip", "compress", "bytes"),
+    "bz2.decompress": _roundtrip("bz2", "compress", "bytes"),
 }
 
 
@@ -1191,25 +1271,43 @@ def _specs_for(fn: Any) -> Optional[List[Any]]:
             _resolve_arg(n, ann, lits, "builtins", name) for n, ann, lits in sig
         ]
     mod, name = info[1], info[2]
-    specs = [_resolve_arg(n, ann, lits, mod, name) for n, ann, lits in sig]
-    rt = _ROUNDTRIP.get((mod, name))
-    if rt and specs:
-        specs[0] = ("roundtrip",) + rt
-    return specs
+    return [_resolve_arg(n, ann, lits, mod, name) for n, ann, lits in sig]
+
+
+def tuple_strategy(
+    seedkey: Optional[str], specs: List[Any], size: int
+) -> "st.SearchStrategy[tuple]":
+    """The argument-tuple strategy for an op: a :data:`CUSTOM_INPUTS` override when
+    one is registered (correlated / aliased / roundtrip inputs), else independent
+    per-arg fuzzing.  Shared by both input paths -- valid_inputs and the support
+    sweep -- so a custom input reaches both consumers."""
+    custom = CUSTOM_INPUTS.get(seedkey) if seedkey else None
+    if custom is not None:
+        return custom(specs, size)
+    return st.tuples(*[_arg_strategy(s, size) for s in specs])
 
 
 def valid_inputs(
-    fn: Any, k: int = 5, seed: int = 0, develop: bool = True, size: int = 3
+    fn: Any,
+    k: int = 5,
+    seed: int = 0,
+    develop: bool = True,
+    size: int = 3,
+    seedkey: Optional[str] = None,
 ) -> List[Tuple[Any, ...]]:
     """Up to ``k`` concrete, valid argument tuples for ``fn`` (a builtin function
     or method descriptor).  Deterministic given ``seed``.  ``develop`` drops the
     first (often degenerate) example for more diverse values.  ``size`` scales the
     generated arguments (string/collection length, etc.) -- sweep it to see where
-    an op cliffs.  Returns [] when no signature can be resolved."""
+    an op cliffs.  ``seedkey`` is the op's catalog identity -- pass it to enable a
+    :data:`CUSTOM_INPUTS` override (correlated / aliased / roundtrip inputs); a
+    caller with only ``fn`` (which can't recover the public seedkey -- ``operator``
+    funcs report ``__module__ == "_operator"``) simply omits it.  Returns [] when no
+    signature can be resolved."""
     specs = _specs_for(fn)
     if not specs:
         return []
-    strat = st.tuples(*[_arg_strategy(s, size) for s in specs])
+    strat = tuple_strategy(seedkey, specs, size)
     out = []
 
     @hyp_seed(seed)
@@ -1355,7 +1453,9 @@ class Operation:
         """Concrete valid argument tuples for this op at the given ``size``."""
         if self.call is None:
             return []
-        return valid_inputs(self.call[0], k=k, seed=seed, size=size)
+        return valid_inputs(
+            self.call[0], k=k, seed=seed, size=size, seedkey=self.seedkey
+        )
 
 
 def _static_skip_reason(

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -1534,7 +1534,9 @@ NOT_VALUE_FUNCTION: Dict[str, str] = {
     "builtins.compile": "compiles source; output isn't value-comparable",
     "builtins.exec": "executes code for side effects",
     "builtins.eval": "evaluates a symbolic code string -- not meaningful",
-    "builtins.getattr": "attribute access by (symbolic) name",
+    # (builtins.getattr is deliberately ABSENT: given a real attribute name it IS
+    # a deterministic value function, and CUSTOM_INPUTS["builtins.getattr"] draws
+    # exactly that -- so we fuzz-test it rather than skip it.)
     "builtins.setattr": "mutates an attribute by name",
     "builtins.delattr": "deletes an attribute by name",
     "builtins.hasattr": "attribute probe by name",

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -1512,7 +1512,6 @@ NOT_VALUE_FUNCTION: Dict[str, str] = {
     "builtins.setattr": "mutates an attribute by name",
     "builtins.delattr": "deletes an attribute by name",
     "builtins.hasattr": "attribute probe by name",
-    "builtins.breakpoint": "enters the debugger",
     "builtins.globals": "introspects the caller's namespace",
     "builtins.locals": "introspects the caller's namespace",
     "builtins.vars": "introspects an object's namespace",
@@ -1567,6 +1566,7 @@ PROBE_HAZARD_OVERRIDES: Dict[str, str] = {
     "lzma.open": "opens a file (blocks the probe)",
     "codecs.open": "opens a file (blocks the probe)",
     "signal.sigwait": "blocks waiting for a signal",
+    "builtins.breakpoint": "enters the debugger (blocks on debugger input)",
 }
 
 # probe_hazard values for an op whose concrete probe misbehaved -- each a signal to

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -17,16 +17,23 @@ Layers exposed here:
 """
 
 import ast as _ast
+import contextlib
+import copy
 import functools
 import importlib
+import io
+import multiprocessing
 import sys
 import typing
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, cast
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, cast
 
 from hypothesis import HealthCheck, given
 from hypothesis import seed as hyp_seed
 from hypothesis import settings
 from hypothesis import strategies as st
+
+from crosshair.auditwall import SideEffectDetected, enabled_auditwall
 
 # ---------------------------------------------------------------------------
 # the operation surface: builtin types + their methods
@@ -1192,16 +1199,17 @@ def _specs_for(fn: Any) -> Optional[List[Any]]:
 
 
 def valid_inputs(
-    fn: Any, k: int = 5, seed: int = 0, develop: bool = True
+    fn: Any, k: int = 5, seed: int = 0, develop: bool = True, size: int = 3
 ) -> List[Tuple[Any, ...]]:
     """Up to ``k`` concrete, valid argument tuples for ``fn`` (a builtin function
     or method descriptor).  Deterministic given ``seed``.  ``develop`` drops the
-    first (often degenerate) example for more diverse values.  Returns [] when no
-    signature can be resolved."""
+    first (often degenerate) example for more diverse values.  ``size`` scales the
+    generated arguments (string/collection length, etc.) -- sweep it to see where
+    an op cliffs.  Returns [] when no signature can be resolved."""
     specs = _specs_for(fn)
     if not specs:
         return []
-    strat = st.tuples(*[_arg_strategy(s, 3) for s in specs])
+    strat = st.tuples(*[_arg_strategy(s, size) for s in specs])
     out = []
 
     @hyp_seed(seed)
@@ -1258,3 +1266,534 @@ def func_call(
     if not argnames:  # nothing to vary
         return None
     return (fn, f"_fn({', '.join(argnames)})", argnames, {"_fn": fn})
+
+
+def func_surface(module: str) -> List[str]:
+    """Public free-function names of ``module`` that the catalog targets:
+    typeshed-known, public, present + callable at runtime, and not a type (type
+    constructors belong to the type surface, not here)."""
+    try:
+        mod = importlib.import_module(module)
+    except Exception:
+        return []
+    out = []
+    for name in sorted(_module_funcs(module)):
+        if name.startswith("_"):
+            continue
+        obj = getattr(mod, name, None)
+        if obj is None or not callable(obj) or isinstance(obj, type):
+            continue
+        out.append(name)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# the operation catalog: ONE uniform record per operation, so the support
+# measurement and the differential fuzz test cover the *same* set instead of
+# three hand-drifting module lists.  Classification decisions are moved FORWARD
+# into cataloging here, as five ORTHOGONAL facts per op:
+#   * skip_reason  -- statically not drivable: a dunder / no typeshed signature /
+#     operator arity gap.  Knowable from the op's shape; no execution.
+#   * out_of_scope -- statically unsupportable: takes an OS-layer handle (a file
+#     descriptor, ...) that CrossHair can never model -- we can inject a symbolic
+#     int at the Python layer, but the syscall behind it needs a REAL descriptor.
+#     Distinct from a side effect: a side effect COULD be supported one day.
+#   * not_value_function -- drivable, but its output isn't a deterministic,
+#     value-comparable function of the inputs (unordered-container ordering, an
+#     arbitrary popped element, an identity-eq result, reflection/introspection),
+#     so the forward differential can't judge it.  Static cases are hardcoded in
+#     NOT_VALUE_FUNCTION; runtime nondeterminism is caught at measure time by
+#     :func:`is_deterministic`.  (Formerly behavior_compare.DIFFERENTIAL_SKIP.)
+#   * side_effect  -- discovered by a CONCRETE auditwall probe: run the op once
+#     with the wall engaged; an audit event (open/subprocess/socket/...) fires
+#     BEFORE the effect, so we learn "this reaches for I/O" WITHOUT performing it.
+#     A neutral FACT, not a verdict: a future symbolic read()/urandom() (cf.
+#     symbolic time.time()) could make such an op supported.  The builtin I/O ops
+#     on the always-measured surface are hardcoded in SIDE_EFFECT_OVERRIDES so
+#     ``probe=False`` classifies them without a live probe.
+#   * probe_hazard -- the concrete probe can't be run: the op blocks (HANG) or
+#     crashes the interpreter (CRASH), so its nature is hardcoded, not observed.
+# The *dynamic* "unsupported" verdict (proxy intolerance / can't pin) still
+# belongs to the measurement pass -- it needs symbolic execution, which inputgen
+# neither does nor depends on.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Operation:
+    """One catalogued operation, uniform across builtin methods, stdlib class
+    methods, and module-level free functions.
+
+    ``call`` is the drive spec every consumer shares -- ``(fn, expr, arg_names,
+    eval_globals)`` -- or None when the op isn't drivable.  ``seedkey`` is the
+    dotted identity (``"<owner>.<name>"``) used for the fuzz seed and static-set
+    lookups; ``key`` is the rendered form the support map / usage prior use.  The
+    five classification fields are orthogonal (see the module comment above)."""
+
+    key: str
+    seedkey: str
+    kind: str  # "method" | "func"
+    module: str  # owning module ("builtins" for the builtin types)
+    owner: str  # type name (methods) or module name (funcs)
+    name: str
+    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]]
+    skip_reason: Optional[str] = None  # statically not drivable
+    out_of_scope: Optional[str] = None  # OS-layer handle; never modelable
+    not_value_function: Optional[str] = None  # output not a comparable value fn
+    side_effect: Optional[str] = None  # audit event the concrete op reaches for
+    probe_hazard: Optional[str] = None  # op blocks/crashes the concrete probe
+
+    @property
+    def drivable(self) -> bool:
+        return (
+            self.call is not None
+            and self.skip_reason is None
+            and self.out_of_scope is None
+        )
+
+    def inputs(self, k: int = 5, seed: int = 0, size: int = 3) -> List[Tuple[Any, ...]]:
+        """Concrete valid argument tuples for this op at the given ``size``."""
+        if self.call is None:
+            return []
+        return valid_inputs(self.call[0], k=k, seed=seed, size=size)
+
+
+def _static_skip_reason(
+    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+) -> Optional[str]:
+    """Why this op is statically excluded from measurement, or None.  Knowable
+    from the op's shape -- no symbolic execution required.  (Identity ops like
+    ``id``/``is_`` are deliberately NOT excluded: they read as forward divergences,
+    which is honest -- opcode interception could one day model them.)"""
+    if call is None:  # SKIP_DUNDERS, no typeshed signature, or operator arity gap
+        return "no drivable signature"
+    return None
+
+
+# Parameter NAMES that denote an OS-layer handle.  typeshed annotates all of these
+# as bare ``int`` (``os.read(fd: int, ...)``), so the TYPE carries no signal -- the
+# name is the only reliable one, and typeshed is consistent about it.  An op taking
+# one is out of scope: a symbolic int can stand in at the Python layer, but the
+# syscall behind it needs a REAL handle CrossHair can't conjure.  (``maxfds`` is
+# deliberately absent -- it's a COUNT of fds, not a descriptor.  Signal NUMBERS are
+# absent too -- a small modelable int, not a handle.)
+_OS_HANDLE_PARAMS: Dict[str, str] = {
+    "fd": "takes an OS file descriptor",
+    "fd_low": "takes an OS file descriptor",
+    "fd_high": "takes an OS file descriptor",
+    "fd2": "takes an OS file descriptor",
+    "pidfd": "takes an OS file descriptor",
+    "pid": "takes an OS process id",
+    "pgid": "takes an OS process-group id",
+    "thread_id": "takes an OS thread id",
+}
+
+
+def _out_of_scope_reason(
+    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+) -> Optional[str]:
+    """Why this op is fundamentally out of CrossHair's scope, or None.  Currently:
+    it takes an OS-layer handle (a file descriptor) we can never model."""
+    if call is None:
+        return None
+    _fn, _expr, argnames, _eg = call
+    for name in argnames:
+        reason = _OS_HANDLE_PARAMS.get(name)
+        if reason is not None:
+            return reason
+    return None
+
+
+# Ops whose output the forward differential can't meaningfully compare -- NOT
+# because they're undrivable, but because the output isn't a deterministic,
+# value-comparable function of the inputs: unordered-container ordering, an
+# arbitrary popped element, an identity-eq result, or a reflective/introspective
+# operation (name-based attribute access, code eval, namespace peeking).  seedkey
+# -> reason.  Both consumers read this off the Operation: the fuzz test SKIPS these
+# (no sound symbolic-vs-concrete assertion exists), and the support sweep still
+# grades their inversion but suppresses the black (forward-soundness) check.  This
+# is the static half of "not a pure value function"; the dynamic half is caught at
+# measure time by :func:`is_deterministic` (which flags time/random/hash-ordering).
+NOT_VALUE_FUNCTION: Dict[str, str] = {
+    # repr/str of an unordered container -- element order in the string is arbitrary
+    "set.__repr__": "set repr element order is unspecified",
+    "frozenset.__repr__": "frozenset repr element order is unspecified",
+    "dict.__repr__": "dict repr order need not match between symbolic and concrete",
+    "set.__str__": "set str element order is unspecified",
+    "frozenset.__str__": "frozenset str element order is unspecified",
+    "dict.__str__": "dict str order need not match between symbolic and concrete",
+    # pop an arbitrary element -- which one is unspecified
+    "set.pop": "set.pop removes an arbitrary, unspecified element",
+    "dict.popitem": "dict.popitem removes an arbitrary, unspecified item",
+    # not value-comparable
+    "dict.values": "dict_values has identity equality; not value-comparable",
+    # builtins that aren't pure value transforms (identity / code / names)
+    "builtins.id": "identity, not a value",
+    "builtins.__import__": "imports a module; not a value transform",
+    "builtins.__lazy_import__": "[3.15+] lazily imports a module; not a value transform",
+    "builtins.compile": "compiles source; output isn't value-comparable",
+    "builtins.exec": "executes code for side effects",
+    "builtins.eval": "evaluates a symbolic code string -- not meaningful",
+    "builtins.getattr": "attribute access by (symbolic) name",
+    "builtins.setattr": "mutates an attribute by name",
+    "builtins.delattr": "deletes an attribute by name",
+    "builtins.hasattr": "attribute probe by name",
+    "builtins.breakpoint": "enters the debugger",
+    "builtins.globals": "introspects the caller's namespace",
+    "builtins.locals": "introspects the caller's namespace",
+    "builtins.vars": "introspects an object's namespace",
+    "builtins.dir": "introspection; order/content not a pure value",
+}
+
+# Ops statically known to reach for I/O -- the tiny set the auditwall probe WOULD
+# flag, hardcoded so ``probe=False`` (the fast default) still classifies them and
+# neither consumer runs them concretely.  (The concrete sweep otherwise fuzzes an
+# op FORWARD; ``open`` on a fuzzed path would drop real files.)  A fuller surface
+# discovers its side effects via a live probe; this list just covers the builtin
+# I/O ops that live on the always-measured surface.  seedkey -> reason.
+SIDE_EFFECT_OVERRIDES: Dict[str, str] = {
+    "builtins.open": "opens a file (I/O)",
+    "builtins.print": "writes output (I/O)",
+}
+
+
+def is_deterministic(
+    forward: Any, args: Sequence[Any], result: Any, mut: bool = False
+) -> bool:
+    """Is this op's output a function of its inputs -- same input, same output?
+
+    Re-runs ``forward`` on a deepcopy of ``args`` and compares.  If it differs
+    (hash with a per-process seed, set/dict-ordering-derived values, time / random
+    / id) the output isn't a function of the inputs, so any inversion verdict is
+    meaningless.  ``mut``: the op mutates its receiver in place, so compare the
+    post-call receiver (``args[0]``) rather than the return value.  A flake on
+    recompute returns True -- don't penalize an op we couldn't re-measure.  This is
+    the DYNAMIC counterpart to :data:`NOT_VALUE_FUNCTION` (which hardcodes the
+    statically-known cases)."""
+    try:
+        args_copy = copy.deepcopy(tuple(args))
+        r = forward(*args_copy)
+        recomputed = args_copy[0] if mut else r
+        return bool(result == recomputed)
+    except Exception:
+        return True
+
+
+# Ops the concrete probe can't RUN -- they block or crash without the auditwall
+# catching them first, so their nature is hardcoded rather than observed.  seedkey
+# -> the probe_hazard reason.  Everything NOT listed (and not out_of_scope) is safe
+# to probe in-process; a new hazard surfaces as HANG/CRASH under a
+# ``probe="isolated"`` discovery pass (see :func:`probe_side_effect_isolated`),
+# which is how this list was built -- rerun it after a Python/typeshed bump.
+# (``os.closerange`` is absent: it takes fds, so ``out_of_scope`` catches it first.)
+PROBE_HAZARD_OVERRIDES: Dict[str, str] = {
+    # file-opening ops: block on a fuzzed path (the wall's ``open`` check only
+    # blocks WRITE flags, so a read-mode open of a real path proceeds and hangs).
+    "os.open": "opens a file (blocks the probe)",
+    "gzip.open": "opens a file (blocks the probe)",
+    "bz2.open": "opens a file (blocks the probe)",
+    "lzma.open": "opens a file (blocks the probe)",
+    "codecs.open": "opens a file (blocks the probe)",
+    "signal.sigwait": "blocks waiting for a signal",
+    # (``time.pthread_getcpuclockid`` used to live here -- it segfaults on a bogus
+    # thread id -- but its ``thread_id`` param now makes it out_of_scope, which
+    # short-circuits before we'd ever probe it.)
+}
+
+# probe_hazard values for an op whose concrete probe misbehaved -- each a signal to
+# add the op to PROBE_HAZARD_OVERRIDES with a hand-written classification.  HANG:
+# still running at the timeout (a blocking op).  CRASH: the child died without a
+# result (a segfault / abort -- e.g. a C call handed a bogus pointer-shaped int).
+HANG = "unprobeable: concrete probe did not terminate"
+CRASH = "unprobeable: concrete probe crashed the interpreter"
+
+
+def probe_side_effect(
+    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+    seedkey: Optional[str] = None,
+    k: int = 3,
+    seed: int = 0,
+    size: int = 1,
+) -> Optional[str]:
+    """Run the op CONCRETELY on a few valid inputs with the auditwall engaged; if
+    it reaches for a blocked side effect (I/O, subprocess, socket, ...) return the
+    audit event message, else None.  A ``seedkey`` in :data:`PROBE_HAZARD_OVERRIDES`
+    short-circuits to its hardcoded reason WITHOUT running the op.
+
+    The wall raises BEFORE the effect happens, so this detects I/O without
+    performing it (no junk files).  std streams are redirected so an op that reads
+    stdin (``input``) or writes stdout (``print``) can't block or spew.  This is an
+    in-process probe: safe on a vetted surface, but an op that BLOCKS (and isn't
+    overridden) will wedge the caller -- use :func:`probe_side_effect_isolated` for
+    an unvetted surface."""
+    if call is None:
+        return None
+    if seedkey is not None and seedkey in PROBE_HAZARD_OVERRIDES:
+        return PROBE_HAZARD_OVERRIDES[seedkey]
+    fn, expr, argnames, eval_globals = call
+    inputs = valid_inputs(fn, k=k, seed=seed, size=size)
+    if not inputs:
+        return None
+    for vals in inputs:
+        if len(vals) != len(argnames):
+            continue
+        try:
+            with enabled_auditwall(), contextlib.redirect_stdout(
+                io.StringIO()
+            ), contextlib.redirect_stderr(io.StringIO()):
+                stdin, sys.stdin = sys.stdin, io.StringIO()
+                try:
+                    eval(expr, dict(eval_globals), dict(zip(argnames, vals)))
+                finally:
+                    sys.stdin = stdin
+        except SideEffectDetected as exc:
+            return str(exc)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException:
+            continue  # the op's OWN error isn't a side effect; try another input
+    return None
+
+
+def _probe_child(call: Any, seedkey: Optional[str], q: Any) -> None:
+    try:
+        q.put(("ok", probe_side_effect(call, seedkey)))
+    except BaseException as exc:  # the probe itself blew up (not the op's own error)
+        q.put(("crash", f"{type(exc).__name__}: {exc}"))
+
+
+def probe_side_effect_isolated(
+    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+    seedkey: Optional[str] = None,
+    timeout: float = 5.0,
+) -> Optional[str]:
+    """Like :func:`probe_side_effect`, but runs in a KILLABLE ``fork`` subprocess so
+    an op that blocks (``time.sleep``, a ``select``/``signal`` wait) the auditwall
+    can't catch returns :data:`HANG` after ``timeout`` (or :data:`CRASH` if the
+    child dies without a result) instead of wedging the caller.  Use for bulk
+    probing of an unvetted surface, or to DISCOVER which ops to add to
+    :data:`PROBE_HAZARD_OVERRIDES`.
+
+    Forks, so call it from a clean process -- no active z3/tracing whose inherited
+    locks would deadlock the child (the lesson the measurement pool learned)."""
+    if call is None:
+        return None
+    if seedkey is not None and seedkey in PROBE_HAZARD_OVERRIDES:
+        return PROBE_HAZARD_OVERRIDES[seedkey]
+    ctx = multiprocessing.get_context("fork")
+    q = ctx.Queue()
+    proc = ctx.Process(target=_probe_child, args=(call, seedkey, q), daemon=True)
+    proc.start()
+    proc.join(timeout)
+    if proc.is_alive():
+        proc.kill()  # SIGKILL reaches even a native-wedged child
+        proc.join()
+        return HANG  # still running: a blocking op (sleep / wait / huge loop)
+    try:
+        status, val = q.get(timeout=1.0)
+    except Exception:
+        return CRASH  # finished but no result: segfault / abort / os._exit
+    return val if status == "ok" else None  # a probe-side crash isn't a side effect
+
+
+def _probe(
+    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+    seedkey: str,
+    mode: Any,
+) -> Tuple[Optional[str], Optional[str]]:
+    """LIVE probe (a no-op unless ``mode`` is truthy).  Returns ``(side_effect,
+    probe_hazard)``: a HANG/CRASH from the isolated probe is a hazard, a discovered
+    audit event a side_effect.  ``mode``: False (skip), True (in-process), or
+    "isolated" (killable subprocess).  Hardcoded PROBE_HAZARD_OVERRIDES are applied
+    by :func:`_classify` BEFORE this runs, so they don't need a live probe."""
+    if not mode or call is None:
+        return (None, None)
+    reason = (
+        probe_side_effect_isolated(call, seedkey)
+        if mode == "isolated"
+        else probe_side_effect(call, seedkey)
+    )
+    if reason in (HANG, CRASH):
+        return (None, reason)
+    return (reason, None)  # a discovered audit event, or (None, None)
+
+
+def _classify(
+    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+    seedkey: str,
+    probe: Any,
+) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """The five classification fields for one op, in precedence order: static skip,
+    out_of_scope, not_value_function, hardcoded side-effect/hazard, then (only if
+    none apply) a LIVE probe.  Everything but the live probe is STATIC -- so
+    ``probe=False`` still yields a complete classification except for
+    live-discovered side effects (empty on a curated surface, where the known I/O
+    ops are already in SIDE_EFFECT_OVERRIDES); consumers enumerate cheaply without
+    probing."""
+    skip = _static_skip_reason(call)
+    if skip is not None:
+        return (skip, None, None, None, None)
+    oos = _out_of_scope_reason(call)
+    if oos is not None:  # never modelable -> don't waste a probe on it
+        return (None, oos, None, None, None)
+    nvf = NOT_VALUE_FUNCTION.get(seedkey)
+    if nvf is not None:  # drivable, but the forward differential can't judge it
+        return (None, None, nvf, None, None)
+    if seedkey in SIDE_EFFECT_OVERRIDES:  # known I/O -> don't run it concretely
+        return (None, None, None, SIDE_EFFECT_OVERRIDES[seedkey], None)
+    if seedkey in PROBE_HAZARD_OVERRIDES:  # hardcoded; applies at any probe level
+        return (None, None, None, None, PROBE_HAZARD_OVERRIDES[seedkey])
+    side_effect, hazard = _probe(call, seedkey, probe)
+    return (None, None, None, side_effect, hazard)
+
+
+def _method_op(module: str, typ: type, meth: str, probe: Any) -> Operation:
+    call = op_call(typ, meth, module)
+    if module == "builtins":
+        key = f"builtins.{typ.__name__}_{meth}_method"
+        seedkey = f"{typ.__name__}.{meth}"
+    else:
+        key = f"{module}.{typ.__name__}_{meth}_method"
+        seedkey = f"{module}.{typ.__name__}.{meth}"
+    skip, oos, nvf, side_effect, hazard = _classify(call, seedkey, probe)
+    return Operation(
+        key=key,
+        seedkey=seedkey,
+        kind="method",
+        module=module,
+        owner=typ.__name__,
+        name=meth,
+        call=call,
+        skip_reason=skip,
+        out_of_scope=oos,
+        not_value_function=nvf,
+        side_effect=side_effect,
+        probe_hazard=hazard,
+    )
+
+
+def _func_op(module: str, name: str, probe: Any) -> Operation:
+    call = func_call(module, name)
+    seedkey = f"{module}.{name}"
+    skip, oos, nvf, side_effect, hazard = _classify(call, seedkey, probe)
+    return Operation(
+        key=seedkey,
+        seedkey=seedkey,
+        kind="func",
+        module=module,
+        owner=module,
+        name=name,
+        call=call,
+        skip_reason=skip,
+        out_of_scope=oos,
+        not_value_function=nvf,
+        side_effect=side_effect,
+        probe_hazard=hazard,
+    )
+
+
+# The canonical operation surface -- the ONE definition both the support map and
+# the differential fuzz test enumerate, so their coverage can't drift.  Free
+# functions (incl. ``builtins`` for len/id/open/...) plus the public classes each
+# module defines (decimal.Decimal, datetime.date, ...); builtin TYPES come from the
+# ``types`` arg.
+CATALOG_FUNC_MODULES: Tuple[str, ...] = (
+    "builtins",
+    "math",
+    "cmath",
+    "statistics",
+    "decimal",
+    "fractions",
+    "numbers",
+    "random",
+    "secrets",
+    "string",
+    "textwrap",
+    "re",
+    "unicodedata",
+    "stringprep",
+    "difflib",
+    "shlex",
+    "html",
+    "json",
+    "base64",
+    "binascii",
+    "quopri",
+    "zlib",
+    "gzip",
+    "bz2",
+    "lzma",
+    "hashlib",
+    "hmac",
+    "itertools",
+    "functools",
+    "operator",
+    "heapq",
+    "bisect",
+    "collections",
+    "copy",
+    "reprlib",
+    "pprint",
+    "calendar",
+    "colorsys",
+    "fnmatch",
+    "posixpath",
+    "ntpath",
+    "genericpath",
+    "urllib.parse",
+    "ipaddress",
+    "uuid",
+    "struct",
+    "ast",
+    "graphlib",
+    "codecs",
+    "time",
+)
+CATALOG_METHOD_MODULES: Tuple[str, ...] = (
+    "decimal",
+    "fractions",
+    "datetime",
+    "collections",
+    "re",
+    "ipaddress",
+    "array",
+    "struct",
+    "time",
+    "urllib.parse",
+)
+
+
+def catalog(
+    *,
+    types: Sequence[type] = tuple(TYPES),
+    method_modules: Sequence[str] = CATALOG_METHOD_MODULES,
+    func_modules: Sequence[str] = CATALOG_FUNC_MODULES,
+    probe: Any = False,
+) -> Iterator[Operation]:
+    """Yield one :class:`Operation` per catalogued op -- the single surface both
+    the support map and the differential fuzz test draw from.  Defaults enumerate
+    the whole canonical surface; pass narrower lists to scope it.
+
+    ``types`` is the builtin type surface (methods over ``builtins``);
+    ``method_modules`` adds methods of the public classes each stdlib module
+    defines; ``func_modules`` adds module-level free functions.
+
+    ``probe`` selects the LIVE side-effect probe per drivable op (static
+    classification -- skip / out_of_scope / hardcoded hazard -- always applies):
+      * ``False``      -- no live probe (the safe default; fast, and complete on a
+                          pure surface where nothing new is discovered).
+      * ``True``       -- in-process (fast; safe on a vetted surface, but a
+                          non-overridden blocking op will wedge the caller).
+      * ``"isolated"`` -- each op in a killable subprocess (safe on ANY surface;
+                          a blocking op is tagged :data:`HANG`).  Slower; forks,
+                          so run it from a clean process."""
+    for typ in types:
+        for meth in surface(typ):
+            yield _method_op("builtins", typ, meth, probe)
+    for module in method_modules:
+        for typ in _module_classes(module):
+            for meth in surface(typ):
+                yield _method_op(module, typ, meth, probe)
+    for module in func_modules:
+        for name in func_surface(module):
+            yield _func_op(module, name, probe)

--- a/crosshair/inputgen_test.py
+++ b/crosshair/inputgen_test.py
@@ -1,0 +1,67 @@
+"""Tests for crosshair.inputgen -- the operation catalog and input generation."""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# The sweep runs in a CLEAN subprocess, not in-process: the concrete probe forks
+# per op, and forking pytest's multi-threaded process risks deadlocking the child
+# (and pytest's own breakpoint/capture hooks perturb ops like builtins.breakpoint).
+# A fresh single-threaded interpreter is the environment the probe is built for.
+_SWEEP = textwrap.dedent(
+    """
+    import sys
+    from crosshair.inputgen import catalog, probe_side_effect_isolated
+    bad = []
+    for op in catalog(probe=False):
+        # Skip what the sweep never runs forward: undrivable, or already excluded
+        # as out-of-scope / a side effect / a probe hazard.  not_value_function ops
+        # ARE run (measured, black-suppressed), so they stay in.
+        if op.call is None or op.out_of_scope or op.side_effect or op.probe_hazard:
+            continue
+        reason = probe_side_effect_isolated(op.call, seedkey=None, timeout=2.0)
+        if reason is not None:
+            bad.append(f"{op.key}: {reason}")
+    sys.stdout.write("\\n".join(bad))
+    """
+)
+
+
+@pytest.mark.slow
+def test_uncategorized_ops_probe_cleanly():
+    """One-sided guard on the classification exclusion lists.
+
+    Every op the concrete support sweep runs forward -- i.e. every drivable op we
+    DON'T already classify away -- must run under the side-effect probe cleanly:
+    without blocking, crashing the interpreter, or reaching for I/O.  A non-clean
+    result names an op the sweep would run for real (wedging a worker, or doing
+    actual I/O), so it must be categorized:
+
+    * a blocking / crashing op -> ``PROBE_HAZARD_OVERRIDES``
+    * an I/O op                -> ``SIDE_EFFECT_OVERRIDES``
+    * an OS-handle op          -> ``_OS_HANDLE_PARAMS`` (out_of_scope)
+
+    Deliberately one-sided: already-excluded ops are NOT re-checked (an
+    input-dependent hang would only flake, and they already read as grey TODO cells
+    on the support grid).  We assert only that nothing NEW slips through
+    uncategorized -- which is what a Python / typeshed bump can introduce.
+
+    Slow: the probe forks per op (~1900 ops / ~90s today, shrinking as the surface
+    is categorized).  Runs only with ``--run-slow``.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _SWEEP],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    offenders = [line for line in proc.stdout.splitlines() if line.strip()]
+    detail = "\n  ".join(offenders)
+    if proc.returncode != 0:
+        detail += f"\n[sweep exited {proc.returncode}]\n{proc.stderr[-2000:]}"
+    assert proc.returncode == 0 and not offenders, (
+        "uncategorized ops don't probe cleanly (hang / crash / I/O); categorize "
+        "them so the concrete sweep skips them:\n  " + detail
+    )

--- a/crosshair/inputgen_test.py
+++ b/crosshair/inputgen_test.py
@@ -10,8 +10,7 @@ import pytest
 # per op, and forking pytest's multi-threaded process risks deadlocking the child
 # (and pytest's own breakpoint/capture hooks perturb ops like builtins.breakpoint).
 # A fresh single-threaded interpreter is the environment the probe is built for.
-_SWEEP = textwrap.dedent(
-    """
+_SWEEP = textwrap.dedent("""
     import sys
     from crosshair.inputgen import catalog, probe_side_effect_isolated
     bad = []
@@ -25,8 +24,7 @@ _SWEEP = textwrap.dedent(
         if reason is not None:
             bad.append(f"{op.key}: {reason}")
     sys.stdout.write("\\n".join(bad))
-    """
-)
+    """)
 
 
 @pytest.mark.slow

--- a/crosshair/tools/measure_support.py
+++ b/crosshair/tools/measure_support.py
@@ -11,12 +11,19 @@ size and watch where CrossHair stops being able to do it:
     only the trivial case    -> red     (CrossHair struggles to reason backwards)
     no drivable / opaque call -> "?"    (couldn't measure it)
 
-The operation surface and the valid-input generation both come from
-``crosshair.inputgen`` (typeshed signatures + fuzzing).
+The operation surface, the valid-input generation, AND the up-front operation
+classification (drivable / out of scope / probe hazard / side effect) all come
+from the ONE ``crosshair.inputgen.catalog`` -- the same surface the differential
+fuzz test enumerates, so the map and the test can't drift.
 
-CLI (both emit the JSON that ``generate_treemap.py`` renders):
-    python -m crosshair.tools.measure_support surface [--types str,int]    --json out.json
-    python -m crosshair.tools.measure_support funcs   [--modules math,json] --json out.json
+CLI (emits the JSON that ``generate_treemap.py`` renders):
+    python -m crosshair.tools.measure_support measure --json out.json
+    # a subset (per-module, for the deadlock workaround; or a single tier):
+    python -m crosshair.tools.measure_support measure --modules math,json --json out.json
+    python -m crosshair.tools.measure_support measure --tiers builtin-methods,functions ...
+
+``--tiers`` selects among {builtin-methods, functions, stdlib-methods}; the docs
+map is ``--tiers builtin-methods,functions`` (no stdlib class methods).
 """
 
 import argparse
@@ -50,12 +57,13 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 import crosshair.core_and_libs  # noqa: F401  -- loads opcode patches / registrations
-from crosshair.behavior_compare import DIFFERENTIAL_SKIP, _is_opaque, run_differential
+from crosshair.behavior_compare import _is_opaque, run_differential
 from crosshair.core import suspected_proxy_intolerance_exception
 from crosshair.core_and_libs import analyze_function, run_checkables
 from crosshair.inputgen import (  # shared surface + valid-input generation
     _ROUNDTRIP,
     ANN_NS,
+    NOT_VALUE_FUNCTION,
     RECV,
     SKIP_DUNDERS,
     TYPES,
@@ -64,10 +72,12 @@ from crosshair.inputgen import (  # shared surface + valid-input generation
     _candidate_sigs,
     _func_candidate_sigs,
     _module_classes,
-    _module_funcs,
     _resolve_arg,
     call_expr,
+    catalog,
     func_call,
+    func_surface,
+    is_deterministic,
     op_call,
     surface,
 )
@@ -268,22 +278,6 @@ def _invert_one(
     return "unknown"
 
 
-def _deterministic(fwd: Callable, t: Sequence[Any], v: Any, mut: bool) -> bool:
-    """Does the op give the same output for the same input?  If not (hash with a
-    per-process seed aside, set/dict-ordering-derived values, time/random/id) the
-    inversion target isn't a function of the inputs, so the verdict is meaningless.
-    Recomputed on a deepcopy so an in-place mutator's input isn't disturbed."""
-    import copy
-
-    try:
-        tc = copy.deepcopy(t)
-        r = fwd(*tc)
-        v2 = tc[0] if mut else r
-        return bool(v == v2)
-    except Exception:
-        return True  # flaked on recompute -> don't penalize it
-
-
 def _sweep(
     params: Sequence[Tuple[str, str, Any]],
     expr: str,
@@ -343,7 +337,7 @@ def _sweep(
         # return even though concrete re-runs differ), so only check when params.
         if params and not checked_determinism:  # op-level property; check once
             checked_determinism = True
-            if not _deterministic(fwd, t, v, mut):
+            if not is_deterministic(fwd, t, v, mut):
                 return ("?", "nondeterministic output", None)
         samples.append((n, t, v))
     if not samples:
@@ -493,19 +487,6 @@ def _synth_candidates(
     return cands
 
 
-# Ops whose result is NOT a function of their declared arguments -- it's an
-# object identity / address.  CrossHair's inversion "confirms" no input yields
-# the (address-valued) output that one demonstrably does, which we'd misread as a
-# soundness bug.  These aren't value transforms at all, so grade "?" (unmeasured)
-# rather than black.  (Nondeterministic ops like ``secrets.randbelow`` are caught
-# separately -- the differential's determinism guard + the holdout's
-# ``_deterministic`` check both drop them.)
-_NOT_A_VALUE_FUNCTION = {
-    "builtins.id",
-    "operator.is_",
-    "operator.is_not",
-}
-
 DIFF_K = 3  # valid inputs to try in the forward-soundness check
 # Keep the soundness probe cheap: don't grind the full pin-search on hard-to-pin
 # container shapes (an input that can't pin in budget is skipped; the holdout
@@ -556,7 +537,7 @@ def _diff_black(label: str, call: Any) -> Optional[Tuple[str, str, Optional[str]
     unsoundness (falsely confirming no input yields an output), so forward bugs
     like ``float // float`` returning an int read GREEN without it.  Ops whose
     output legitimately varies (order/identity) are left to the holdout."""
-    if call is None or label in DIFFERENTIAL_SKIP:
+    if call is None or label in NOT_VALUE_FUNCTION:
         return None
     fn, expr, names, eval_globals = call
     try:
@@ -604,8 +585,6 @@ def measure_op(
         if module == "builtins"
         else f"{module}.{typ.__name__}.{method}"
     )
-    if seedkey in _NOT_A_VALUE_FUNCTION:
-        return ("?", "not a pure value function", None)
     black = _diff_black(seedkey, op_call(typ, method, module))  # forward-soundness
     if black:
         return black
@@ -647,8 +626,6 @@ def measure_func(module: str, func: str) -> Optional[Tuple[str, str, Optional[st
     if not cands:
         return ("?", "no signature: no synthesizable call", None)
     seedkey = f"{module}.{func}"
-    if seedkey in _NOT_A_VALUE_FUNCTION:
-        return ("?", "not a pure value function", None)
     black = _diff_black(seedkey, func_call(module, func))  # forward-soundness first
     if black:
         return black
@@ -676,25 +653,6 @@ def measure_func(module: str, func: str) -> Optional[Tuple[str, str, Optional[st
         deferred = (color, verdict, None)
     # every candidate raised while resolving arguments -> no drivable call at all
     return deferred or ("?", "no signature: no resolvable arguments", None)
-
-
-def func_surface(module: str) -> List[str]:
-    """Public free-function names of a module that the funcs measurement targets:
-    typeshed-known, public, present + callable at runtime, and not a type
-    (type constructors are covered by the type surface, not here)."""
-    try:
-        mod = importlib.import_module(module)
-    except Exception:
-        return []
-    out = []
-    for name in sorted(_module_funcs(module)):
-        if name.startswith("_"):
-            continue
-        obj = getattr(mod, name, None)
-        if obj is None or not callable(obj) or isinstance(obj, type):
-            continue
-        out.append(name)
-    return out
 
 
 # ---------------------------------------------------------------------------
@@ -725,23 +683,41 @@ def _safe(call: Callable[[], Any]) -> Any:
         _cleanup_tmp()
 
 
-def _op_task(item: Tuple[type, str]) -> Tuple[str, str, Any]:
-    typ, meth = item
-    res = _safe(lambda: measure_op(typ, meth))
-    return (f"builtins.{typ.__name__}_{meth}_method", f"{typ.__name__}.{meth}", res)
+def _resolve_type(op: Any) -> Optional[type]:
+    """The runtime type object for a catalogued method op (its ``owner`` name in
+    the op's owning module).  None if the module/type is absent at runtime."""
+    try:
+        return getattr(importlib.import_module(op.module), op.owner, None)
+    except Exception:
+        return None
 
 
-def _func_task(item: Tuple[str, str]) -> Tuple[str, str, Any]:
-    module, name = item
-    res = _safe(lambda: measure_func(module, name))
-    return (f"{module}.{name}", f"{module}.{name}", res)
-
-
-def _method_task(item: Tuple[str, type, str]) -> Tuple[str, str, Any]:
-    module, typ, meth = item
-    res = _safe(lambda: measure_op(typ, meth, module))
-    key = f"{module}.{typ.__name__}_{meth}_method"
-    return (key, f"{module}.{typ.__name__}.{meth}", res)
+def _measure_task(key: str) -> Tuple[str, str, Any]:
+    """Measure ONE catalogued op, looked up by its key.  The catalog already
+    settled the up-front classification, so we honor it here instead of
+    re-deriving it: an op that is out of scope, a probe hazard, or reaches for I/O
+    is rendered as an explained grey cell and is NEVER run concretely (that's what
+    kept the concrete sweep from doing real I/O).  Only a cleanly drivable op is
+    handed to the symbolic measurement."""
+    op = _CATALOG[key]
+    if op.out_of_scope:
+        res: Any = ("?", f"out of scope: {op.out_of_scope}", None)
+    elif op.probe_hazard:
+        res = ("?", f"probe hazard: {op.probe_hazard}", None)
+    elif op.side_effect:
+        res = ("?", f"side effect: {op.side_effect}", None)
+    elif op.call is None:
+        res = ("?", op.skip_reason or "no signature: no synthesizable call", None)
+    elif op.kind == "method":
+        typ = _resolve_type(op)
+        res = (
+            _safe(lambda: measure_op(typ, op.name, op.module))
+            if typ is not None
+            else ("?", "not in runtime: type absent from interpreter", None)
+        )
+    else:
+        res = _safe(lambda: measure_func(op.module, op.name))
+    return (op.key, op.seedkey, res)
 
 
 # A single op can wedge a worker in native code (CrossHair's own per-condition
@@ -756,7 +732,9 @@ _PER_TASK_TIMEOUT = 90
 _TASKS_PER_CHILD = 8
 
 
-def _label(t: Iterable[Any]) -> str:
+def _label(t: Any) -> str:
+    if isinstance(t, str):  # catalog tasks are op keys (already the identity)
+        return t
     return ".".join(getattr(x, "__name__", str(x)) for x in t)
 
 
@@ -922,65 +900,53 @@ def _measure_cmd(
     _emit(args, out)
 
 
-def cmd_surface(args: argparse.Namespace) -> None:
-    """Measure every builtin (type, method) pair via synthesized calls."""
-    wanted = set(args.types.split(",")) if args.types else None
-    tasks = [
-        (typ, meth)
-        for typ in TYPES
-        if not wanted or typ.__name__ in wanted
-        for meth in surface(typ)
-    ]
-    _measure_cmd(args, tasks, _op_task, 32)
+# The ONE surface -- built once at import from crosshair.inputgen.catalog and
+# reused by every worker (forkserver inherits it; spawn rebuilds it on re-import).
+# probe=False: static classification is complete and safe on this curated surface --
+# the I/O ops are caught statically (gzip/bz2/... open -> probe_hazard; builtins
+# open/print -> side_effect override) -- so we never need a live probe here.  Keyed
+# by op.key (the exact key generate_treemap looks up).
+_CATALOG = {op.key: op for op in catalog(probe=False)}
+
+_ALL_TIERS = ("builtin-methods", "functions", "stdlib-methods")
 
 
-# A broad, pure (no side effects on import/call) set of stdlib modules to measure
-# free functions in -- the default corpus for the `funcs` command and the docs map.
-STDLIB_MODULES = (
-    "builtins,math,cmath,statistics,decimal,fractions,numbers,random,secrets,string,"
-    "textwrap,re,unicodedata,stringprep,difflib,shlex,html,json,base64,binascii,quopri,"
-    "zlib,gzip,bz2,lzma,hashlib,hmac,itertools,functools,operator,heapq,bisect,"
-    "collections,copy,reprlib,pprint,calendar,colorsys,fnmatch,posixpath,ntpath,"
-    "genericpath,urllib.parse,ipaddress,uuid,struct,ast,graphlib,codecs,time"
-).split(",")
+def _tier(op: Any) -> str:
+    """Which map tier a catalogued op belongs to -- the successor of the old
+    surface / funcs / methods split, now just a VIEW over the one catalog."""
+    if op.kind == "func":
+        return "functions"
+    return "builtin-methods" if op.module == "builtins" else "stdlib-methods"
 
 
-def cmd_funcs(args: argparse.Namespace) -> None:
-    """Measure module-level (free) functions in the given stdlib modules.
+def cmd_measure(args: argparse.Namespace) -> None:
+    """Measure the whole catalog (or a scoped subset).
 
-    Draws the surface from ``func_surface`` (not raw ``_module_funcs``) so the
-    measured set matches exactly what ``generate_treemap`` renders.  ``_module_funcs``
-    follows typeshed re-exports, which drags in typing/abc decorators the stubs
-    import but the runtime module never defines (``overload``, ``final``,
-    ``type_check_only``, ``disjoint_base``, ``abstractmethod`` -- 65 such cells across
-    the default corpus).  Those were measured as noise ``"?"`` records that never
-    appeared on the map; ``func_surface`` drops any name absent/uncallable at
-    runtime, so they no longer inflate the tally or the JSON."""
-    modules = args.modules.split(",") if args.modules else STDLIB_MODULES
-    tasks = [(module, name) for module in modules for name in func_surface(module)]
-    _measure_cmd(args, tasks, _func_task, 36)
-
-
-# stdlib modules whose CLASSES CrossHair models (libimpl coverage) -- the default
-# corpus for the `methods` command.  Unmodeled classes measure red/unsupported
-# (honest), so we don't over-broaden past what carries signal.
-METHOD_MODULES = (
-    "decimal,fractions,datetime,collections,re,ipaddress,array,struct,time,"
-    "urllib.parse"
-).split(",")
-
-
-def cmd_methods(args: argparse.Namespace) -> None:
-    """Measure methods of classes DEFINED in the given stdlib modules (e.g.
-    decimal.Decimal.quantize) -- the class-method analogue of ``surface``."""
-    modules = args.modules.split(",") if args.modules else METHOD_MODULES
-    tasks = [
-        (module, cls, meth)
-        for module in modules
-        for cls in _module_classes(module)
-        for meth in surface(cls)
-    ]
-    _measure_cmd(args, tasks, _method_task, 40)
+    One code path replaces the old surface / funcs / methods commands, which each
+    kept their own drifting module list.  ``--tiers`` selects among the three map
+    tiers (the docs map is ``builtin-methods,functions`` -- no stdlib class
+    methods); ``--modules`` / ``--types`` scope it further, chiefly so a wedged
+    module can be re-measured in its own killable invocation."""
+    tiers = set(args.tiers.split(",")) if args.tiers else set(_ALL_TIERS)
+    bad = tiers - set(_ALL_TIERS)
+    if bad:
+        raise SystemExit(f"unknown --tiers {sorted(bad)}; pick from {_ALL_TIERS}")
+    modules = set(args.modules.split(",")) if args.modules else None
+    types = set(args.types.split(",")) if args.types else None
+    tasks = []
+    for op in _CATALOG.values():
+        if _tier(op) not in tiers:
+            continue
+        if modules is not None and op.module not in modules:
+            continue
+        if (
+            types is not None
+            and _tier(op) == "builtin-methods"
+            and op.owner not in types
+        ):
+            continue
+        tasks.append(op.key)
+    _measure_cmd(args, tasks, _measure_task, 44)
 
 
 def _emit(args: argparse.Namespace, results: Dict[str, Any]) -> None:
@@ -995,47 +961,27 @@ def _emit(args: argparse.Namespace, results: Dict[str, Any]) -> None:
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     sub = ap.add_subparsers(dest="cmd", required=True)
-    s = sub.add_parser("surface", help="measure every builtin (type, method) pair")
-    s.add_argument("--types", help="comma-separated builtin type filter (e.g. str,int)")
-    s.add_argument("--json", dest="json_path")
-    s.add_argument(
-        "--jobs",
-        type=int,
-        default=1,
-        help="parallel worker processes (default 1); each pins a core with a z3 "
-        "solve, so keep it at or below your core count",
+    m = sub.add_parser("measure", help="measure the operation catalog (or a subset)")
+    m.add_argument(
+        "--tiers",
+        help="comma-separated map tiers to measure "
+        f"(default: all of {','.join(_ALL_TIERS)})",
     )
-    s.set_defaults(func=cmd_surface)
-    fn = sub.add_parser("funcs", help="measure module-level (free) functions")
-    fn.add_argument(
+    m.add_argument(
         "--modules",
-        help="comma-separated module list "
-        "(default: the curated stdlib set in STDLIB_MODULES)",
+        help="comma-separated owning-module filter (e.g. math,json); scopes "
+        "functions and stdlib methods, chiefly for per-module re-measurement",
     )
-    fn.add_argument("--json", dest="json_path")
-    fn.add_argument(
+    m.add_argument("--types", help="comma-separated builtin type filter (e.g. str,int)")
+    m.add_argument("--json", dest="json_path")
+    m.add_argument(
         "--jobs",
         type=int,
         default=1,
         help="parallel worker processes (default 1); each pins a core with a z3 "
         "solve, so keep it at or below your core count",
     )
-    fn.set_defaults(func=cmd_funcs)
-    me = sub.add_parser("methods", help="measure methods of stdlib-defined classes")
-    me.add_argument(
-        "--modules",
-        help="comma-separated module list "
-        "(default: the modeled-class set in METHOD_MODULES)",
-    )
-    me.add_argument("--json", dest="json_path")
-    me.add_argument(
-        "--jobs",
-        type=int,
-        default=1,
-        help="parallel worker processes (default 1); each pins a core with a z3 "
-        "solve, so keep it at or below your core count",
-    )
-    me.set_defaults(func=cmd_methods)
+    m.set_defaults(func=cmd_measure)
     args = ap.parse_args()
     args.func(args)
 

--- a/crosshair/tools/measure_support.py
+++ b/crosshair/tools/measure_support.py
@@ -61,14 +61,12 @@ from crosshair.behavior_compare import _is_opaque, run_differential
 from crosshair.core import suspected_proxy_intolerance_exception
 from crosshair.core_and_libs import analyze_function, run_checkables
 from crosshair.inputgen import (  # shared surface + valid-input generation
-    _ROUNDTRIP,
     ANN_NS,
     NOT_VALUE_FUNCTION,
     RECV,
     SKIP_DUNDERS,
     TYPES,
     _ann,
-    _arg_strategy,
     _candidate_sigs,
     _func_candidate_sigs,
     _module_classes,
@@ -80,6 +78,7 @@ from crosshair.inputgen import (  # shared surface + valid-input generation
     is_deterministic,
     op_call,
     surface,
+    tuple_strategy,
 )
 from crosshair.options import AnalysisOptionSet
 from crosshair.statespace import MessageType
@@ -135,12 +134,15 @@ def _fuzz_valid(
     n: int,
     rngseed: int,
     record: Callable[[tuple], Optional[Tuple[Any, Any]]],
+    seedkey: Optional[str] = None,
 ) -> Optional[Tuple[Any, Any]]:
     """Drive Hypothesis over a size-n input tuple and return the last (input,
     target) pair ``record`` keeps -- a developed (not Hypothesis's first minimal)
     example.  ``record(t)`` returns the pair to store, or None to assume() the
-    example away (an exception, or a degenerate/non-mutating call)."""
-    strat = st.tuples(*[_arg_strategy(spec, n) for _, spec in args])
+    example away (an exception, or a degenerate/non-mutating call).  ``seedkey``
+    selects a CUSTOM_INPUTS override (shared with the differential path) when one
+    is registered for this op."""
+    strat = tuple_strategy(seedkey, [spec for _, spec in args], n)
     found = []
 
     @hyp_seed(rngseed)
@@ -166,7 +168,11 @@ def _fuzz_valid(
 
 
 def fuzz_valid(
-    args: Sequence[Tuple[str, Any]], n: int, forward: Callable, rngseed: int
+    args: Sequence[Tuple[str, Any]],
+    n: int,
+    forward: Callable,
+    rngseed: int,
+    seedkey: Optional[str] = None,
 ) -> Optional[Tuple[Any, Any]]:
     """A VALID, non-degenerate input at size n: skip exceptions and None results,
     and take a developed example."""
@@ -182,11 +188,15 @@ def fuzz_valid(
             return None
         return (pre, v)  # store the PRE-call input, not the mutated one
 
-    return _fuzz_valid(args, n, rngseed, record)
+    return _fuzz_valid(args, n, rngseed, record, seedkey)
 
 
 def fuzz_valid_mut(
-    args: Sequence[Tuple[str, Any]], n: int, forward: Callable, rngseed: int
+    args: Sequence[Tuple[str, Any]],
+    n: int,
+    forward: Callable,
+    rngseed: int,
+    seedkey: Optional[str] = None,
 ) -> Optional[Tuple[Any, Any]]:
     """Like ``fuzz_valid`` but for an in-place mutator: a VALID, non-degenerate
     input at size n whose call returns None *and* actually changes the receiver
@@ -207,7 +217,7 @@ def fuzz_valid_mut(
         # pinning) starts from the original, not the already-mutated, receiver.
         return ((orig, *t[1:]), copy.deepcopy(t[0]))
 
-    return _fuzz_valid(args, n, rngseed, record)
+    return _fuzz_valid(args, n, rngseed, record, seedkey)
 
 
 def _invert_one(
@@ -323,9 +333,9 @@ def _sweep(
     for n in SIZES:
         seed = hash(seedkey) % 1000 + n
         sample = (
-            fuzz_valid_mut(specs, n, fwd, seed)
+            fuzz_valid_mut(specs, n, fwd, seed, seedkey)
             if mut
-            else fuzz_valid(specs, n, fwd, seed)
+            else fuzz_valid(specs, n, fwd, seed, seedkey)
         )
         if sample is None:
             continue
@@ -542,7 +552,13 @@ def _diff_black(label: str, call: Any) -> Optional[Tuple[str, str, Optional[str]
     fn, expr, names, eval_globals = call
     try:
         result = run_differential(
-            fn, expr, names, eval_globals, k=DIFF_K, max_pin_iters=DIFF_MAX_PIN_ITERS
+            fn,
+            expr,
+            names,
+            eval_globals,
+            k=DIFF_K,
+            max_pin_iters=DIFF_MAX_PIN_ITERS,
+            seedkey=label,
         )
     except BaseException:
         return None  # never let the soundness probe break measurement
@@ -642,9 +658,9 @@ def measure_func(module: str, func: str) -> Optional[Tuple[str, str, Optional[st
             continue
         # zero-arg funcs are still measurable: invert the RETURN (CrossHair models
         # some, e.g. time.time(), as a symbolic value), so we don't skip them.
-        rt = _ROUNDTRIP.get((module, func))  # feed a decoder a real encoded input
-        if rt:
-            params[0] = (params[0][0], params[0][1], ("roundtrip",) + rt)
+        # (A decoder's real-encoded input, aliased pairs, etc. now come from the
+        # catalog's CUSTOM_INPUTS, keyed by seedkey inside _sweep -- no per-arg
+        # override here.)
         color, verdict, demo = _sweep(
             params, expr, f"import {module}\n", module, seedkey, defer_on_norun=True
         )


### PR DESCRIPTION
Unifies the operation-classification layer that the differential fuzz test and the support-map measurement had been duplicating (with separate, drifting module lists and ad-hoc decisions).

## What changed

**One catalog** (`crosshair.inputgen.catalog()`) yields an `Operation` per op with five orthogonal classification fields — `skip_reason`, `out_of_scope`, `not_value_function`, `side_effect`, `probe_hazard`. Both `fuzz_core_test` and `measure_support` now enumerate it, so their coverage can’t drift.

- **Retire `behavior_compare.DIFFERENTIAL_SKIP`**: split by concept into `inputgen.NOT_VALUE_FUNCTION` (order/identity/reflection) and `SIDE_EFFECT_OVERRIDES` (builtin I/O), read off each `Operation`. Making `open`/`print` static side-effects means the sweep short-circuits them instead of fuzzing them forward (no more junk files).
- **Relocate** `measure_support._deterministic` → `inputgen.is_deterministic` (the dynamic half of `not_value_function`).
- **measure_support**: collapse the `surface`/`funcs`/`methods` commands (each with its own module list) into one `measure` command over the catalog, with `--tiers`/`--modules`/`--types` scoping. Keep the forkserver kill-harness.
- **auditwall**: add `enabled_auditwall()` so the concrete side-effect probe can police a short region without leaving the wall active.

**`CUSTOM_INPUTS` registry** (generalizes the former `_ROUNDTRIP`): seedkey-keyed whole-tuple input strategies for ops where independent per-arg fuzzing can’t build a useful input, consulted by *both* input paths so a custom input is tested *and* performance-measured.

- `getattr(o, name)`: draw `name` from `o`’s real attributes; it’s now a passing CI-gate test (removed from `NOT_VALUE_FUNCTION`).
- `operator.is_`/`is_not`: draw an aliased `(x, x)`, which witnesses [#47](https://github.com/pschanely/CrossHair/issues/47) (top-level parameter aliasing unmodeled). Recorded as `xfail`; the coupled harness change (shared-proxy pinning) is noted there.

## Testing

CI fuzz gate: **390 passed, 1466 skipped, 8 xfailed, 4 xpassed**. Support map unchanged except `getattr`/`is_`/`is_not` now render as measured cells and `open`/`print` as explained side-effect cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)