### PR TITLE
Dump diagnostics on unexpected realization unsat

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -4,6 +4,11 @@
       "version": "1.0.5",
       "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
       "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,10 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
+  // Pin the folder VS Code opens inside the container. Without this the Dev
+  // Containers extension can reopen whatever folder was last open (e.g. the
+  // ~/.claude/.../memory dir), which then shows "no git repo" and breaks pyenv.
+  "workspaceFolder": "/workspaces/CrossHair",
   "remoteEnv": {
     "PYTHONHASHSEED": "0",
     "CROSSHAIR_EXTRA_ASSERTS": "1",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,6 +7,10 @@ sudo chown -R "$(id -u):$(id -g)" /home/vscode/.commandhistory
 pyenv update
 pyenv install -s 3.13
 pyenv local 3.13
+# Also set a global default so `python`/`pip`/`crosshair` resolve even when the
+# shell cwd is outside the repo (otherwise pyenv falls back to `system`, which
+# has no Python, and bare `python` reports "command not found").
+pyenv global 3.13
 
 bash "$(dirname "$0")/install-crosshair.sh"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ The repo ships a **devcontainer** (`.devcontainer/`) that matches CI (dev deps, 
 - **Pre-commit** runs black, isort, flake8, mypy, and pytest
 - **Type annotations**: Required for all non-test code. Generally avoid type annotations in tests.
 - **Naming and doc strings**: Name functions and parameters by what they **do**, not by how they're used. Rename as function behaviors evolve. Doc strings should not include historical context or litigate design decisions. Describe current behaviors only.
-- **Code comments**: Use a **very high bar** - genuinely surpising or confusing behaviors only.
+- **Code comments**: Use a **very high bar** - very surpising or confusing behaviors only. Same rules as naming: current behaviors only, never explain decisions or changes in comments. (you can and should do this in PR descriptions however)
 
 ## Must-Know Technical Background
 

--- a/crosshair/statespace.py
+++ b/crosshair/statespace.py
@@ -691,10 +691,7 @@ class ModelValueNode(WorstResultNode):
     condition_value: object = None
 
     def __init__(self, rand: random.Random, expr: z3.ExprRef, solver: z3.Solver):
-        # find_model_value() is our only caller; it guarantees the solver is
-        # satisfiable (and leaves an up-to-date model) before growing us. See
-        # StateSpace._raise_realization_unsat for how an unsat solver at this
-        # point is attributed to nondeterminism vs. unsoundness.
+        # The caller (find_model_value) guarantees the solver is satisfiable here.
         self.condition_value = solver.model().evaluate(expr, model_completion=True)
         self._stats_key = f"realize_{expr}" if z3.is_const(expr) else None
         WorstResultNode.__init__(self, rand, expr == self.condition_value, solver)
@@ -1017,66 +1014,27 @@ class StateSpace:
             raise exc
 
     def _raise_unexpected_realization_unsat(
-        self, expr: z3.ExprRef, culprit_node: Optional[SearchTreeNode]
+        self, expr: z3.ExprRef, culprit: Optional[z3.ExprRef]
     ) -> NoReturn:
-        # We reached a realization stem with an unsatisfiable solver: a branch we
-        # were offered contradicts the current path constraints. This shouldn't
-        # happen, so we stay loud (CrossHairInternal). We fold a compact diagnosis
-        # into the exception message (so it survives into logs even without
-        # DEBUG_CROSSHAIR) to tell nondeterminism from unsoundness after the fact:
-        #  * is_detached -- realization for counterexample reporting runs detached.
-        #  * the offending branch's iteration vs. the current one. An *earlier*
-        #    iteration points at nondeterminism (its feasibility was decided
-        #    against a solver state that no longer holds this run); the *current*
-        #    iteration points at a bad solver.add() within this run.
-        #  * the minimal contradicting core, so the two conflicting constraints
-        #    are named directly.
         details = [
             f"realizing {expr}",
             f"is_detached={self.is_detached}",
             f"iteration={self._root.iteration}",
         ]
-        if culprit_node is not None:
-            details.append(
-                f"last_negated={getattr(culprit_node, 'expr', None)}"
-                f"@iter{getattr(culprit_node, 'iteration', None)}"
-            )
-        core = self._unsat_core_constraints()
-        if core is not None:
-            details.append("contradicting_core=[" + "; ".join(core) + "]")
+        if culprit is not None:
+            details.append(f"culprit_add={culprit}")
+        message = "Unexpected unsat from solver (" + "; ".join(details) + ")"
         if in_debug():
-            debug("Solver unexpectedly unsat;", "; ".join(details))
+            debug(message)
             debug("  full solver state:", self.solver.sexpr())
-        raise CrossHairInternal(
-            "Unexpected unsat from solver (" + "; ".join(details) + ")"
-        )
-
-    def _unsat_core_constraints(self) -> Optional[List[str]]:
-        # Re-check the current assertions with tracking enabled so z3 can report a
-        # minimal unsatisfiable subset (the constraints that actually conflict).
-        # Best-effort: never let diagnosis mask the original failure.
-        try:
-            core_solver = z3.Solver()
-            core_solver.set(unsat_core=True)
-            tracked = []
-            for i, assertion in enumerate(self.solver.assertions()):
-                label = z3.Bool(f"_ch_unsat_core_{i}")
-                core_solver.assert_and_track(assertion, label)
-                tracked.append((label, assertion))
-            if core_solver.check() != z3.unsat:
-                return None
-            core = {str(c) for c in core_solver.unsat_core()}
-            return [str(a) for label, a in tracked if str(label) in core]
-        except BaseException:
-            return None
+        raise CrossHairInternal(message)
 
     def find_model_value(self, expr: z3.ExprRef, choice_conformity=1.0) -> Any:
         with NoTracing():
-            last_negated: Optional[SearchTreeNode] = None
             while True:
                 if isinstance(self._search_position, NodeStem):
                     if not solver_is_sat(self.solver):
-                        self._raise_unexpected_realization_unsat(expr, last_negated)
+                        self._raise_unexpected_realization_unsat(expr, None)
                     self._search_position = self.grow_into(
                         ModelValueNode(self._random, expr, self.solver)
                     )
@@ -1096,8 +1054,15 @@ class StateSpace:
                 )
                 self.choices_made.append(node)
                 self._search_position = next_node
+                constraint = (
+                    expr == node.condition_value
+                    if chosen
+                    else expr != node.condition_value
+                )
+                self.solver.add(constraint)
+                if self.is_detached and not solver_is_sat(self.solver):
+                    self._raise_unexpected_realization_unsat(expr, constraint)
                 if chosen:
-                    self.solver.add(expr == node.condition_value)
                     ret = model_value_to_python(node.condition_value)
                     if (
                         in_debug()
@@ -1108,9 +1073,6 @@ class StateSpace:
                         debug("SMT realized symbolic:", expr, "==", repr(ret))
                         debug("Realized at", ch_stack())
                     return ret
-                else:
-                    last_negated = node
-                    self.solver.add(expr != node.condition_value)
 
     def current_snapshot(self) -> SnapshotRef:
         return SnapshotRef(len(self.heaps) - 1)

--- a/crosshair/statespace.py
+++ b/crosshair/statespace.py
@@ -1021,8 +1021,9 @@ class StateSpace:
     ) -> NoReturn:
         # We reached a realization stem with an unsatisfiable solver: a branch we
         # were offered contradicts the current path constraints. This shouldn't
-        # happen, so we stay loud (CrossHairInternal). Under DEBUG_CROSSHAIR, dump
-        # enough to tell nondeterminism from unsoundness after the fact:
+        # happen, so we stay loud (CrossHairInternal). We fold a compact diagnosis
+        # into the exception message (so it survives into logs even without
+        # DEBUG_CROSSHAIR) to tell nondeterminism from unsoundness after the fact:
         #  * is_detached -- realization for counterexample reporting runs detached.
         #  * the offending branch's iteration vs. the current one. An *earlier*
         #    iteration points at nondeterminism (its feasibility was decided
@@ -1030,37 +1031,44 @@ class StateSpace:
         #    iteration points at a bad solver.add() within this run.
         #  * the minimal contradicting core, so the two conflicting constraints
         #    are named directly.
+        details = [
+            f"realizing {expr}",
+            f"is_detached={self.is_detached}",
+            f"iteration={self._root.iteration}",
+        ]
+        if culprit_node is not None:
+            details.append(
+                f"last_negated={getattr(culprit_node, 'expr', None)}"
+                f"@iter{getattr(culprit_node, 'iteration', None)}"
+            )
+        core = self._unsat_core_constraints()
+        if core is not None:
+            details.append("contradicting_core=[" + "; ".join(core) + "]")
         if in_debug():
-            debug("Solver unexpectedly unsat while realizing", expr)
-            debug("  is_detached:", self.is_detached)
-            debug("  current iteration:", self._root.iteration)
-            if culprit_node is not None:
-                debug(
-                    "  last-negated branch:",
-                    getattr(culprit_node, "expr", None),
-                    "grown in iteration",
-                    getattr(culprit_node, "iteration", None),
-                )
-            self._debug_dump_unsat_core()
+            debug("Solver unexpectedly unsat;", "; ".join(details))
             debug("  full solver state:", self.solver.sexpr())
-        raise CrossHairInternal("Unexpected unsat from solver")
+        raise CrossHairInternal(
+            "Unexpected unsat from solver (" + "; ".join(details) + ")"
+        )
 
-    def _debug_dump_unsat_core(self) -> None:
-        # Re-check the current assertions with tracking enabled so z3 can report
-        # a minimal unsatisfiable subset (the constraints that actually conflict).
-        core_solver = z3.Solver()
-        core_solver.set(unsat_core=True)
-        tracked = []
-        for i, assertion in enumerate(self.solver.assertions()):
-            label = z3.Bool(f"_ch_unsat_core_{i}")
-            core_solver.assert_and_track(assertion, label)
-            tracked.append((label, assertion))
-        if core_solver.check() == z3.unsat:
+    def _unsat_core_constraints(self) -> Optional[List[str]]:
+        # Re-check the current assertions with tracking enabled so z3 can report a
+        # minimal unsatisfiable subset (the constraints that actually conflict).
+        # Best-effort: never let diagnosis mask the original failure.
+        try:
+            core_solver = z3.Solver()
+            core_solver.set(unsat_core=True)
+            tracked = []
+            for i, assertion in enumerate(self.solver.assertions()):
+                label = z3.Bool(f"_ch_unsat_core_{i}")
+                core_solver.assert_and_track(assertion, label)
+                tracked.append((label, assertion))
+            if core_solver.check() != z3.unsat:
+                return None
             core = {str(c) for c in core_solver.unsat_core()}
-            debug("  minimal contradicting constraints:")
-            for label, assertion in tracked:
-                if str(label) in core:
-                    debug("    ", assertion)
+            return [str(a) for label, a in tracked if str(label) in core]
+        except BaseException:
+            return None
 
     def find_model_value(self, expr: z3.ExprRef, choice_conformity=1.0) -> Any:
         with NoTracing():

--- a/crosshair/statespace.py
+++ b/crosshair/statespace.py
@@ -691,10 +691,10 @@ class ModelValueNode(WorstResultNode):
     condition_value: object = None
 
     def __init__(self, rand: random.Random, expr: z3.ExprRef, solver: z3.Solver):
-        if not solver_is_sat(solver):
-            debug("Solver unexpectedly unsat; solver state:", solver.sexpr())
-            raise CrossHairInternal("Unexpected unsat from solver")
-
+        # find_model_value() is our only caller; it guarantees the solver is
+        # satisfiable (and leaves an up-to-date model) before growing us. See
+        # StateSpace._raise_realization_unsat for how an unsat solver at this
+        # point is attributed to nondeterminism vs. unsoundness.
         self.condition_value = solver.model().evaluate(expr, model_completion=True)
         self._stats_key = f"realize_{expr}" if z3.is_const(expr) else None
         WorstResultNode.__init__(self, rand, expr == self.condition_value, solver)
@@ -1016,10 +1016,59 @@ class StateSpace:
         else:
             raise exc
 
+    def _raise_unexpected_realization_unsat(
+        self, expr: z3.ExprRef, culprit_node: Optional[SearchTreeNode]
+    ) -> NoReturn:
+        # We reached a realization stem with an unsatisfiable solver: a branch we
+        # were offered contradicts the current path constraints. This shouldn't
+        # happen, so we stay loud (CrossHairInternal). Under DEBUG_CROSSHAIR, dump
+        # enough to tell nondeterminism from unsoundness after the fact:
+        #  * is_detached -- realization for counterexample reporting runs detached.
+        #  * the offending branch's iteration vs. the current one. An *earlier*
+        #    iteration points at nondeterminism (its feasibility was decided
+        #    against a solver state that no longer holds this run); the *current*
+        #    iteration points at a bad solver.add() within this run.
+        #  * the minimal contradicting core, so the two conflicting constraints
+        #    are named directly.
+        if in_debug():
+            debug("Solver unexpectedly unsat while realizing", expr)
+            debug("  is_detached:", self.is_detached)
+            debug("  current iteration:", self._root.iteration)
+            if culprit_node is not None:
+                debug(
+                    "  last-negated branch:",
+                    getattr(culprit_node, "expr", None),
+                    "grown in iteration",
+                    getattr(culprit_node, "iteration", None),
+                )
+            self._debug_dump_unsat_core()
+            debug("  full solver state:", self.solver.sexpr())
+        raise CrossHairInternal("Unexpected unsat from solver")
+
+    def _debug_dump_unsat_core(self) -> None:
+        # Re-check the current assertions with tracking enabled so z3 can report
+        # a minimal unsatisfiable subset (the constraints that actually conflict).
+        core_solver = z3.Solver()
+        core_solver.set(unsat_core=True)
+        tracked = []
+        for i, assertion in enumerate(self.solver.assertions()):
+            label = z3.Bool(f"_ch_unsat_core_{i}")
+            core_solver.assert_and_track(assertion, label)
+            tracked.append((label, assertion))
+        if core_solver.check() == z3.unsat:
+            core = {str(c) for c in core_solver.unsat_core()}
+            debug("  minimal contradicting constraints:")
+            for label, assertion in tracked:
+                if str(label) in core:
+                    debug("    ", assertion)
+
     def find_model_value(self, expr: z3.ExprRef, choice_conformity=1.0) -> Any:
         with NoTracing():
+            last_negated: Optional[SearchTreeNode] = None
             while True:
                 if isinstance(self._search_position, NodeStem):
+                    if not solver_is_sat(self.solver):
+                        self._raise_unexpected_realization_unsat(expr, last_negated)
                     self._search_position = self.grow_into(
                         ModelValueNode(self._random, expr, self.solver)
                     )
@@ -1052,6 +1101,7 @@ class StateSpace:
                         debug("Realized at", ch_stack())
                     return ret
                 else:
+                    last_negated = node
                     self.solver.add(expr != node.condition_value)
 
     def current_snapshot(self) -> SnapshotRef:


### PR DESCRIPTION
## What

When `find_model_value()` hits a realization stem with an unsatisfiable solver it still raises `CrossHairInternal("Unexpected unsat from solver ...")` — we want to stay loud when CrossHair is used directly. This folds a diagnosis into the message so it survives into CI logs without `DEBUG_CROSSHAIR`:

- **`is_detached`** — counterexample realization runs detached; this is where it fires.
- **`iteration`** — the current search iteration.
- **`culprit_add`** — on a detached path we re-check satisfiability right after adding each realization constraint, so if a realization add flips the solver, we name that exact `expr == value` / `expr != value`. Its absence means the solver was already unsat on entry (the contradiction predates realization).

The `solver_is_sat` check also moves from `ModelValueNode.__init__` (its sole caller) into `find_model_value`, so the diagnosis has the statespace context.

## What it found

`Unexpected unsat from solver (realizing int_01; is_detached=True; iteration=7)` — detached, and **no `culprit_add`**, with the per-add check clean. So the realization adds are innocent; the solver is already unsatisfiable when realization begins. The contradiction lives in the generated path constraints, not in realization-time branching.

## Behavior change

None when the invariant holds — same loud `CrossHairInternal`, now with a diagnosis in the message. Full solver `sexpr()` stays `DEBUG_CROSSHAIR`-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
