### PR TITLE
devcontainer: pre-fetch pinned pre-commit tools for CI parity

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,5 +10,13 @@ pyenv local 3.13
 
 bash "$(dirname "$0")/install-crosshair.sh"
 
+# Pre-fetch the pinned code-quality tools (black/isort/flake8/mypy at the versions
+# in .pre-commit-config.yaml) so `pre-commit run` matches CI exactly -- and can't
+# drift from it even when a stale interpreter has an older pip-installed black.
+# Deliberately NOT `pre-commit install`: we don't wire a git hook, so commits stay
+# free of hidden reformats.  Run checks explicitly with `pre-commit run` (or
+# `pre-commit run --all-files`); CI enforces them on push.
+pre-commit install-hooks
+
 echo "CrossHair devcontainer is ready (Python 3.13)."
 echo "Use 'switch-python 3.11' (etc.) to test other CI versions."


### PR DESCRIPTION
Makes local code-quality checks match CI without any hidden execution.

`post-create.sh` now runs `pre-commit install-hooks`, which installs the tool
environments (black / isort / flake8 / mypy) at the versions pinned in
`.pre-commit-config.yaml`.  `pre-commit run` then produces byte-identical results
to CI and runs fast — and can't drift from CI even when the container has a stale
pip-installed `black` (exactly what let a black-version mismatch slip to CI recently:
local `black` was 25.11.0 while the repo pins 26.5.1).

**Deliberately not `pre-commit install`** — no git hook is wired, so `git commit`
stays free of hidden reformats.  Checks are run explicitly (`pre-commit run`, or
`pre-commit run --all-files`) and CI enforces them on push.  (A bare
`pre-commit install` would also abort `post-create` under an agent session, which
sets `core.hooksPath=/dev/null` to disable hooks.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)