### PR TITLE
Use IEEE equality for symbolic float ==/!=

### DIFF
--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -669,6 +669,11 @@ def apply_smt(op: BinFn, x: z3.ExprRef, y: z3.ExprRef) -> z3.ExprRef:
     # TODO: we should investigate using the op override mechanism to
     # dispatch to the right SMT operations.
     space = context_statespace()
+    if op in (ops.eq, ops.ne) and z3.is_fp(x) and z3.is_fp(y):
+        # On floats, z3's `==`/`!=` are structural, not IEEE: +0.0 and -0.0
+        # compare unequal, and NaN compares equal to itself.
+        smt_eq = fpEQ(x, y)
+        return smt_eq if op is ops.eq else z3.Not(smt_eq)
     if op in _ARITHMETIC_OPS:
         if op in (ops.truediv, ops.floordiv, ops.mod):
             iszero = (fpEQ(y, 0.0)) if isinstance(y, z3.FPRef) else (y == 0)
@@ -1576,26 +1581,9 @@ class PreciseIeeeSymbolicFloat(SymbolicFloat):
             return z3.FPVal(literal, cls._ch_smt_sort())
         return None
 
-    def __eq__(self, other):
-        with NoTracing():
-            coerced = type(self)._coerce_to_smt_sort(other)
-            if coerced is None:
-                return False
-            return SymbolicBool(fpEQ(self.var, coerced))
-
-    # __hash__ has to be explicitly reassigned because we define __eq__
-    __hash__ = SymbolicFloat.__hash__
-
     def __bool__(self):
         with NoTracing():
             return not SymbolicBool(z3.fpIsZero(self.var))
-
-    def __ne__(self, other):
-        with NoTracing():
-            coerced = type(self)._coerce_to_smt_sort(other)
-            if coerced is None:
-                return True
-            return SymbolicBool(z3.Not(fpEQ(self.var, coerced)))
 
     def __int__(self):
         with NoTracing():

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -398,6 +398,62 @@ def test_int___pow___to_real_based_float():
             realize(sqrt_a == 3)
 
 
+def test_int_eq_ieee_negative_zero():
+    # Regression for the unsound `sampled_from([0, 0.0])` uniqueness bug: when an
+    # int is compared against a PreciseIeeeSymbolicFloat, the comparison must use
+    # IEEE equality. z3's structural fp equality treats +0.0 and -0.0 as distinct,
+    # which made CrossHair believe 0 and -0.0 were unequal. The int==float path
+    # promotes the int to a float and dispatches through numeric_binop/apply_smt.
+    with standalone_statespace as space:
+        with NoTracing():
+            space.extra(ModelingDirector).global_representations[
+                float
+            ] = PreciseIeeeSymbolicFloat
+            zero_int = SymbolicInt("zero_int")
+            neg_zero = PreciseIeeeSymbolicFloat(
+                z3.FPVal(-0.0, PreciseIeeeSymbolicFloat._ch_smt_sort())
+            )
+        with ResumedTracing():
+            space.add(zero_int == 0)
+            assert zero_int == neg_zero
+            assert not (zero_int != neg_zero)
+
+
+def test_apply_smt_ieee_equality():
+    # apply_smt must implement IEEE (not z3's structural) equality on floats:
+    # +0.0 == -0.0 and nan != nan. eq/ne need a special-case because z3 leaves
+    # FPRef.__eq__/__ne__ as structural equality; the ordering operators are
+    # already overloaded to the IEEE fp predicates, so they need no special-case.
+    from crosshair.libimpl.builtinslib import apply_smt
+
+    def is_true(expr):
+        return z3.is_true(z3.simplify(expr))
+
+    def is_false(expr):
+        return z3.is_false(z3.simplify(expr))
+
+    sort = PreciseIeeeSymbolicFloat._ch_smt_sort()
+    pos_zero = z3.FPVal(0.0, sort)
+    neg_zero = z3.FPVal(-0.0, sort)
+    nan = z3.fpNaN(sort)
+    one = z3.FPVal(1.0, sort)
+    with standalone_statespace as space:
+        with NoTracing():
+            # equality treats +0.0 and -0.0 as equal, and nan as unequal to itself:
+            assert is_true(apply_smt(operator.eq, pos_zero, neg_zero))
+            assert is_false(apply_smt(operator.ne, pos_zero, neg_zero))
+            assert is_false(apply_smt(operator.eq, nan, nan))
+            assert is_true(apply_smt(operator.ne, nan, nan))
+            # ordered comparisons: +0.0 and -0.0 compare equal, nan is unordered:
+            assert is_true(apply_smt(operator.le, pos_zero, neg_zero))
+            assert is_true(apply_smt(operator.ge, pos_zero, neg_zero))
+            assert is_false(apply_smt(operator.lt, pos_zero, neg_zero))
+            assert is_false(apply_smt(operator.gt, pos_zero, neg_zero))
+            for op in (operator.le, operator.ge, operator.lt, operator.gt):
+                assert is_false(apply_smt(op, nan, nan))
+                assert is_false(apply_smt(op, nan, one))
+
+
 @pytest.mark.demo
 def test_int___sub___method():
     def f(a: int) -> int:

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,6 +6,14 @@ Changelog
 Next Version
 ---------------
 
+ * Fix symbolic floats treating ``0.0`` and ``-0.0`` as unequal (and ``nan`` as
+   equal to itself). Equality on the IEEE float representation used z3's structural
+   comparison rather than IEEE equality, so e.g. ``0 == -0.0`` could evaluate to
+   ``False``. This surfaced as an unsound counterexample for
+   ``st.lists(st.sampled_from([0, 0.0]), unique=True, min_size=1)`` (two "distinct"
+   zeros), which could also trip an "Unexpected unsat" error while reporting the
+   result. Float ``==``/``!=`` now use IEEE equality; ordered comparisons were
+   already correct.
  * Run the ``bytes`` and ``bytearray`` search/match methods symbolically instead
    of realizing the whole value first. ``find``, ``rfind``, ``index``, ``rindex``,
    ``count``, ``replace``, ``startswith``, ``endswith``, ``removeprefix``, and


### PR DESCRIPTION
## Summary

On floats, z3's `==`/`!=` are **structural**, not IEEE: they treat `+0.0` and `-0.0` as unequal (and `NaN` as equal to itself). `apply_smt` used these directly, so symbolic float equality was wrong whenever an `int` was compared against a `PreciseIeeeSymbolicFloat` (the value is promoted to a float and routed through `numeric_binop`/`apply_smt`, bypassing `PreciseIeeeSymbolicFloat.__eq__`): `0 == -0.0` could evaluate to `False`.

## Changes

- `apply_smt` now uses `fpEQ` for `eq`/`ne` on two fp operands.
- Removed the now-redundant `PreciseIeeeSymbolicFloat.__eq__`/`__ne__` overrides; the base `SymbolicNumberAble` path handles them correctly, matching `RealBasedSymbolicFloat` (which never had them).
- Ordered comparisons (`<=`/`>=`/`<`/`>`) need no change — z3py overloads `FPRef` ordering to the IEEE fp predicates; only `__eq__`/`__ne__` were structural.

## Impact: fixes the hypothesis-integration `test_issue_2247_regression` crash

This resolves the intermittent `CrossHairInternal: Unexpected unsat from solver (realizing int_01…)` failure on `st.lists(st.sampled_from([0, 0.0]), unique=True, min_size=1)`.

Mechanism (confirmed via an unsat-core/fresh-solver diagnostic on CI — see the companion diagnostics PR): the `unique` filter's `value not in seen` check runs against a symbolic set whose `__contains__` compares the two zero-valued elements. Built with structural fp `==`, the "these are distinct" fork was satisfiable by setting the float element to `-0.0`, but it is elsewhere pinned to `+0.0` — a contradiction that surfaced as the realization-time `unsat`. Raw z3 confirms the fix is decisive and deterministic:

```
Not( as_fp(item5) == item4 )       -> SAT   (item4 = -0.0)    # structural: bug
Not( fpEQ(as_fp(item5), item4) )   -> UNSAT                    # fpEQ: fork infeasible -> dedup
```

CI: the combined fix+diagnostics branch passed the hypothesis-integration job 2/2, where the no-fix diagnostics branch failed 2/2.

## Tests

- `test_int_eq_ieee_negative_zero`, `test_apply_smt_ieee_equality` (both fail without the fix; the latter also asserts ordered comparisons stay IEEE-correct).
- Full `crosshair/libimpl/builtinslib_test.py`: 495 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
