### PR TITLE
Curated demo links for the support treemap (harvested from @pytest.mark.demo)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ CrossHair is a Python analysis tool that uses **symbolic execution** and an **SM
 - **`crosshair/tracers.py`** – Bytecode tracing for symbolic execution (C extension in `_tracers.c`)
 - **`crosshair/smtlib.py`**, **`crosshair/z3util.py`** – Z3/SMT integration
 - **`doc/source/`** - documentation (log user-facing changes in `changelog.rst`)
+
 ## Development Environment
 
 The repo ships a **devcontainer** (`.devcontainer/`) that matches CI (dev deps, pre-commit hooks, pyenv-managed Python). It's the recommended way to run agents but not required — the notes below apply in any environment. See `.devcontainer/README.md` for host setup and what the container shares with your host.
@@ -29,8 +30,9 @@ The repo ships a **devcontainer** (`.devcontainer/`) that matches CI (dev deps, 
 - **Tests**: pytest; run with `PYTHONHASHSEED=0` for reproducibility
 - **Pre-commit** runs black, isort, flake8, mypy, and pytest
 - **Type annotations**: Required for all non-test code. Generally avoid type annotations in tests.
-- **Naming and doc strings**: Name functions and parameters by what they **do**, not by how they're used. Rename as function behaviors evolve. Doc strings should not include historical context or litigate design decisions. Describe current behaviors only.
-- **Code comments**: Use a **very high bar** - very surpising or confusing behaviors only. Same rules as naming: current behaviors only, never explain decisions or changes in comments. (you can and should do this in PR descriptions however)
+- **Naming**: Name functions and parameters by what they **do**, not by how they're used. Rename as function behaviors evolve.
+- **Doc strings**:  Drop anything that requires (or refers to) external context. Describe current behaviors only - no rationales.
+- **Code comments**: Use a **very high bar** - very surpising or confusing behaviors only. Do not include historical context or litigate design decisions. **Never** explain decisions or changes in comments. (you can and should do this in PR descriptions however)
 
 ## Must-Know Technical Background
 
@@ -63,7 +65,10 @@ The repo ships a **devcontainer** (`.devcontainer/`) that matches CI (dev deps, 
   - Consider realizing symbolics early when we know they can't remain symbolic. (an integer that determines a future loop iteration)
   - Re-order operations to retain a larger state space for longer. Push work towards values that are likely to be concrete.
 - Testing
-  - **Unit tests start without tracing.**
+  - The 2 most common test patterns:
+    - Accepts a `space` fixture (or uses standalone_statespace). Call proxy_for_type() to generate symbolics, space.add() to assert, and space.is_possible() to check what values the symbolics can possess. Preferred when you don't need to explore multiple execution paths to exercise your test.
+    - Define an inner function `f` with a contract; then call `check_messages(analyze_function(f), MessageType.POST_FAIL)` to ensure a counterexample can be found. This exercises the full path-tree-exploration loop, and is therefore much more expensive.
+  - **Unit tests will start with tracing off**
     – If you use a `space` fixture parameter, you can `with ResumedTracing():` to enable tracing.
     - Otherwise, enter a statespace context to begin tracing.
   - To assert something is symbolic, query both sides for satisfiability: `assert space.is_possible(x == a)` and `assert space.is_possible(x != a)`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crosshair/behavior_compare.py
+++ b/crosshair/behavior_compare.py
@@ -380,8 +380,7 @@ class DiffResult:
 
 
 def _union_of(types: Iterable[object]) -> object:
-    """Union of proxy types, order-preserved and de-duplicated (a single type stays
-    itself; single-element ``Union`` collapses anyway)."""
+    """Union of proxy types, order-preserved and de-duplicated."""
     uniq = tuple(dict.fromkeys(types))
     return uniq[0] if len(uniq) == 1 else Union[uniq]  # type: ignore
 
@@ -389,13 +388,7 @@ def _union_of(types: Iterable[object]) -> object:
 def _proxy_type(v: object) -> object:
     """A (possibly parameterized) type to build a symbolic stand-in for ``v``.
 
-    A container's element type is a UNION over ALL its elements, not just the first.
-    Inferring from ``next(iter(v))`` alone coerces a heterogeneous container -- e.g.
-    ``[0, 0.0]`` would become ``List[int]``, forcing the float ``0.0`` into a
-    symbolic int that realizes back as ``0`` -- a false symbolic-vs-concrete
-    divergence.  (Heterogeneous containers are common: json-able fuzz inputs mix
-    int/str/bool/None, and an ``int | float`` element strategy mixes numbers.)  The
-    union keeps every element representable so the value pins faithfully."""
+    A container's element type is a union over all of its elements."""
     t = type(v)
     if t is list:
         return List[_union_of(_proxy_type(x) for x in v)] if v else List[int]  # type: ignore

--- a/crosshair/behavior_compare.py
+++ b/crosshair/behavior_compare.py
@@ -19,12 +19,14 @@ from typing import (
     Collection,
     Dict,
     FrozenSet,
+    Iterable,
     List,
     Mapping,
     Optional,
     Sequence,
     Set,
     Tuple,
+    Union,
     cast,
 )
 
@@ -377,21 +379,37 @@ class DiffResult:
     unsupported: int = 0
 
 
+def _union_of(types: Iterable[object]) -> object:
+    """Union of proxy types, order-preserved and de-duplicated (a single type stays
+    itself; single-element ``Union`` collapses anyway)."""
+    uniq = tuple(dict.fromkeys(types))
+    return uniq[0] if len(uniq) == 1 else Union[uniq]  # type: ignore
+
+
 def _proxy_type(v: object) -> object:
-    """A (possibly parameterized) type to build a symbolic stand-in for ``v``."""
+    """A (possibly parameterized) type to build a symbolic stand-in for ``v``.
+
+    A container's element type is a UNION over ALL its elements, not just the first.
+    Inferring from ``next(iter(v))`` alone coerces a heterogeneous container -- e.g.
+    ``[0, 0.0]`` would become ``List[int]``, forcing the float ``0.0`` into a
+    symbolic int that realizes back as ``0`` -- a false symbolic-vs-concrete
+    divergence.  (Heterogeneous containers are common: json-able fuzz inputs mix
+    int/str/bool/None, and an ``int | float`` element strategy mixes numbers.)  The
+    union keeps every element representable so the value pins faithfully."""
     t = type(v)
     if t is list:
-        return List[_proxy_type(next(iter(v)))] if v else List[int]  # type: ignore
+        return List[_union_of(_proxy_type(x) for x in v)] if v else List[int]  # type: ignore
     if t is set:
-        return Set[_proxy_type(next(iter(v)))] if v else Set[int]  # type: ignore
+        return Set[_union_of(_proxy_type(x) for x in v)] if v else Set[int]  # type: ignore
     if t is frozenset:
-        return FrozenSet[_proxy_type(next(iter(v)))] if v else FrozenSet[int]  # type: ignore
+        return FrozenSet[_union_of(_proxy_type(x) for x in v)] if v else FrozenSet[int]  # type: ignore
     if t is tuple:
         return Tuple[tuple(_proxy_type(x) for x in v)] if v else Tuple[()]  # type: ignore
     if t is dict:
         if v:
-            k, val = next(iter(v.items()))  # type: ignore
-            return Dict[_proxy_type(k), _proxy_type(val)]  # type: ignore
+            keys = _union_of(_proxy_type(k) for k in v)  # type: ignore
+            vals = _union_of(_proxy_type(x) for x in v.values())  # type: ignore
+            return Dict[keys, vals]  # type: ignore
         return Dict[int, int]
     return t
 

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -1146,10 +1146,14 @@ def _getattr_inputs(specs: List[Any], n: int) -> "st.SearchStrategy[tuple]":
     """``getattr(o, name, ...)`` where ``name`` is a real (data) attribute of ``o``
     -- so it exercises actual attribute access instead of raising AttributeError on
     a fuzzed string.  Preserves the op's arity (any trailing ``default`` fuzzes
-    normally)."""
-    objs = st.one_of(
-        st.integers(), st.floats(allow_nan=False), st.complex_numbers(allow_nan=False)
-    )
+    normally).
+
+    ``o`` is drawn from its OWN annotation-derived strategy (``specs[0]`` -- Layer 1,
+    i.e. ``GENERIC``), NOT a hardcoded object set.  This keeps the fuzzed object type
+    identical to what the holdout inverts over: a wider fuzz domain (e.g. an extra
+    ``complex``) would produce outputs the typed inversion can't reach, a false
+    "black".  The real-attribute correlation below is the Layer-2 part."""
+    objs = _arg_strategy(specs[0], n) if specs else st.integers()
 
     def with_name(o: Any) -> "st.SearchStrategy[tuple]":
         names = [

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -794,13 +794,32 @@ def _map_ann(node: Any, binds: Dict[str, str]) -> str:
             return "Tuple[" + ", ".join(_map_ann(e, binds) for e in inner) + "]"
         if base in ("dict", "Dict", "SupportsKeysAndGetItem"):
             return f"Dict[{_map_ann(elts[0], binds)}, {_map_ann(elts[1], binds)}]"
-        if (
-            base == "Literal"
-        ):  # map to the underlying value's type (e.g. Literal[-1,0,1] -> int)
+        if base == "Literal":
+            # Pass the Literal THROUGH (Literal[-1, 0, 1], Literal["r", "w"], ...):
+            # both hypothesis.from_type and CrossHair sample/invert the EXACT values,
+            # which is more faithful than widening to the underlying type -- the op
+            # genuinely accepts only these.  Render only the simple constant kinds we
+            # can reproduce verbatim (int/str/bytes/bool); enum members / qualified
+            # names fall back to the underlying scalar type's mapping.
+            rendered: Optional[List[str]] = []
             for e in elts:
-                c = (
-                    e.operand if isinstance(e, _ast.UnaryOp) else e
-                )  # Literal[-1] -> UnaryOp
+                neg = isinstance(e, _ast.UnaryOp) and isinstance(e.op, _ast.USub)
+                c = e.operand if isinstance(e, _ast.UnaryOp) else e  # Literal[-1]
+                if isinstance(c, _ast.Constant) and type(c.value) in (
+                    int,
+                    str,
+                    bytes,
+                    bool,
+                ):
+                    r = repr(c.value)
+                    rendered.append(f"-{r}" if neg else r)  # type: ignore[union-attr]
+                else:
+                    rendered = None
+                    break
+            if rendered:
+                return f"Literal[{', '.join(rendered)}]"
+            for e in elts:  # fall back: map to the underlying scalar type
+                c = e.operand if isinstance(e, _ast.UnaryOp) else e
                 if isinstance(c, _ast.Constant) and c.value is not None:
                     return _map_ann(_ast.Name(id=type(c.value).__name__), binds)
             raise _Unsupported("Literal")

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -601,10 +601,22 @@ def _class_chain(cls_name: str, module: str = "builtins") -> List[Any]:
     return chain
 
 
+# THE universally-generatable value type: one annotation that both
+# hypothesis.from_type() can build AND CrossHair can symbolize/invert.  It is the
+# single vocabulary for every unconstrained "object-like" slot -- a bare object/Any
+# parameter, an unbound element TypeVar, and a generic container's element type --
+# so widening it (int -> int|float -> int|str|... ) is a ONE-LINE edit here instead
+# of a scattered find-and-replace.  Constrained slots keep their own specific
+# mappings (SupportsIndex -> int, the str/buffer families, the numeric protocols).
+# Spelled ``Union[...]`` not ``int | float``: the annotation string is eval'd at
+# runtime and the ``|`` type-union operator only exists on Python 3.10+.
+GENERIC = "int"
+
+
 # receiver annotation + TypeVar bindings.  Every container is mono-element, so we
-# bind all of typeshed's element TypeVar names (_T/_T_co/_KT/_VT) -- as used by
-# the ABC bases methods are inherited from -- to the receiver's element type.
-def _elem(t: str) -> Dict[str, str]:
+# bind all of typeshed's element TypeVar names (_T/_T_co/_KT/_VT) -- as used by the
+# ABC bases methods are inherited from -- to the receiver's element type.
+def _elem(t: str = GENERIC) -> Dict[str, str]:
     return {"_T": t, "_S": t, "_T_co": t, "_KT": t, "_VT": t}
 
 
@@ -613,21 +625,21 @@ RECV = {
     float: ("float", {}),
     bool: ("bool", {}),
     str: ("str", _elem("str")),
-    bytes: ("bytes", _elem("int")),
+    bytes: ("bytes", _elem("int")),  # bytes/bytearray elements are ints in 0..255
     bytearray: ("bytearray", _elem("int")),
-    list: ("List[int]", _elem("int")),
-    tuple: ("Tuple[int, ...]", _elem("int")),
-    dict: ("Dict[int, int]", _elem("int")),
-    set: ("Set[int]", _elem("int")),
-    frozenset: ("FrozenSet[int]", _elem("int")),
+    list: (f"List[{GENERIC}]", _elem()),
+    tuple: (f"Tuple[{GENERIC}, ...]", _elem()),
+    dict: (f"Dict[{GENERIC}, {GENERIC}]", _elem()),
+    set: (f"Set[{GENERIC}]", _elem()),
+    frozenset: (f"FrozenSet[{GENERIC}]", _elem()),
 }
 
 
 # typeshed leaf names -> a fuzzable annotation.  Beyond the concrete builtins,
 # this maps the common stdlib type-vocabulary the probe surfaced: numeric
 # protocols (math/statistics), generic element TypeVars (free functions have no
-# receiver to bind them, so they default to int -- for builtin methods RECV binds
-# win since _map_ann checks `binds` first), and str/buffer families.  Over-broad
+# receiver to bind them, so they default to GENERIC -- for builtin methods RECV
+# binds win since _map_ann checks `binds` first), and str/buffer families.  Over-broad
 # mappings are safe: the fuzz-validation step drops any candidate whose call
 # doesn't actually run.
 _NAME_MAP = {
@@ -648,8 +660,8 @@ _NAME_MAP = {
     "LiteralString": "str",
     "ReadableBuffer": "bytes",
     "memoryview": "bytes",
-    "object": "int",
-    "Any": "int",
+    "object": GENERIC,
+    "Any": GENERIC,
     # numeric protocols / numeric TypeVars
     "_SupportsFloatOrIndex": "float",
     "SupportsFloat": "float",
@@ -673,18 +685,19 @@ _NAME_MAP = {
     "_MultiplicableT2": "int",
     "_SupportsProdNoDefaultT": "int",
     "_SupportsSumNoDefaultT": "int",
-    # generic element TypeVars (default for unbound free-function type params)
-    "_T": "int",
-    "_S": "int",
-    "_U": "int",
-    "_T1": "int",
-    "_T2": "int",
-    "_KT": "int",
-    "_VT": "int",
-    "_K": "int",
-    "_V": "int",
-    "_T_co": "int",
-    "_T_contra": "int",
+    # generic element TypeVars (the unbound-free-function default) -- the SAME
+    # unconstrained value slot as object/Any, so they share GENERIC.
+    "_T": GENERIC,
+    "_S": GENERIC,
+    "_U": GENERIC,
+    "_T1": GENERIC,
+    "_T2": GENERIC,
+    "_KT": GENERIC,
+    "_VT": GENERIC,
+    "_K": GENERIC,
+    "_V": GENERIC,
+    "_T_co": GENERIC,
+    "_T_contra": GENERIC,
     # string / buffer / path families
     "AnyStr": "str",
     "StrOrLiteralStr": "str",
@@ -702,13 +715,31 @@ class _Unsupported(Exception):
     pass
 
 
+def normalize(name: str, binds: Dict[str, str]) -> Optional[str]:
+    """Layer 1 -- map a typeshed leaf type NAME to a universally-generatable type:
+    one that both ``hypothesis.from_type()`` can build AND CrossHair can symbolize
+    and invert.  This is the SINGLE SOURCE of an argument's type: the returned
+    annotation string is used verbatim as the parameter annotation *and* (re-eval'd
+    via :func:`_ann`) as the fuzz strategy, so every concrete example is an instance
+    of the declared type -- the holdout can trust the annotation without re-deriving
+    it from a witness value.
+
+    ``binds`` (Self / receiver / element TypeVars) win first, so a context-specific
+    type -- e.g. a comparison dunder's comparand bound to the receiver type -- beats
+    the default table.  Returns None when the name isn't known here (the caller then
+    falls through to structural handling or raises ``_Unsupported``).
+    """
+    if name in binds:
+        return binds[name]
+    return _NAME_MAP.get(name)
+
+
 def _map_ann(node: Any, binds: Dict[str, str]) -> str:
     """typeshed annotation AST -> a fuzzable annotation string (or raise)."""
     if isinstance(node, _ast.Name):
-        if node.id in binds:
-            return binds[node.id]
-        if node.id in _NAME_MAP:
-            return _NAME_MAP[node.id]
+        got = normalize(node.id, binds)
+        if got is not None:
+            return got
         raise _Unsupported(node.id)
     if isinstance(node, _ast.Attribute):  # typing.SupportsIndex -> SupportsIndex
         return _map_ann(_ast.Name(id=node.attr), binds)
@@ -776,10 +807,9 @@ def _map_ann(node: Any, binds: Dict[str, str]) -> str:
         # a subscripted scalar protocol/TypeVar (SupportsAbs[_T], PathLike[AnyStr],
         # _SupportsInversion[_T_co], ...): the element type doesn't change how we
         # fuzz it, so fall back to the base name's scalar mapping.
-        if base in binds:
-            return binds[base]
-        if base in _NAME_MAP:
-            return _NAME_MAP[base]
+        got = normalize(base, binds)
+        if got is not None:
+            return got
         raise _Unsupported(base)
     raise _Unsupported(type(node).__name__)
 

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -603,9 +603,8 @@ def _class_chain(cls_name: str, module: str = "builtins") -> List[Any]:
 
 # The generatable type for every unconstrained "object-like" slot: a bare
 # object/Any parameter, an unbound element TypeVar, or a generic container's element
-# type.  Spelled ``Union[...]`` not ``int | float``: the string is eval'd at runtime
-# and the ``|`` type-union operator needs Python 3.10+.
-GENERIC = "Union[int, float]"
+# type.
+GENERIC = "int"  # TODO: Something like "Union[int, float, str]" (requires speeding up pinning)
 
 
 # receiver annotation + TypeVar bindings.  Bind all of typeshed's element TypeVar

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -840,6 +840,17 @@ def _overload_sigs(
     return out
 
 
+# The reflexive comparison dunders: a user reads these as "compare two of the
+# SAME type".  typeshed types the comparand of ==/!= as bare ``object`` (and some
+# ordering dunders as ``object``/``Any`` too), which _NAME_MAP resolves to ``int``
+# -- so e.g. str.__eq__ would be measured as str-vs-int: a vacuous always-False
+# compare that CrossHair "solves" for any input, yielding a meaningless green cell
+# with an unreadable astral-plane demo.  For these methods we bind the generic
+# comparand annotation to the receiver's own type instead (a no-op where typeshed
+# already types the arg concretely, e.g. str.__lt__(value: str)).
+_REFLEXIVE_CMP = frozenset({"__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__"})
+
+
 @functools.lru_cache(maxsize=None)
 def _candidate_sigs(
     typ: type, method: str, module: str = "builtins"
@@ -851,6 +862,8 @@ def _candidate_sigs(
     instance (ipaddress ``subnet_of(other: Self)``, ...) become drivable."""
     recv_ann, recv_binds = RECV.get(typ, (f"{module}.{typ.__name__}", {}))
     binds = {"Self": recv_ann, **recv_binds}
+    if method in _REFLEXIVE_CMP:  # measure ==/!=/ordering against the SAME type
+        binds = {**binds, "object": recv_ann, "Any": recv_ann}
     return _overload_sigs(
         _method_overloads(typ, method, module), binds, module, ("self",)
     )
@@ -1760,6 +1773,96 @@ SIDE_EFFECT_OVERRIDES: Dict[str, str] = {
     "ossaudiodev.open": "opens the audio device for writing (I/O)",
     "pydoc.pipepager": "pipes text to a pager subprocess (I/O)",
     "pydoc.tempfilepager": "writes text to a temp file and launches a pager (I/O)",
+    # --- method forms and posix twins the single-input probe misses.  The live
+    # sweep (test_uncategorized_ops_probe_cleanly) probes each op with ONE fuzzed
+    # input, which errors before the I/O call fires -- but measure_support's real
+    # fuzzer eventually drives a VALID input that reaches it, so these must be
+    # named by hand (same reason as the exec/credential block above).  They only
+    # differ from already-listed entries by owner: a bound METHOD seedkey
+    # (module.Class.method) rather than the module function, or the ``posix``
+    # alias of an ``os`` entry. ---
+    "venv.EnvBuilder.create": "writes a virtual environment (I/O)",  # method of venv.create
+    "posix.mknod": "creates a filesystem node (I/O)",
+    "posix.mkfifo": "creates a filesystem node (I/O)",
+    "posix.setuid": "changes process credentials",
+    "posix.setgid": "changes process credentials",
+    "posix.seteuid": "changes process credentials",
+    "posix.setegid": "changes process credentials",
+    "posix.setreuid": "changes process credentials",
+    "posix.setregid": "changes process credentials",
+    "posix.setresuid": "changes process credentials",
+    "posix.setresgid": "changes process credentials",
+    "posix.initgroups": "changes process credentials",
+    "posix.setpriority": "changes process scheduling priority",
+    "posix.chroot": "changes the process root directory (I/O)",
+    "posix.unshare": "unshares OS namespaces",
+    "zipapp.create_archive": "writes an application archive (I/O)",
+    "pydoc.writedocs": "writes HTML documentation files (I/O)",
+    # webbrowser.open* dispatch to a concrete browser class per-platform; each
+    # bound method launches a browser, so name every class's open/open_new/open_new_tab.
+    "webbrowser.BackgroundBrowser.open": "launches a web browser (I/O)",
+    "webbrowser.BackgroundBrowser.open_new": "launches a web browser (I/O)",
+    "webbrowser.BackgroundBrowser.open_new_tab": "launches a web browser (I/O)",
+    "webbrowser.BaseBrowser.open": "launches a web browser (I/O)",
+    "webbrowser.BaseBrowser.open_new": "launches a web browser (I/O)",
+    "webbrowser.BaseBrowser.open_new_tab": "launches a web browser (I/O)",
+    "webbrowser.Chrome.open": "launches a web browser (I/O)",
+    "webbrowser.Chrome.open_new": "launches a web browser (I/O)",
+    "webbrowser.Chrome.open_new_tab": "launches a web browser (I/O)",
+    "webbrowser.Elinks.open": "launches a web browser (I/O)",
+    "webbrowser.Elinks.open_new": "launches a web browser (I/O)",
+    "webbrowser.Elinks.open_new_tab": "launches a web browser (I/O)",
+    "webbrowser.GenericBrowser.open": "launches a web browser (I/O)",
+    "webbrowser.GenericBrowser.open_new": "launches a web browser (I/O)",
+    "webbrowser.GenericBrowser.open_new_tab": "launches a web browser (I/O)",
+    "webbrowser.Konqueror.open": "launches a web browser (I/O)",
+    "webbrowser.Konqueror.open_new": "launches a web browser (I/O)",
+    "webbrowser.Konqueror.open_new_tab": "launches a web browser (I/O)",
+    "webbrowser.Mozilla.open": "launches a web browser (I/O)",
+    "webbrowser.Mozilla.open_new": "launches a web browser (I/O)",
+    "webbrowser.Mozilla.open_new_tab": "launches a web browser (I/O)",
+    "webbrowser.Opera.open": "launches a web browser (I/O)",
+    "webbrowser.Opera.open_new": "launches a web browser (I/O)",
+    "webbrowser.Opera.open_new_tab": "launches a web browser (I/O)",
+    "webbrowser.UnixBrowser.open": "launches a web browser (I/O)",
+    "webbrowser.UnixBrowser.open_new": "launches a web browser (I/O)",
+    "webbrowser.UnixBrowser.open_new_tab": "launches a web browser (I/O)",
+    # logging emitters have module-function forms (logging.info, ...) already
+    # listed; the bound methods on Logger/LoggerAdapter/RootLogger write too.
+    "logging.Logger.critical": "writes a log record (I/O)",
+    "logging.Logger.debug": "writes a log record (I/O)",
+    "logging.Logger.error": "writes a log record (I/O)",
+    "logging.Logger.exception": "writes a log record (I/O)",
+    "logging.Logger.info": "writes a log record (I/O)",
+    "logging.Logger.log": "writes a log record (I/O)",
+    "logging.Logger.warn": "writes a log record (I/O)",
+    "logging.Logger.warning": "writes a log record (I/O)",
+    "logging.LoggerAdapter.critical": "writes a log record (I/O)",
+    "logging.LoggerAdapter.debug": "writes a log record (I/O)",
+    "logging.LoggerAdapter.error": "writes a log record (I/O)",
+    "logging.LoggerAdapter.exception": "writes a log record (I/O)",
+    "logging.LoggerAdapter.info": "writes a log record (I/O)",
+    "logging.LoggerAdapter.log": "writes a log record (I/O)",
+    "logging.LoggerAdapter.warn": "writes a log record (I/O)",
+    "logging.LoggerAdapter.warning": "writes a log record (I/O)",
+    "logging.RootLogger.critical": "writes a log record (I/O)",
+    "logging.RootLogger.debug": "writes a log record (I/O)",
+    "logging.RootLogger.error": "writes a log record (I/O)",
+    "logging.RootLogger.exception": "writes a log record (I/O)",
+    "logging.RootLogger.info": "writes a log record (I/O)",
+    "logging.RootLogger.log": "writes a log record (I/O)",
+    "logging.RootLogger.warn": "writes a log record (I/O)",
+    "logging.RootLogger.warning": "writes a log record (I/O)",
+    # exec-arbitrary-code + remaining I/O ops the single-input probe misses (a valid
+    # input reaches them in the full fuzz; hand-named like the block above):
+    "doctest.DocFileCase.debug": "executes example code under sys.settrace (I/O)",
+    "doctest.DocTestCase.debug": "executes example code under sys.settrace (I/O)",
+    "doctest.SkipDocTestCase.debug": "executes example code under sys.settrace (I/O)",
+    "cProfile.Profile.run": "executes a code string under the profiler (exec)",
+    "profile.Profile.run": "executes a code string under the profiler (exec)",
+    "gettext.bindtextdomain": "binds a message-catalog directory (I/O + global state)",
+    "os.copy_file_range": "copies between file descriptors (I/O)",
+    "posix.copy_file_range": "copies between file descriptors (I/O)",
 }
 
 # Ops that MUTATE GLOBAL INTERPRETER / PROCESS STATE -- what the side-effect probe

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -601,21 +601,15 @@ def _class_chain(cls_name: str, module: str = "builtins") -> List[Any]:
     return chain
 
 
-# THE universally-generatable value type: one annotation that both
-# hypothesis.from_type() can build AND CrossHair can symbolize/invert.  It is the
-# single vocabulary for every unconstrained "object-like" slot -- a bare object/Any
-# parameter, an unbound element TypeVar, and a generic container's element type --
-# so widening it (int -> int|float -> int|str|... ) is a ONE-LINE edit here instead
-# of a scattered find-and-replace.  Constrained slots keep their own specific
-# mappings (SupportsIndex -> int, the str/buffer families, the numeric protocols).
-# Spelled ``Union[...]`` not ``int | float``: the annotation string is eval'd at
-# runtime and the ``|`` type-union operator only exists on Python 3.10+.
+# The generatable type for every unconstrained "object-like" slot: a bare
+# object/Any parameter, an unbound element TypeVar, or a generic container's element
+# type.  Spelled ``Union[...]`` not ``int | float``: the string is eval'd at runtime
+# and the ``|`` type-union operator needs Python 3.10+.
 GENERIC = "Union[int, float]"
 
 
-# receiver annotation + TypeVar bindings.  Every container is mono-element, so we
-# bind all of typeshed's element TypeVar names (_T/_T_co/_KT/_VT) -- as used by the
-# ABC bases methods are inherited from -- to the receiver's element type.
+# receiver annotation + TypeVar bindings.  Bind all of typeshed's element TypeVar
+# names (_T/_T_co/_KT/_VT) to the container's element type.
 def _elem(t: str = GENERIC) -> Dict[str, str]:
     return {"_T": t, "_S": t, "_T_co": t, "_KT": t, "_VT": t}
 
@@ -625,7 +619,7 @@ RECV = {
     float: ("float", {}),
     bool: ("bool", {}),
     str: ("str", _elem("str")),
-    bytes: ("bytes", _elem("int")),  # bytes/bytearray elements are ints in 0..255
+    bytes: ("bytes", _elem("int")),
     bytearray: ("bytearray", _elem("int")),
     list: (f"List[{GENERIC}]", _elem()),
     tuple: (f"Tuple[{GENERIC}, ...]", _elem()),
@@ -685,8 +679,7 @@ _NAME_MAP = {
     "_MultiplicableT2": "int",
     "_SupportsProdNoDefaultT": "int",
     "_SupportsSumNoDefaultT": "int",
-    # generic element TypeVars (the unbound-free-function default) -- the SAME
-    # unconstrained value slot as object/Any, so they share GENERIC.
+    # generic element TypeVars (the unbound-free-function default)
     "_T": GENERIC,
     "_S": GENERIC,
     "_U": GENERIC,
@@ -716,18 +709,11 @@ class _Unsupported(Exception):
 
 
 def normalize(name: str, binds: Dict[str, str]) -> Optional[str]:
-    """Layer 1 -- map a typeshed leaf type NAME to a universally-generatable type:
-    one that both ``hypothesis.from_type()`` can build AND CrossHair can symbolize
-    and invert.  This is the SINGLE SOURCE of an argument's type: the returned
-    annotation string is used verbatim as the parameter annotation *and* (re-eval'd
-    via :func:`_ann`) as the fuzz strategy, so every concrete example is an instance
-    of the declared type -- the holdout can trust the annotation without re-deriving
-    it from a witness value.
+    """Map a typeshed leaf type NAME to a generatable annotation string, or None.
 
-    ``binds`` (Self / receiver / element TypeVars) win first, so a context-specific
-    type -- e.g. a comparison dunder's comparand bound to the receiver type -- beats
-    the default table.  Returns None when the name isn't known here (the caller then
-    falls through to structural handling or raises ``_Unsupported``).
+    The returned string serves as both the parameter annotation and (re-eval'd via
+    :func:`_ann`) the fuzz strategy.  ``binds`` (Self / receiver / element TypeVars)
+    take precedence over the default table.
     """
     if name in binds:
         return binds[name]
@@ -795,12 +781,9 @@ def _map_ann(node: Any, binds: Dict[str, str]) -> str:
         if base in ("dict", "Dict", "SupportsKeysAndGetItem"):
             return f"Dict[{_map_ann(elts[0], binds)}, {_map_ann(elts[1], binds)}]"
         if base == "Literal":
-            # Pass the Literal THROUGH (Literal[-1, 0, 1], Literal["r", "w"], ...):
-            # both hypothesis.from_type and CrossHair sample/invert the EXACT values,
-            # which is more faithful than widening to the underlying type -- the op
-            # genuinely accepts only these.  Render only the simple constant kinds we
-            # can reproduce verbatim (int/str/bytes/bool); enum members / qualified
-            # names fall back to the underlying scalar type's mapping.
+            # Emit the Literal verbatim for constant kinds we can render
+            # (int/str/bytes/bool); enum / qualified members fall back to the
+            # underlying scalar type.
             rendered: Optional[List[str]] = []
             for e in elts:
                 neg = isinstance(e, _ast.UnaryOp) and isinstance(e.op, _ast.USub)
@@ -1164,14 +1147,9 @@ def _roundtrip(
 def _getattr_inputs(specs: List[Any], n: int) -> "st.SearchStrategy[tuple]":
     """``getattr(o, name, ...)`` where ``name`` is a real (data) attribute of ``o``
     -- so it exercises actual attribute access instead of raising AttributeError on
-    a fuzzed string.  Preserves the op's arity (any trailing ``default`` fuzzes
-    normally).
-
-    ``o`` is drawn from its OWN annotation-derived strategy (``specs[0]`` -- Layer 1,
-    i.e. ``GENERIC``), NOT a hardcoded object set.  This keeps the fuzzed object type
-    identical to what the holdout inverts over: a wider fuzz domain (e.g. an extra
-    ``complex``) would produce outputs the typed inversion can't reach, a false
-    "black".  The real-attribute correlation below is the Layer-2 part."""
+    a fuzzed string.  ``o`` is drawn from its own annotation-derived strategy
+    (``specs[0]``).  Preserves the op's arity (any trailing ``default`` fuzzes
+    normally)."""
     objs = _arg_strategy(specs[0], n) if specs else st.integers()
 
     def with_name(o: Any) -> "st.SearchStrategy[tuple]":

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -610,7 +610,7 @@ def _class_chain(cls_name: str, module: str = "builtins") -> List[Any]:
 # mappings (SupportsIndex -> int, the str/buffer families, the numeric protocols).
 # Spelled ``Union[...]`` not ``int | float``: the annotation string is eval'd at
 # runtime and the ``|`` type-union operator only exists on Python 3.10+.
-GENERIC = "int"
+GENERIC = "Union[int, float]"
 
 
 # receiver annotation + TypeVar bindings.  Every container is mono-element, so we

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -2333,8 +2333,11 @@ class SymbolicArrayBasedUniformTuple(SymbolicSequence):
             if self is other:
                 return True
             self_arr, self_len = self.var
-            if isinstance(other, SymbolicArrayBasedUniformTuple):
-                # TODO: Can these be HeapRefs? If so, we're only doing identity checks:
+            if (
+                isinstance(other, SymbolicArrayBasedUniformTuple)
+                and self.item_smt_sort is not HeapRef
+                and self_arr.sort() == other._arr().sort()
+            ):
                 return SymbolicBool(
                     z3.And(self_len == other._len(), self_arr == other._arr())
                 )

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -5242,9 +5242,7 @@ def _bytearray_join(self, itr) -> bytes:
 
 
 def _str_format(self, /, *a, **kw) -> Union[AnySymbolicStr, str]:
-    # ``self`` is positional-only: ``str.format`` accepts a ``self`` keyword field
-    # ("{self}".format(self=x)), which would otherwise collide with this receiver
-    # parameter ("got multiple values for argument 'self'").
+    # positional-only: str.format takes a "self" keyword field ("{self}".format(self=x))
     template = realize(self)
     return string.Formatter().format(template, *a, **kw)
 

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -5238,7 +5238,10 @@ def _bytearray_join(self, itr) -> bytes:
     return _join(self, itr, self_type=bytearray, item_type=Buffer)
 
 
-def _str_format(self, *a, **kw) -> Union[AnySymbolicStr, str]:
+def _str_format(self, /, *a, **kw) -> Union[AnySymbolicStr, str]:
+    # ``self`` is positional-only: ``str.format`` accepts a ``self`` keyword field
+    # ("{self}".format(self=x)), which would otherwise collide with this receiver
+    # parameter ("got multiple values for argument 'self'").
     template = realize(self)
     return string.Formatter().format(template, *a, **kw)
 

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -2218,17 +2218,11 @@ def test_list_equality() -> None:
     check_states(f, POST_FAIL)
 
 
-def test_list_equality_mismatched_element_sorts() -> None:
-    # Comparing two symbolic sequences whose backing arrays have DIFFERENT element
-    # sorts (Int-valued vs Real-valued) used to fast-path into a raw ``arr == arr``,
-    # leaking a Z3Exception "sort mismatch"; it must fall through to element-wise
-    # comparison (which coerces int/float) and yield a symbolic bool instead.
+def test_list_equality_mismatched_element_sorts(space) -> None:
+    a = proxy_for_type(List[int], "a")
+    b = proxy_for_type(List[float], "b")
     for op in (lambda a, b: a == b, lambda a, b: a != b, lambda a, b: a < b):
-        with standalone_statespace:
-            with NoTracing():
-                a = proxy_for_type(List[int], "a")
-                b = proxy_for_type(List[float], "b")
-            op(a, b)  # must not raise
+        op(a, b)  # must not raise
 
 
 def test_list_extend_literal_unknown() -> None:

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -1702,6 +1702,16 @@ def test_str_format_map():
         assert space.is_possible(ord("a{foo}c".format_map({"foo": s})[1]) == ord("b"))
 
 
+def test_str_format_self_keyword():
+    # str.format accepts a "self" field/keyword; the format patch's receiver
+    # parameter must not collide with it ("got multiple values for 'self'").
+    with standalone_statespace as space:
+        with NoTracing():
+            s = LazyIntSymbolicStr("s")
+        space.add(s.__len__() == 1)
+        assert space.is_possible(ord("a{self}c".format(self=s)[1]) == ord("b"))
+
+
 def test_str_rfind() -> None:
     with standalone_statespace, NoTracing():
         string = LazyIntSymbolicStr(list(map(ord, "ababb")))

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -2218,6 +2218,19 @@ def test_list_equality() -> None:
     check_states(f, POST_FAIL)
 
 
+def test_list_equality_mismatched_element_sorts() -> None:
+    # Comparing two symbolic sequences whose backing arrays have DIFFERENT element
+    # sorts (Int-valued vs Real-valued) used to fast-path into a raw ``arr == arr``,
+    # leaking a Z3Exception "sort mismatch"; it must fall through to element-wise
+    # comparison (which coerces int/float) and yield a symbolic bool instead.
+    for op in (lambda a, b: a == b, lambda a, b: a != b, lambda a, b: a < b):
+        with standalone_statespace:
+            with NoTracing():
+                a = proxy_for_type(List[int], "a")
+                b = proxy_for_type(List[float], "b")
+            op(a, b)  # must not raise
+
+
 def test_list_extend_literal_unknown() -> None:
     def f(ls: List[int]) -> List[int]:
         """

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -1703,8 +1703,6 @@ def test_str_format_map():
 
 
 def test_str_format_self_keyword():
-    # str.format accepts a "self" field/keyword; the format patch's receiver
-    # parameter must not collide with it ("got multiple values for 'self'").
     with standalone_statespace as space:
         with NoTracing():
             s = LazyIntSymbolicStr("s")

--- a/crosshair/patch_equivalence_test.py
+++ b/crosshair/patch_equivalence_test.py
@@ -43,6 +43,13 @@ edge_args = [
 
 untested_patches = {
     itertools.groupby,  # the return value has nested iterators that break comparisons
+    # Order-dependent output: CrossHair realizes a set/frozenset in solver order,
+    # which need not match CPython's hash order, so repr strings and the popped
+    # element legitimately differ.  (Value-comparable set ops -- union, difference,
+    # membership -- are still tested; these three are not value functions.)
+    set.pop,
+    set.__repr__,
+    frozenset.__repr__,
     # CrossHair intentionally no-ops sleep; it doesn't replicate CPython's
     # OverflowError for out-of-range durations.
     time.sleep,

--- a/crosshair/tools/demo_overrides.py
+++ b/crosshair/tools/demo_overrides.py
@@ -38,13 +38,14 @@ demo you just write (or fix) a ``@pytest.mark.demo`` test -- CI keeps it honest 
 this harvester picks it up automatically.
 
 Because those tests assert ``check_states(f, POST_FAIL)`` in CI, every harvested
-demo is *winnable* (CrossHair solves it) by construction.  A winnable demo can only
-honestly illustrate a cell CrossHair handles, so ``measure_support`` applies
-overrides to GREEN/YELLOW cells only (re-confirming the demo still solves under the
-measurement budget).  Red/black cells keep their generated demo, which shows the
-*limitation* itself -- something a CI-passing test could never demonstrate; a
-curated "watch it struggle" demo would have to be a hand-authored source here, not
-a harvested test.
+demo is *winnable* (CrossHair solves it) by construction.  ``measure_support``
+applies overrides to GREEN/YELLOW/RED cells (re-confirming the demo still solves
+under the measurement budget) -- showing a case CrossHair CAN handle is a fine
+illustration even for a hard op (a red cell's own generated demo often shows a
+solvable small case too).  BLACK cells are the exception: they are unsound and must
+exhibit the wrong answer, which a winnable demo would hide, so they keep their
+generated wrong-answer repro.  A curated "watch it struggle" demo (or a black
+bug demo) would have to be a hand-authored source here, not a harvested test.
 
 The mapping from a test name to the op's ``seedkey`` (its dotted identity, the
 same key ``measure_support`` looks up) is::

--- a/crosshair/tools/demo_overrides.py
+++ b/crosshair/tools/demo_overrides.py
@@ -1,0 +1,137 @@
+"""
+Curated demo overrides for the support treemap.
+
+The support map (:mod:`crosshair.tools.measure_support`) colors each operation
+cell from an honest fuzzed sweep, then auto-generates a runnable crosshair-web
+demo from the sweep's own witness.  Those generated demos are always *consistent*
+with the cell color, but they are often pedagogically weak: the contract is
+``post: _ != <the value we just computed>``, so for an idempotent op (``str.lower``,
+``str.strip``, ...) the reader can "solve" it by pasting the literal, and the
+fuzzed literals are frequently unreadable astral-plane noise.
+
+A better demo is a hand-written one that poses a natural-language question.  We
+already have 50+ of those -- the ``@pytest.mark.demo`` tests in the ``libimpl``
+``*lib_test`` modules::
+
+    @pytest.mark.demo
+    def test_int___add___method():
+        def f(a: int, b: int) -> int:
+            '''
+            Can the sum of two consecutive integers be 37?
+
+            pre: a + 1 == b
+            post: _ != 37
+            '''
+            return a + b
+
+        check_states(f, POST_FAIL)
+
+These are curated, readable, AND self-verifying (a real test asserts they behave).
+This module HARVESTS them -- by parsing the test *source*, so it pulls in no test
+dependencies (no pytest import, no test-module side effects) -- into a
+``seedkey -> crosshair-web source`` registry that ``measure_support`` consults for
+the demo link.
+
+Crucially, an override changes ONLY the link.  The cell color stays the honest
+measured verdict, and a curated demo can never paint the map.  To improve a cell's
+demo you just write (or fix) a ``@pytest.mark.demo`` test -- CI keeps it honest and
+this harvester picks it up automatically.
+
+Because those tests assert ``check_states(f, POST_FAIL)`` in CI, every harvested
+demo is *winnable* (CrossHair solves it) by construction.  A winnable demo can only
+honestly illustrate a cell CrossHair handles, so ``measure_support`` applies
+overrides to GREEN/YELLOW cells only (re-confirming the demo still solves under the
+measurement budget).  Red/black cells keep their generated demo, which shows the
+*limitation* itself -- something a CI-passing test could never demonstrate; a
+curated "watch it struggle" demo would have to be a hand-authored source here, not
+a harvested test.
+
+The mapping from a test name to the op's ``seedkey`` (its dotted identity, the
+same key ``measure_support`` looks up) is::
+
+    test_<owner>___<dunder>___method  ->  <owner>.<dunder>        (builtin method)
+    test_<owner>_<name>_method        ->  <owner>.<name>          (builtin method)
+    test_<owner>___<dunder>___method  ->  <module>.<owner>.<dunder>  (stdlib method)
+    test_<name>                       ->  <module>.<name>         (free function)
+
+with ``<module>`` taken from the owning ``*lib_test`` file.
+"""
+
+import re
+import textwrap
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Iterator, List, Tuple
+
+_LIBIMPL = Path(__file__).resolve().parent.parent / "libimpl"
+
+# A demo test: the marker (optional color arg), the def line, then everything up
+# to the closing ``check_states(`` call, from which we lift the inner ``def f``.
+_DEMO_RE = re.compile(r'@pytest\.mark\.demo(?:\("(\w+)"\))?\s*\ndef (test_\w+)\(')
+_F_RE = re.compile(r"( *def f\(.*?)\n\s*check_states\(", re.DOTALL)
+
+
+def _iter_demo_tests(src: str) -> Iterator[Tuple[str, str, str]]:
+    """Yield ``(test_name, marker_color, dedented_f_source)`` for every
+    ``@pytest.mark.demo`` test in a module's source text."""
+    for m in _DEMO_RE.finditer(src):
+        color = m.group(1) or "green"
+        test = m.group(2)
+        # the test body runs from just after the def line to the next top-level
+        # ``def``/``class``/decorator (or EOF); the demo's ``f`` lives inside it.
+        tail = src[m.end() :]
+        nxt = re.search(r"\n(?=@pytest\.mark|def |class )", tail)
+        block = tail[: nxt.start()] if nxt else tail
+        fm = _F_RE.search(block)
+        if fm:
+            yield test, color, textwrap.dedent(fm.group(1))
+
+
+def _seedkey(module: str, test: str) -> str:
+    """The op seedkey a demo test targets (see the module docstring for the
+    conventions).  A trailing ``_method`` or ``_operator`` marks a method/operator
+    test (``test_float___pow___operator`` -> ``float.__pow__``); anything else is a
+    free function (``test_sorted`` -> ``builtins.sorted``)."""
+    name = test[len("test_") :]
+    for suffix in ("_method", "_operator"):
+        if name.endswith(suffix):
+            owner, _, meth = name[: -len(suffix)].partition("_")
+            return (
+                f"{owner}.{meth}"
+                if module == "builtins"
+                else f"{module}.{owner}.{meth}"
+            )
+    return f"{module}.{name}"
+
+
+def _source(module: str, f_src: str) -> str:
+    """Wrap a harvested ``def f`` in a self-contained crosshair-web source.  Stdlib
+    demos may reference either qualified (``json.dumps``) or bare (``deque``) names,
+    so we make both available; ``from typing import *`` covers the annotations."""
+    if module == "builtins":
+        return "from typing import *\n\n" + f_src
+    return f"from typing import *\nimport {module}\nfrom {module} import *\n\n" + f_src
+
+
+@lru_cache(maxsize=None)
+def demo_overrides() -> Dict[str, List[Tuple[str, str]]]:
+    """``seedkey -> [(marker_color, crosshair_web_source), ...]`` harvested from the
+    ``@pytest.mark.demo`` tests, best (first-declared) candidate first.
+
+    A list per seedkey so a cell can offer several curated demos;
+    ``measure_support`` uses the first that survives its color-consistency check.
+    """
+    out: Dict[str, List[Tuple[str, str]]] = {}
+    for path in sorted(_LIBIMPL.glob("*lib_test.py")):
+        module = path.stem[: -len("lib_test")] or "builtins"
+        src = path.read_text()
+        for test, color, f_src in _iter_demo_tests(src):
+            out.setdefault(_seedkey(module, test), []).append(
+                (color, _source(module, f_src))
+            )
+    return out
+
+
+def demo_sources(seedkey: str) -> List[str]:
+    """Curated crosshair-web sources for an op (best first), or ``[]`` if none."""
+    return [src for _color, src in demo_overrides().get(seedkey, [])]

--- a/crosshair/tools/demo_overrides_test.py
+++ b/crosshair/tools/demo_overrides_test.py
@@ -1,0 +1,75 @@
+"""Tests for the curated demo-override harvester.
+
+The ``@pytest.mark.demo`` tests themselves are self-verifying (each asserts its
+``check_states`` behavior in its own libimpl ``*lib_test`` module).  These tests
+guard the HARVEST -- that the name->seedkey convention still holds, that every
+demo yields a self-contained, parseable crosshair-web source, and that the keys
+line up with what ``measure_support`` looks up -- so the map's demo links can't
+silently rot when a demo is renamed or the convention drifts."""
+
+import ast
+import re
+
+import pytest
+
+# a crosshair contract line: pre:/post:, the latter optionally scoped (post[ls]:)
+_CONTRACT_RE = re.compile(r"\b(?:pre|post(?:\[[^\]]*\])?):")
+
+from crosshair.tools.demo_overrides import (
+    _seedkey,
+    _source,
+    demo_overrides,
+    demo_sources,
+)
+
+
+def test_harvest_is_populated():
+    ov = demo_overrides()
+    # dozens of @pytest.mark.demo tests exist across the libimpl test modules
+    assert len(ov) >= 40
+
+
+@pytest.mark.parametrize(
+    "module,test,expected",
+    [
+        ("builtins", "test_int___add___method", "int.__add__"),
+        ("builtins", "test_str_replace_method", "str.replace"),
+        ("builtins", "test_float___pow___operator", "float.__pow__"),
+        ("builtins", "test_sorted", "builtins.sorted"),
+        ("json", "test_dumps", "json.dumps"),
+        ("collections", "test_deque_extendleft_method", "collections.deque.extendleft"),
+        ("datetime", "test_timedelta___add___method", "datetime.timedelta.__add__"),
+    ],
+)
+def test_seedkey_mapping(module, test, expected):
+    assert _seedkey(module, test) == expected
+
+
+def test_known_ops_are_covered():
+    ov = demo_overrides()
+    for seedkey in ("int.__add__", "str.replace", "str.join", "json.dumps"):
+        assert seedkey in ov, f"expected a curated demo for {seedkey}"
+
+
+def test_every_source_is_self_contained_and_has_a_contract():
+    for seedkey, candidates in demo_overrides().items():
+        for _color, source in candidates:
+            # parses as a module and defines exactly the demo function ``f``
+            tree = ast.parse(source)
+            fns = [n.name for n in tree.body if isinstance(n, ast.FunctionDef)]
+            assert fns == ["f"], f"{seedkey}: expected one def f, got {fns}"
+            # carries a contract crosshair can act on
+            assert _CONTRACT_RE.search(source), f"{seedkey}: no contract"
+
+
+def test_source_imports_typing_and_owning_module():
+    # a builtins demo needs only typing; a stdlib demo must also import its module
+    assert _source("builtins", "def f(): pass\n").startswith("from typing import *")
+    stdlib = _source("json", "def f(): pass\n")
+    assert "import json" in stdlib and "from typing import *" in stdlib
+
+
+def test_demo_sources_helper_drops_colors():
+    both = demo_overrides()["int.__add__"]
+    assert demo_sources("int.__add__") == [src for _c, src in both]
+    assert demo_sources("no.such.op") == []

--- a/crosshair/tools/generate_treemap.py
+++ b/crosshair/tools/generate_treemap.py
@@ -2,7 +2,7 @@
 Render the measured CrossHair support corpus as an SVG.
 
 Two modes, both nested by builtin type / ``builtins`` functions / stdlib module,
-each cell colored by its support result (green/yellow/red/grey):
+each cell colored by its support result (green/yellow/red/black/grey):
 
   * default -- a fixed-size grid (every operation the same size).
   * ``--weights usage.json`` -- a single area-weighted treemap, each cell sized by
@@ -10,11 +10,48 @@ each cell colored by its support result (green/yellow/red/grey):
     away.  This is what the docs ship.
 
 Cells carry a plain-English hover and a click-through to a runnable crosshair-web
-demo.  Reads the merged JSON emitted by ``measure_support surface``/``funcs``.
+demo.  ``--measured`` takes one or more JSON files from ``measure_support measure``
+(comma-separated; later files win on key collisions).
 
-    python -m crosshair.tools.generate_treemap \\
-        --measured surface.json,funcs.json --weights usage.json \\
-        --out doc/source/support_treemap.svg
+================================================================================
+Regenerating the shipped map  (doc/source/support_treemap.svg)
+================================================================================
+The map joins two JSON inputs: a MEASUREMENT (how well CrossHair reasons about
+each op -- from ``measure_support``) and a USAGE PRIOR (how widely each op is
+used -- from ``mine_usage``).  The usage prior (``doc/source/usage_prior.json``)
+is checked in and changes rarely, so the everyday refresh is just steps 2 + 4:
+
+    # 1. (occasional) fetch a corpus of top-PyPI wheels -- .py text only, no exec
+    python -m crosshair.tools.fetch_corpus --n 200 --out /tmp/pypi_corpus
+
+    # 2. measure the whole operation catalog -> measured.json
+    #    ~22k ops, but ~19k are statically classified (out-of-scope / no inputs /
+    #    side effect / probe hazard) and return instantly; only ~3k get a real
+    #    symbolic sweep.  Keep --jobs at or below your core count (each worker
+    #    pins a core with a z3 solve).  Run it from a SCRATCH dir: the fuzzer
+    #    writes a .hypothesis/ cache into the cwd.
+    python -m crosshair.tools.measure_support measure --jobs 8 --json measured.json
+
+    # 3. (occasional) re-mine the usage prior from the corpus, keyed to the cells
+    #    the measurement just produced (so weights join onto treemap cells)
+    python -m crosshair.tools.mine_usage --measured measured.json \\
+        --corpus /tmp/pypi_corpus --out doc/source/usage_prior.json
+
+    # 4. render the shipped SVG: full catalog, area-weighted by package usage.
+    #    The committed map uses the DEFAULTS below -- do not pass --metric/--scale/
+    #    --min-weight unless you intend to change what ships.
+    python -m crosshair.tools.generate_treemap --measured measured.json \\
+        --weights doc/source/usage_prior.json --out doc/source/support_treemap.svg
+
+The committed map is the area-weighted treemap with ``--metric packages
+--scale linear --min-weight 1.0`` (the defaults): each cell's area is the number
+of packages that use the op, and ops used by fewer than one package are dropped.
+Omit ``--weights`` entirely for the fixed-size grid instead of the treemap.
+
+Scoped re-measurement (step 2) -- for re-running one wedged module or a single
+tier in its own killable invocation, then merging the JSONs at step 4:
+    python -m crosshair.tools.measure_support measure --modules math,json --json m1.json
+    python -m crosshair.tools.measure_support measure --tiers builtin-methods,functions ...
 """
 
 import argparse

--- a/crosshair/tools/measure_support.py
+++ b/crosshair/tools/measure_support.py
@@ -82,7 +82,7 @@ from crosshair.inputgen import (  # shared surface + valid-input generation
 )
 from crosshair.options import AnalysisOptionSet
 from crosshair.statespace import MessageType
-from crosshair.tools.demo_overrides import demo_sources
+from crosshair.tools.demo_overrides import demo_overrides, demo_sources
 
 _DEVNULL = open(os.devnull, "w")
 
@@ -733,7 +733,7 @@ def _demo_solves(source: str, lib: str) -> bool:
     """Does CrossHair actually solve this curated demo here (find a POST_FAIL
     counterexample) under the measurement budget?  Any load/analysis failure ->
     False -> fall back to the generated demo.  Cheap: one analysis, run only for the
-    handful of green/yellow ops that carry an override."""
+    handful of green/yellow/red ops that carry an override."""
     try:
         fn = _load(source, lib)
         states = {m.state for m in run_checkables(analyze_function(fn, HOLDOUT_OPTS))}
@@ -975,6 +975,11 @@ def _measure_cmd(
 ) -> None:
     tally = {"green": 0, "yellow": 0, "red": 0, "black": 0, "?": 0, "skip": 0}
     out = {}
+    # Track which curated demo overrides actually landed as a cell's demo, and why
+    # the rest were dropped -- so a harvested demo silently going unused is visible.
+    overrides = demo_overrides()
+    ov_used: Dict[str, str] = {}  # seedkey -> color
+    ov_drop: Dict[str, str] = {}  # seedkey -> reason
     print(f"{'op':{label_w}s} {'result':6s}  verdict")
     print("-" * (label_w + 30))
     done = 0
@@ -991,6 +996,19 @@ def _measure_cmd(
             if example:  # runnable crosshair-web source for this op
                 rec["example"] = example
             out[key] = rec
+        if label in overrides:  # label is the op seedkey for a measured cell
+            if example is not None and example in demo_sources(label):
+                ov_used[label] = color
+            else:
+                ov_drop[label] = (
+                    "black cell (kept the wrong-answer repro)"
+                    if color == "black"
+                    else (
+                        'unmeasured "?" cell'
+                        if color == "?"
+                        else "curated demo did not solve within budget"
+                    )
+                )
         print(
             f"{label:{label_w}s} {color:6s}  {verdict}  [{done}/{len(tasks)}]",
             flush=True,  # long runs are block-buffered otherwise -> looks hung
@@ -1000,7 +1018,33 @@ def _measure_cmd(
         f"green={tally['green']} yellow={tally['yellow']} red={tally['red']} "
         f"black={tally['black']} defer(?)={tally['?']} skipped={tally['skip']}"
     )
+    _report_overrides(ov_used, ov_drop)
     _emit(args, out)
+
+
+def _report_overrides(used: Dict[str, str], dropped: Dict[str, str]) -> None:
+    """Summarize curated demo-override usage for this run: how many landed as a
+    cell's demo vs. were discarded (grouped by why), plus any harvested override
+    that matches no operation in the catalog at all (a permanently-dead demo,
+    usually a stale/renamed op -- worth fixing)."""
+    exercised = len(used) + len(dropped)
+    catalog_seedkeys = {op.seedkey for op in _CATALOG.values()}
+    dead = sorted(k for k in demo_overrides() if k not in catalog_seedkeys)
+    print(
+        f"demo overrides: {len(demo_overrides())} harvested, "
+        f"{exercised} exercised this run"
+    )
+    if exercised:
+        n_used, n_drop = len(used), len(dropped)
+        print(f"  used:      {n_used:3d}/{exercised} ({100 * n_used // exercised}%)")
+        print(f"  discarded: {n_drop:3d}/{exercised} ({100 * n_drop // exercised}%)")
+        by_reason: Dict[str, List[str]] = {}
+        for seedkey, reason in sorted(dropped.items()):
+            by_reason.setdefault(reason, []).append(seedkey)
+        for reason, seedkeys in by_reason.items():
+            print(f"    {reason} ({len(seedkeys)}): {', '.join(seedkeys)}")
+    if dead:
+        print(f"  no matching op in catalog ({len(dead)}): {', '.join(dead)}")
 
 
 # The ONE surface -- built once at import from crosshair.inputgen.catalog and

--- a/crosshair/tools/measure_support.py
+++ b/crosshair/tools/measure_support.py
@@ -82,6 +82,7 @@ from crosshair.inputgen import (  # shared surface + valid-input generation
 )
 from crosshair.options import AnalysisOptionSet
 from crosshair.statespace import MessageType
+from crosshair.tools.demo_overrides import demo_sources
 
 _DEVNULL = open(os.devnull, "w")
 
@@ -395,20 +396,36 @@ def _sweep(
     # inverted args (ok_max None) sort worst -> red.
     worst = min(measurable, key=lambda e: (e[1] if e[1] is not None else -1, -e[0]))
     wi, w_ok, _, w_unsup, w_t, w_v = worst
-    # Demo the worst arg's inversion.  If it never inverted (a red), there's no
-    # successful witness -- fall back to a forward sample so the cell still links
-    # to a runnable contract (CrossHair failing to satisfy it IS the "struggles
-    # here" demonstration).
+    # A successful inversion (``w_t`` set) demos a case CrossHair SOLVES; with none,
+    # fall back to a forward sample -- a runnable contract CrossHair can't satisfy
+    # (its failure IS the "struggles here" demonstration).  These read very
+    # differently to a user clicking through, so the demo docstring says which.
+    witnessed = w_t is not None
     if w_t is None:
         _, w_t, w_v = samples[-1]
-    demo = _pinned_demo(header, params, expr, wi, w_t, w_v, scope)
+
+    def demo(note: str = "") -> Optional[str]:
+        return _pinned_demo(header, params, expr, wi, w_t, w_v, scope, note)
+
     if w_unsup:
-        return ("red", "unsupported: can't accept a symbolic argument here", demo)
+        return (
+            "red",
+            "unsupported: can't accept a symbolic argument here",
+            demo(
+                "CrossHair can't reason about a symbolic value in this position, "
+                "so it can only try fixed guesses here."
+            ),
+        )
     if w_ok is not None and w_ok >= SIZES[-1]:
-        return ("green", "handled at every size", demo)
+        return ("green", "handled at every size", demo())
     if w_ok is None or w_ok <= SIZES[0]:
-        return ("red", "only the trivial case", demo)
-    return ("yellow", f"slows down past size {w_ok}", demo)
+        note = (
+            "CrossHair can solve this small case, but struggles as the inputs grow."
+            if witnessed
+            else "CrossHair is unlikely to find a solution to this within its time budget."
+        )
+        return ("red", "only the trivial case", demo(note))
+    return ("yellow", f"slows down past size {w_ok}", demo())
 
 
 def _repr_ok(x: Any) -> bool:
@@ -428,11 +445,15 @@ def _pinned_demo(
     t: Optional[Sequence[Any]],
     V: Any,
     scope: Optional[str],
+    note: str = "",
 ) -> Optional[str]:
     """A runnable crosshair-web source inverting ONLY ``params[free_i]`` -- the
     other arguments are pinned by ``pre`` to their values in ``t`` (so the demo
     shows real backward reasoning, not a degenerate set-an-arg-to-the-output).
-    None if any pinned value or the target won't round-trip through repr."""
+    ``note`` is an optional plain-English line prepended to the docstring to tell
+    the reader what to expect (a red demo may be a small case CrossHair solves, or
+    one it can't -- see :func:`_sweep`).  None if any pinned value or the target
+    won't round-trip through repr."""
     if V is None or t is None:
         return None
     if not _repr_ok(V):
@@ -445,7 +466,8 @@ def _pinned_demo(
                 return None
             pres.append(f"pre: {name} == {t[j]!r}")
     target = f"post[{scope}]: {scope} != {V!r}" if scope else f"post: _ != {V!r}"
-    doc = "\n    ".join(pres + [target])
+    lines = ([note, ""] if note else []) + pres + [target]
+    doc = "\n    ".join(lines)
     return (
         f"{header}from typing import *\n\n"
         f"def f({', '.join(sig)}):\n"
@@ -707,13 +729,58 @@ def _resolve_type(op: Any) -> Optional[type]:
         return None
 
 
+def _demo_solves(source: str, lib: str) -> bool:
+    """Does CrossHair actually solve this curated demo here (find a POST_FAIL
+    counterexample) under the measurement budget?  Any load/analysis failure ->
+    False -> fall back to the generated demo.  Cheap: one analysis, run only for the
+    handful of green/yellow ops that carry an override."""
+    try:
+        fn = _load(source, lib)
+        states = {m.state for m in run_checkables(analyze_function(fn, HOLDOUT_OPTS))}
+    except (KeyboardInterrupt, SystemExit):
+        raise
+    except BaseException:
+        return False
+    return MessageType.POST_FAIL in states
+
+
+def _with_override(op: Any, res: Any) -> Any:
+    """Swap the auto-generated demo for a curated one (:mod:`demo_overrides`, best
+    candidate first).  Changes ONLY the demo link, never the measured color/verdict.
+
+    Curated demos are harvested from ``@pytest.mark.demo`` tests, which assert
+    ``check_states(f, POST_FAIL)`` in CI -- so every one is *winnable* by
+    construction.  We use them for green/yellow AND red cells: showing a case
+    CrossHair CAN handle is a fine illustration even when the op is hard in general
+    (a red cell's own generated demo often shows a solvable small case too), and we
+    re-confirm the demo still solves under the measurement budget.
+
+    BLACK is the exception -- it's unsound, and its whole point is to exhibit a
+    wrong answer.  A winnable demo would HIDE that bug, so a black cell keeps its
+    generated demo (the forward wrong-answer repro / false-confirmation), which a
+    CI-passing test could never show.  "?" cells have no demo to improve."""
+    if not res:
+        return res
+    color, verdict, _example = res
+    if color not in ("green", "yellow", "red"):
+        return res
+    for source in demo_sources(op.seedkey):
+        if _demo_solves(source, op.module):
+            return (color, verdict, source)
+    return res
+
+
 def _measure_task(key: str) -> Tuple[str, str, Any]:
     """Measure ONE catalogued op, looked up by its key.  The catalog already
     settled the up-front classification, so we honor it here instead of
     re-deriving it: an op that is out of scope, a probe hazard, or reaches for I/O
     is rendered as an explained grey cell and is NEVER run concretely (that's what
     kept the concrete sweep from doing real I/O).  Only a cleanly drivable op is
-    handed to the symbolic measurement."""
+    handed to the symbolic measurement.
+
+    A cleanly measured cell then gets its demo link upgraded to a curated one when
+    one is registered and stays consistent with the measured color (:func:`_with_override`).
+    """
     op = _CATALOG[key]
     if op.out_of_scope:
         res: Any = ("?", f"out of scope: {op.out_of_scope}", None)
@@ -734,7 +801,7 @@ def _measure_task(key: str) -> Tuple[str, str, Any]:
         )
     else:
         res = _safe(lambda: measure_func(op.module, op.name))
-    return (op.key, op.seedkey, res)
+    return (op.key, op.seedkey, _safe(lambda: _with_override(op, res)) or res)
 
 
 # A single op can wedge a worker in native code (CrossHair's own per-condition


### PR DESCRIPTION
## What & why

Each cell in the support treemap links to a runnable crosshair-web demo, auto-generated from the measurement sweep's own witness. Those links are *honest* (always consistent with the cell color) but often **pedagogically weak**:

- the contract is always `post: _ != <the value we just computed>`, so idempotent/absorbing ops (`str.lower`, `str.strip`, `max`, `copysign`, …) are "solved" by pasting the literal — no real challenge;
- **~24% (116/469)** of the links carry unreadable astral-plane / `\x`-escape literals like `'\U000ef534\U00089370¬Oá'`.

We already have ~55 curated, readable, self-verifying demos — the surviving `@pytest.mark.demo` tests in `crosshair/libimpl/*lib_test.py`, each a real `check_states(f, POST_FAIL)` test with a natural-language question in the docstring. This PR harvests them as demo-link overrides (reviving the spirit of the old `generate_demo_table` harvest, but with the color now coming from measurement, not a marker arg).

## How

- **`crosshair/tools/demo_overrides.py`** (new) — parses the test *source* (no pytest / test-module import, no side effects) into a `seedkey → crosshair-web source` registry, mapping test names to op seedkeys (`test_int___add___method` → `int.__add__`, `test_dumps` in `jsonlib_test` → `json.dumps`, …). 46/55 land on a real catalog op; the rest are genuinely-unmeasured type constructors and are harmless unused entries.
- **`measure_support._with_override`** — swaps the generated demo for a curated one, changing **only the link**, never the measured color/verdict. So an override can never "paint" the map, and to improve a cell's demo you just write a `@pytest.mark.demo` test.

## The green/yellow/red vs. black policy

Because `@pytest.mark.demo` tests assert `check_states(f, POST_FAIL)` in CI, every harvested demo is **winnable by construction** — you can't author a "watch it struggle" demo as a passing test.

- **green / yellow / red** → overridden with the curated (winnable) demo, re-confirming it still solves under the measurement budget. Showing a case CrossHair *can* handle is a fine illustration even for a red op (a red cell's own generated demo often shows a solvable small case too).
- **black** → **excluded.** Black is a soundness bug; its whole point is to *exhibit* the wrong answer. A winnable demo would hide the bug, so black keeps its generated wrong-answer repro (`_diff_demo` / false-confirmation) — something a CI-passing test could never show.

## Red demo docstring notes

The two red generated-demo sub-cases now carry a plain-English note so a user knows what to expect on click:

- solvable small case (inverted at a small size, then cliffed) → *"CrossHair can solve this small case, but struggles as the inputs grow."*
- unsolvable (worst arg never inverted → pinned to the largest sample) → *"CrossHair is unlikely to find a solution to this within its time budget."*

## Tests

`crosshair/tools/demo_overrides_test.py` guards the harvest and the name→seedkey convention (fast; the demo behavior itself is already covered by the `check_states` tests). Verified end-to-end that green/red cells get their curated demos and black cells are left untouched.

> Note: the shipped `doc/source/support_treemap.svg` is **not** regenerated here — that needs a full measure run (the release-script step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)