### PR TITLE
Windows follow-ups: normalize --unblock, un-skip fuzz_core, expand matrix

### DIFF
--- a/.github/workflows/test_crosshair.yml
+++ b/.github/workflows/test_crosshair.yml
@@ -47,8 +47,16 @@ jobs:
           # Windows: heavy symbolic-execution tests can let a single z3 query
           # overrun its soft wall-clock timeout and wedge the run, so we bound
           # solver work deterministically with a z3 rlimit budget
-          # (CROSSHAIR_SMT_RLIMIT, applied only here). fuzz_core is skipped on
-          # Windows for now -- it surfaces Windows-only op gaps (see the module).
+          # (CROSSHAIR_SMT_RLIMIT, applied only here). We run a low and a high
+          # supported version (3.10 and 3.13) rather than the full Linux matrix.
+          # 3.10 is newly added and starts experimental: fuzz_core's Windows
+          # triage (WINDOWS_KNOWN_FAILURES) was calibrated on 3.13, so 3.10 may
+          # surface a few more version-specific divergences to quarantine. Drop
+          # `experimental` once it's confirmed green.
+          - os: windows-latest
+            python-version: "3.10"
+            smt_rlimit: "200000000"
+            experimental: true
           - os: windows-latest
             python-version: "3.13"
             smt_rlimit: "200000000"

--- a/.github/workflows/test_crosshair.yml
+++ b/.github/workflows/test_crosshair.yml
@@ -47,16 +47,17 @@ jobs:
           # Windows: heavy symbolic-execution tests can let a single z3 query
           # overrun its soft wall-clock timeout and wedge the run, so we bound
           # solver work deterministically with a z3 rlimit budget
-          # (CROSSHAIR_SMT_RLIMIT, applied only here). We run a low and a high
-          # supported version (3.10 and 3.13) rather than the full Linux matrix.
-          # 3.10 is newly added and starts experimental: fuzz_core's Windows
-          # triage (WINDOWS_KNOWN_FAILURES) was calibrated on 3.13, so 3.10 may
-          # surface a few more version-specific divergences to quarantine. Drop
-          # `experimental` once it's confirmed green.
+          # (CROSSHAIR_SMT_RLIMIT, applied only here). We run two versions rather
+          # than the full Linux matrix. The low version is 3.12, NOT 3.10/3.11:
+          # the C tracer's pre-3.11 value-stack read path (crosshair/_tracers.c
+          # crosshair_tracers_stack_lookup) is unguarded and mis-reads operands
+          # during CALL-opcode interception on Windows, causing many failures and
+          # a native access violation (in fuzz_core). 3.12+ uses the guarded
+          # _mark_stacks depth path, so 3.12 and 3.13 are both clean. See the
+          # Windows+3.10 tracer investigation for details.
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.12"
             smt_rlimit: "200000000"
-            experimental: true
           - os: windows-latest
             python-version: "3.13"
             smt_rlimit: "200000000"

--- a/crosshair/auditwall.py
+++ b/crosshair/auditwall.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import itertools
 import os
+import shlex
 import sys
 import traceback
 from contextlib import contextmanager
@@ -27,18 +28,65 @@ _BLOCKED_OPEN_FLAGS = (
     os.O_WRONLY | os.O_RDWR | os.O_APPEND | os.O_CREAT | os.O_EXCL | os.O_TRUNC
 )
 
+# Audit events whose args we canonicalize to an argv token sequence before
+# matching --unblock prefixes (see :func:`match_tokens`).  These are the
+# process-spawn events, whose raw audit args differ by platform.
+_SPAWN_EVENTS = frozenset(("subprocess.Popen", "os.posix_spawn"))
+
+
+def _as_text(value: object) -> str:
+    return os.fsdecode(value) if isinstance(value, (bytes, os.PathLike)) else str(value)
+
+
+def _split_command_string(cmd: str) -> Sequence[str]:
+    # Split a rendered command line back into argv tokens.  On Windows the
+    # tokens were joined via subprocess.list2cmdline (so shlex in non-POSIX mode,
+    # then dropping the surrounding quotes, inverts it -- e.g. a quoted path with
+    # spaces comes back whole); elsewhere the string is a shell command line.
+    try:
+        if sys.platform == "win32":
+            return [tok.strip('"') for tok in shlex.split(cmd, posix=False)]
+        return shlex.split(cmd)
+    except ValueError:
+        return cmd.split()
+
+
+def match_tokens(event: str, args: Tuple) -> Tuple[str, ...]:
+    """The token sequence a ``--unblock`` arg-prefix matches this event against.
+
+    For process-spawn events we canonicalize to the argv ``(program, *arguments)``
+    so a prefix like ``subprocess.Popen:echo`` matches on every platform.  The
+    raw audit args differ: POSIX delivers ``(argv0, [argv...], cwd, env)`` while
+    Windows delivers ``(None, "<joined cmdline>", None, None)`` (the argv already
+    joined by ``list2cmdline``).  Every other event keeps its raw positional args,
+    stringified, exactly as before."""
+    if event in _SPAWN_EVENTS and len(args) >= 2:
+        executable, cmd = args[0], args[1]
+        if isinstance(cmd, (list, tuple)):
+            tokens = [_as_text(a) for a in cmd]
+        elif isinstance(cmd, (str, bytes, os.PathLike)):
+            tokens = list(_split_command_string(_as_text(cmd)))
+        else:
+            tokens = []
+        if not tokens and executable is not None:
+            tokens = [_as_text(executable)]
+        if tokens:
+            return tuple(tokens)
+    return tuple(map(str, args))
+
 
 def accept(event: str, args: Tuple) -> None:
     pass
 
 
 def explain(event: str, args: Tuple) -> str:
-    argstr = "".join(f":{arg}" for arg in args)
+    tokens = match_tokens(event, args)
+    argstr = "".join(f":{arg}" for arg in tokens)
     parts = [
         f"It's dangerous to run CrossHair on code with side effects.",
         f'To allow this operation anyway, use "--unblock={event}{argstr}".',
     ]
-    if args:
+    if tokens:
         parts.append("(or some colon-delimited prefix)")
     return " ".join(parts)
 
@@ -266,7 +314,7 @@ def _make_prefix_based_handler(
 
     def handler(event: str, args: Tuple) -> None:
         current = trie
-        for arg in map(str, args):
+        for arg in match_tokens(event, args):
             if arg not in current:
                 break
             current = current[arg]

--- a/crosshair/auditwall_test.py
+++ b/crosshair/auditwall_test.py
@@ -76,26 +76,14 @@ def test_popen_disallowed():
     assert call([pyexec, __file__, "popen", "withwall"]) == 10
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Windows' subprocess.Popen audit event delivers (None, '<joined cmdline>', "
-    "None, None) instead of (argv0, [argv], cwd, env), so arg-prefix unblock strings "
-    "like 'subprocess.Popen:echo' don't match. Deferred: normalize --unblock matching "
-    "cross-platform (bucketed with the Windows op triage).",
-)
 def test_popen_allowed_if_prefix_allowed():
+    # --unblock arg-prefixes match against the canonicalized argv tokens
+    # (program, *arguments) -- see crosshair.auditwall.match_tokens -- so these
+    # match identically on POSIX and Windows despite the differing raw audit args.
     assert call([pyexec, __file__, "popen", "withwall", "subprocess.Popen"]) == 0
     assert call([pyexec, __file__, "popen", "withwall", "subprocess.Popen:echo"]) == 0
     assert (
-        call(
-            [
-                pyexec,
-                __file__,
-                "popen",
-                "withwall",
-                "subprocess.Popen:echo:['echo', 'hello']",
-            ]
-        )
+        call([pyexec, __file__, "popen", "withwall", "subprocess.Popen:echo:hello"])
         == 0
     )
     assert (
@@ -107,8 +95,8 @@ def test_popen_allowed_if_prefix_allowed():
                 "withwall",
                 "os:chdir",
                 "subprocess.Popen:ech",
-                "subprocess.Popen:echo:['echo', 'bye']",
-                "subprocess.Popen:echo:['echo', 'hello']",
+                "subprocess.Popen:echo:bye",
+                "subprocess.Popen:echo:hello",
             ]
         )
         == 0
@@ -119,16 +107,7 @@ def test_popen_disallowed_with_unrelated_prefix_allowences():
     assert call([pyexec, __file__, "popen", "withwall", "os:chdir"]) == 10
     assert call([pyexec, __file__, "popen", "withwall", "subprocess.Popen:date"]) == 10
     assert (
-        call(
-            [
-                pyexec,
-                __file__,
-                "popen",
-                "withwall",
-                "subprocess.Popen:echo:['echo', 'bye']",
-            ]
-        )
-        == 10
+        call([pyexec, __file__, "popen", "withwall", "subprocess.Popen:echo:bye"]) == 10
     )
 
 

--- a/crosshair/fuzz_core_test.py
+++ b/crosshair/fuzz_core_test.py
@@ -27,16 +27,6 @@ import crosshair.core_and_libs  # noqa: F401  -- ensure patches/plugins load
 from crosshair.behavior_compare import run_differential
 from crosshair.inputgen import catalog
 
-# Skipped on Windows for now: the differential fuzz surfaces genuine
-# Windows-specific gaps (Windows-only ops such as msvcrt/ctypes, and
-# platform-divergent ops like select.select / os.waitstatus_to_exitcode), and it
-# is slow. Deferred with the Windows op triage / --unblock normalization work.
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="fuzz_core surfaces Windows-specific op gaps and is slow; deferred to "
-    "the Windows op triage.",
-)
-
 # Inputs checked per operation (each pinned symbolic-vs-concrete).  Small for CI.
 INPUTS_PER_OP = 3
 
@@ -205,6 +195,42 @@ KNOWN_FAILURES = {
     "pipes.quote": "symbolic str quoting diverges (regex match differs; <3.13 only)",
 }
 
+# Divergences that surface only on Windows (issue #467, the Windows op triage).
+# Scoped to win32 -- not folded into KNOWN_FAILURES -- so they don't muddy the
+# Linux signal, where these ops pass (the Linux differential draws different
+# inputs and/or these are genuinely platform-specific). xfail NON-strict like
+# KNOWN_FAILURES; prune with `pytest -rX` on Windows as models catch up. These
+# reproduce with AND without the CI rlimit budget, so they're real model gaps,
+# not solver-budget artifacts.
+WINDOWS_KNOWN_FAILURES = {
+    # Windows-only C surface: symbolic int/handle rejected or wrong value returned.
+    "msvcrt.SetErrorMode": "[win32] symbolic msvcrt.SetErrorMode returns the wrong mode",
+    "msvcrt.open_osfhandle": "[win32] symbolic open_osfhandle raises TypeError vs concrete OSError",
+    "ctypes.set_last_error": "[win32] symbolic ctypes.set_last_error returns 0, not the prior error",
+    # Platform-divergent ops (behave differently / only on Windows).
+    "select.select": "[win32] select() rejects non-socket fds (WinError 10038); symbolic raises TypeError",
+    "os.waitstatus_to_exitcode": "symbolic int rejected by the C helper ('an integer is required')",
+    # Cross-platform ops that only DIVERGE on Windows here (pass on Linux CI).
+    "operator.pow": "[win32] symbolic pow() of large ints returns None (unmodeled)",
+    "operator.ipow": "[win32] symbolic ipow() of large ints returns None (unmodeled)",
+    "statistics.linear_regression": "[win32] symbolic float arithmetic diverges (last-ULP)",
+    "ast.parse": "symbolic str rejected by compile() (should realize first); cf. ast.literal_eval",
+}
+
+# Ops SKIPPED (not xfail'd) on Windows: turtle drives a live Tk canvas, which on
+# the Windows runner raises CrossHairInternal / a Tcl error or CRASHES the xdist
+# worker (turtle.pencolor) -- so it must not run at all. Not value functions here
+# in any case. Skipped by module prefix so sibling turtle ops can't flake in.
+WINDOWS_SKIP_PREFIXES = ("turtle.",)
+
+
+def _windows_skip_reason(seedkey):
+    if sys.platform == "win32" and seedkey.startswith(WINDOWS_SKIP_PREFIXES):
+        return (
+            "windows: turtle drives a live Tk canvas (crashes/diverges; not fuzzable)"
+        )
+    return None
+
 
 def _check(label, call, seedkey):
     """Assert symbolic == concrete across this op's valid inputs."""
@@ -239,8 +265,14 @@ def _op_marks(op):
         marks.append(
             pytest.mark.skip(reason=f"not a value function: {op.not_value_function}")
         )
+    elif _windows_skip_reason(op.seedkey) is not None:
+        marks.append(pytest.mark.skip(reason=_windows_skip_reason(op.seedkey)))
     elif op.seedkey in KNOWN_FAILURES:
         marks.append(pytest.mark.xfail(reason=KNOWN_FAILURES[op.seedkey], strict=False))
+    elif sys.platform == "win32" and op.seedkey in WINDOWS_KNOWN_FAILURES:
+        marks.append(
+            pytest.mark.xfail(reason=WINDOWS_KNOWN_FAILURES[op.seedkey], strict=False)
+        )
     return marks
 
 

--- a/crosshair/fuzz_core_test.py
+++ b/crosshair/fuzz_core_test.py
@@ -217,18 +217,25 @@ WINDOWS_KNOWN_FAILURES = {
     "ast.parse": "symbolic str rejected by compile() (should realize first); cf. ast.literal_eval",
 }
 
-# Ops SKIPPED (not xfail'd) on Windows: turtle drives a live Tk canvas, which on
-# the Windows runner raises CrossHairInternal / a Tcl error or CRASHES the xdist
-# worker (turtle.pencolor) -- so it must not run at all. Not value functions here
-# in any case. Skipped by module prefix so sibling turtle ops can't flake in.
-WINDOWS_SKIP_PREFIXES = ("turtle.",)
+# Ops SKIPPED (not xfail'd) on Windows: these CRASH the interpreter/worker, so an
+# xfail is unsafe -- they must not run at all. Keyed by module prefix so sibling
+# ops can't flake in. NOT fuzzable value functions in any case.
+#   - turtle.*: drives a live Tk canvas; raises CrossHairInternal / a Tcl error
+#     or crashes the xdist worker (turtle.pencolor).
+#   - msilib.*: Windows-only native MSI library (removed in 3.13, PEP 594); the
+#     C functions access-violate on fuzzed args (msilib.CreateRecord). Only
+#     reachable on the <3.13 Windows job; on 3.13 the module is gone.
+WINDOWS_SKIP_PREFIXES = {
+    "turtle.": "windows: turtle drives a live Tk canvas (crashes/diverges; not fuzzable)",
+    "msilib.": "windows: msilib native calls access-violate on fuzzed args (crash)",
+}
 
 
 def _windows_skip_reason(seedkey):
-    if sys.platform == "win32" and seedkey.startswith(WINDOWS_SKIP_PREFIXES):
-        return (
-            "windows: turtle drives a live Tk canvas (crashes/diverges; not fuzzable)"
-        )
+    if sys.platform == "win32":
+        for prefix, reason in WINDOWS_SKIP_PREFIXES.items():
+            if seedkey.startswith(prefix):
+                return reason
     return None
 
 

--- a/crosshair/watcher_test.py
+++ b/crosshair/watcher_test.py
@@ -112,16 +112,7 @@ def test_removed_file_given_as_argument(tmp_path: Path):
 @pytest.mark.parametrize(
     "unblock,expected_state",
     [
-        pytest.param(
-            "--unblock=subprocess.Popen:echo",
-            MessageType.CONFIRMED,
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="Windows' subprocess.Popen audit event uses a joined-string "
-                "args shape, so 'subprocess.Popen:echo' doesn't match and the call "
-                "stays blocked. Deferred: normalize --unblock matching cross-platform.",
-            ),
-        ),
+        ("--unblock=subprocess.Popen:echo", MessageType.CONFIRMED),
         ("--unblock=subprocess.Popen:xyz", MessageType.EXEC_ERR),
     ],
 )


### PR DESCRIPTION

Addresses several deferred items from the initial Windows CI work (#466).

--unblock matching (#467 item 3): add auditwall.match_tokens(), which canonicalizes subprocess.Popen / os.posix_spawn audit args to argv tokens (program, *args) on every platform. Windows delivers (None, "<joined cmdline>", None, None) where POSIX delivers (argv0, [argv], cwd, env); the joined Windows string is split back with shlex (non-POSIX mode) + quote strip, inverting list2cmdline. Wired into both the prefix-matching trie and explain() (so the suggested --unblock hint is copy-pasteable on Windows). Un-skips test_popen_allowed_if_prefix_allowed and watcher test_auditwall_unblock. The documented `subprocess.Popen:echo` program form is unchanged; the internal list-repr element becomes per-token (`...:echo:hello`).

fuzz_core on Windows (#467 item 1): remove the module skipif and triage the 17 divergences into win32-scoped marks: WINDOWS_KNOWN_FAILURES (xfail non-strict, 9 ops -- msvcrt/ctypes/select/os.waitstatus_to_exitcode/ operator.pow+ipow/statistics.linear_regression/ast.parse, all confirmed to fail with and without the rlimit budget) and WINDOWS_SKIP_PREFIXES=("turtle.",) (turtle drives a live Tk canvas; turtle.pencolor crashes an xdist worker, so skip -- not xfail). Scoped to win32 so the Linux signal stays clean. Full Windows run: 2312 passed, 0 failed.

CI matrix (#467 item 6): add windows-latest Python 3.10 alongside 3.13 (low + high). 3.10 starts experimental since the fuzz_core triage was calibrated on 3.13.