### PR TITLE
Enforce byte range on symbolic bytearray mutation

### DIFF
--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -4389,13 +4389,19 @@ class SymbolicBytes(BytesLike):
         return SymbolicBytes(accumulated)
 
 
+def _out_of_byte_range(value) -> bool:
+    # any() folds the two bounds into one symbolic expression, so a symbolic
+    # value forks once here rather than once per `or` operand.
+    return any((value < 0, value > 255))
+
+
 def _as_byte_value(value):
     """Validate a value being stored into a bytearray, matching CPython: it must
     be an integer in range(0, 256).  Keeps the (possibly symbolic) integer so a
     symbolic value forks into its in-range and ValueError paths."""
     if not isinstance(value, Integral):
         raise TypeError("an integer is required")
-    if value < 0 or value > 255:
+    if _out_of_byte_range(value):
         raise ValueError("byte must be in range(0, 256)")
     return value
 
@@ -4409,7 +4415,14 @@ def _validated_byte_values(seq):
         byte_seq = buffer_to_byte_seq(seq)
         if byte_seq is not None and byte_seq is not seq:
             return seq
-    return [_as_byte_value(x) for x in seq]
+    values = list(seq)
+    if any(not isinstance(x, Integral) for x in values):
+        raise TypeError("an integer is required")
+    # Nesting any() over the per-element checks collapses the whole sequence's
+    # range test into a single path fork instead of one per element.
+    if any(_out_of_byte_range(x) for x in values):
+        raise ValueError("byte must be in range(0, 256)")
+    return values
 
 
 def make_byte_string(creator: SymbolicFactory):

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -4389,6 +4389,29 @@ class SymbolicBytes(BytesLike):
         return SymbolicBytes(accumulated)
 
 
+def _as_byte_value(value):
+    """Validate a value being stored into a bytearray, matching CPython: it must
+    be an integer in range(0, 256).  Keeps the (possibly symbolic) integer so a
+    symbolic value forks into its in-range and ValueError paths."""
+    if not isinstance(value, Integral):
+        raise TypeError("an integer is required")
+    if value < 0 or value > 255:
+        raise ValueError("byte must be in range(0, 256)")
+    return value
+
+
+def _validated_byte_values(seq):
+    """Values destined for a bytearray's storage.  A bytes-like source already
+    constrains its elements to 0..255 (and stays lazy, keeping a symbolic length
+    symbolic), so it passes through untouched; any other iterable is validated
+    element-by-element."""
+    with NoTracing():
+        byte_seq = buffer_to_byte_seq(seq)
+        if byte_seq is not None and byte_seq is not seq:
+            return seq
+    return [_as_byte_value(x) for x in seq]
+
+
 def make_byte_string(creator: SymbolicFactory):
     return SymbolicBytes(SymbolicBoundedIntTuple([(0, 255)], creator.varname))
 
@@ -4445,6 +4468,23 @@ class SymbolicByteArray(BytesLike, ShellMutableSequence):  # type: ignore
 
     def _spawn(self, items: Sequence) -> ShellMutableSequence:
         return SymbolicByteArray(items)
+
+    def append(self, item):
+        ShellMutableSequence.append(self, _as_byte_value(item))
+
+    def extend(self, other):
+        ShellMutableSequence.extend(self, _validated_byte_values(other))
+
+    def insert(self, index, item):
+        ShellMutableSequence.insert(self, index, _as_byte_value(item))
+
+    def __setitem__(self, key, value):
+        if isinstance(key, slice):
+            if is_iterable(value):  # else let super() raise the iterable TypeError
+                value = _validated_byte_values(value)
+        else:
+            value = _as_byte_value(value)
+        ShellMutableSequence.__setitem__(self, key, value)
 
     def decode(self, encoding="utf-8", errors="strict"):
         return codecs.decode(self, encoding, errors=errors)

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -3742,6 +3742,34 @@ def test_bytearray___add___method():
     check_states(f, POST_FAIL)
 
 
+def test_bytearray_mutation_rejects_out_of_range():
+    with standalone_statespace:
+        ba = proxy_for_type(bytearray, "ba")
+        for out_of_range in (-1, 256, 300):
+            with pytest.raises(ValueError):
+                ba.append(out_of_range)
+            with pytest.raises(ValueError):
+                ba.insert(0, out_of_range)
+            with pytest.raises(ValueError):
+                ba.extend([out_of_range])
+
+
+def test_bytearray_append_enforces_byte_range():
+    # Regression: bytearray mutators used to store an out-of-range value silently
+    # (see changelog), so CrossHair unsoundly believed a bytearray could hold a
+    # byte outside 0..255.  Either the mutation raises, or the byte is in range.
+    def f(x: int) -> bool:
+        """post: _"""
+        ba = bytearray()
+        try:
+            ba.append(x)
+        except ValueError:
+            return True
+        return 0 <= ba[0] <= 255
+
+    check_states(f, CONFIRMED)
+
+
 def test_extend_concrete_bytearray():
     with standalone_statespace as space:
         b = bytearray(b"abc")

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,6 +6,13 @@ Changelog
 Next Version
 ---------------
 
+ * Fix symbolic ``bytearray`` mutation (``append``, ``extend``, ``insert``, and
+   ``__setitem__``) accepting values outside ``range(0, 256)``. Storing an
+   out-of-range value (e.g. ``ba.append(256)`` or ``ba.extend([-1])``) silently
+   succeeded, where concrete Python raises ``ValueError`` -- so CrossHair could
+   unsoundly conclude a ``bytearray`` held a byte outside 0..255. These mutators
+   now enforce the byte range (raising ``ValueError`` on the out-of-range path),
+   matching concrete ``bytearray``.
  * Fix symbolic ``decimal.Decimal`` arguments collapsing to ``Decimal(0)``. The
    symbolic factory built the coefficient from the *codepoints* of the digits
    ``"0"``..``"9"`` (48..57) instead of the digit values ``0``..``9``, so every


### PR DESCRIPTION
## What

Fixes an unsoundness in symbolic `bytearray` mutation. `append`, `extend`, `insert`, and `__setitem__` were inherited from `ShellMutableSequence`, which stores any value without the `0..255` range check that concrete `bytearray` enforces. So a symbolic bytearray could silently hold an out-of-range byte:

```python
ba = bytearray()
ba.append(256)      # symbolic: succeeded silently;  concrete Python: ValueError
ba.extend([-1])     # symbolic: succeeded silently;  concrete Python: ValueError
```

CrossHair could then unsoundly conclude a `bytearray` held a byte outside `0..255`.

## How I found it

While investigating the bytes cluster in the support map, I ran the measurement's forward-differential (`measure_support`'s soundness probe) over `bytes`/`bytearray`/`memoryview`. It flagged exactly these four `bytearray` mutators as **black** ("forward result differs from Python"), with concrete divergences like `bytearray(b'\xc2\xe3k').append(366)` → `ValueError('byte must be in range(0, 256)')` on the concrete side, no error on the symbolic side.

## Fix

The four mutators now validate each stored value through a new `_as_byte_value` helper, which raises `TypeError`/`ValueError` matching CPython and **keeps the value symbolic** — so an out-of-range symbolic value forks into its `ValueError` path rather than being rejected up front.

A bytes-like source (`bytes`, `bytearray`, `memoryview`, or their symbolic counterparts) already constrains its elements to `0..255`, so `_validated_byte_values` passes it through untouched — this preserves laziness, keeping a **symbolic-length** source's length symbolic (an earlier eager-validation attempt collapsed it, which `test_extend_concrete_bytearray` caught).

## Tests

- `test_bytearray_mutation_rejects_out_of_range` — `append`/`insert`/`extend` raise `ValueError` for `-1`, `256`, `300`.
- `test_bytearray_append_enforces_byte_range` — soundness regression (`check_states … CONFIRMED`): for all int `x`, either the mutation raises or the stored byte is in `0..255`. Before the fix this returned `False` for `x=256` → `POST_FAIL`.

Verified: the four black cells now show no divergence; `builtinslib_test.py` passes (488 passed, 2 skipped); pre-commit clean.

## Follow-ups (out of scope here)

- `bytes.__mod__` / `bytearray.__mod__` also measured black, but didn't reproduce under my differential seed — needs separate investigation.
- The large red "only the trivial case" cluster across bytes/bytearray string-methods is a *representational* gap (bytes modeled as an int-tuple, which z3 can't invert at non-trivial sizes, vs `str`'s native sequence theory) — a bigger, separate effort.
- Minor: `bytes.translate(table, delete)` and `bytes.maketrans` inherit `str` semantics via `AbcString`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)