### PR TITLE
[investigation] float fix + realization-unsat diagnostics

### DIFF
--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -669,6 +669,13 @@ def apply_smt(op: BinFn, x: z3.ExprRef, y: z3.ExprRef) -> z3.ExprRef:
     # TODO: we should investigate using the op override mechanism to
     # dispatch to the right SMT operations.
     space = context_statespace()
+    if op in (ops.eq, ops.ne) and z3.is_fp(x) and z3.is_fp(y):
+        # z3's structural `==`/`!=` on floats disagrees with IEEE (and Python)
+        # equality: it treats +0.0 and -0.0 as distinct and treats NaN as equal
+        # to itself. Use fpEQ so that, e.g., `0 == -0.0` is True and `nan == nan`
+        # is False.
+        smt_eq = fpEQ(x, y)
+        return smt_eq if op is ops.eq else z3.Not(smt_eq)
     if op in _ARITHMETIC_OPS:
         if op in (ops.truediv, ops.floordiv, ops.mod):
             iszero = (fpEQ(y, 0.0)) if isinstance(y, z3.FPRef) else (y == 0)
@@ -1576,26 +1583,9 @@ class PreciseIeeeSymbolicFloat(SymbolicFloat):
             return z3.FPVal(literal, cls._ch_smt_sort())
         return None
 
-    def __eq__(self, other):
-        with NoTracing():
-            coerced = type(self)._coerce_to_smt_sort(other)
-            if coerced is None:
-                return False
-            return SymbolicBool(fpEQ(self.var, coerced))
-
-    # __hash__ has to be explicitly reassigned because we define __eq__
-    __hash__ = SymbolicFloat.__hash__
-
     def __bool__(self):
         with NoTracing():
             return not SymbolicBool(z3.fpIsZero(self.var))
-
-    def __ne__(self, other):
-        with NoTracing():
-            coerced = type(self)._coerce_to_smt_sort(other)
-            if coerced is None:
-                return True
-            return SymbolicBool(z3.Not(fpEQ(self.var, coerced)))
 
     def __int__(self):
         with NoTracing():

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -398,6 +398,62 @@ def test_int___pow___to_real_based_float():
             realize(sqrt_a == 3)
 
 
+def test_int_eq_ieee_negative_zero():
+    # Regression for the unsound `sampled_from([0, 0.0])` uniqueness bug: when an
+    # int is compared against a PreciseIeeeSymbolicFloat, the comparison must use
+    # IEEE equality. z3's structural fp equality treats +0.0 and -0.0 as distinct,
+    # which made CrossHair believe 0 and -0.0 were unequal. The int==float path
+    # promotes the int to a float and dispatches through numeric_binop/apply_smt.
+    with standalone_statespace as space:
+        with NoTracing():
+            space.extra(ModelingDirector).global_representations[
+                float
+            ] = PreciseIeeeSymbolicFloat
+            zero_int = SymbolicInt("zero_int")
+            neg_zero = PreciseIeeeSymbolicFloat(
+                z3.FPVal(-0.0, PreciseIeeeSymbolicFloat._ch_smt_sort())
+            )
+        with ResumedTracing():
+            space.add(zero_int == 0)
+            assert zero_int == neg_zero
+            assert not (zero_int != neg_zero)
+
+
+def test_apply_smt_ieee_equality():
+    # apply_smt must implement IEEE (not z3's structural) equality on floats:
+    # +0.0 == -0.0 and nan != nan. eq/ne need a special-case because z3 leaves
+    # FPRef.__eq__/__ne__ as structural equality; the ordering operators are
+    # already overloaded to the IEEE fp predicates, so they need no special-case.
+    from crosshair.libimpl.builtinslib import apply_smt
+
+    def is_true(expr):
+        return z3.is_true(z3.simplify(expr))
+
+    def is_false(expr):
+        return z3.is_false(z3.simplify(expr))
+
+    sort = PreciseIeeeSymbolicFloat._ch_smt_sort()
+    pos_zero = z3.FPVal(0.0, sort)
+    neg_zero = z3.FPVal(-0.0, sort)
+    nan = z3.fpNaN(sort)
+    one = z3.FPVal(1.0, sort)
+    with standalone_statespace as space:
+        with NoTracing():
+            # equality treats +0.0 and -0.0 as equal, and nan as unequal to itself:
+            assert is_true(apply_smt(operator.eq, pos_zero, neg_zero))
+            assert is_false(apply_smt(operator.ne, pos_zero, neg_zero))
+            assert is_false(apply_smt(operator.eq, nan, nan))
+            assert is_true(apply_smt(operator.ne, nan, nan))
+            # ordered comparisons: +0.0 and -0.0 compare equal, nan is unordered:
+            assert is_true(apply_smt(operator.le, pos_zero, neg_zero))
+            assert is_true(apply_smt(operator.ge, pos_zero, neg_zero))
+            assert is_false(apply_smt(operator.lt, pos_zero, neg_zero))
+            assert is_false(apply_smt(operator.gt, pos_zero, neg_zero))
+            for op in (operator.le, operator.ge, operator.lt, operator.gt):
+                assert is_false(apply_smt(op, nan, nan))
+                assert is_false(apply_smt(op, nan, one))
+
+
 @pytest.mark.demo
 def test_int___sub___method():
     def f(a: int) -> int:

--- a/crosshair/statespace.py
+++ b/crosshair/statespace.py
@@ -1023,11 +1023,48 @@ class StateSpace:
         ]
         if culprit is not None:
             details.append(f"culprit_add={culprit}")
-        message = "Unexpected unsat from solver (" + "; ".join(details) + ")"
+        message = (
+            "Unexpected unsat from solver ("
+            + "; ".join(details)
+            + ")\n"
+            + self._realization_unsat_debug()
+        )
         if in_debug():
             debug(message)
-            debug("  full solver state:", self.solver.sexpr())
         raise CrossHairInternal(message)
+
+    def _realization_unsat_debug(self) -> str:
+        """Diagnose an unexpected realization-time unsat: report whether a
+        fresh, identically-configured solver agrees the current assertions are
+        unsat (and, if so, the minimal contradicting subset), which
+        distinguishes a genuine contradiction in the accumulated constraints
+        from a corrupted incremental-solver state."""
+        lines: List[str] = []
+        try:
+            assertions = list(self.solver.assertions())
+        except Exception as exc:
+            return f"  (could not read solver assertions: {exc!r})"
+        lines.append(f"  assertion count: {len(assertions)}")
+        try:
+            fresh = make_default_solver()
+            fresh.set(unsat_core=True)
+            by_name: Dict[str, z3.ExprRef] = {}
+            for i, assertion in enumerate(assertions):
+                lit = z3.Bool(f"__ch_track_{i}")
+                by_name[lit.decl().name()] = assertion
+                fresh.assert_and_track(assertion, lit)
+            result = fresh.check()
+            lines.append(f"  fresh same-config solver.check(): {result}")
+            if result == z3.unsat:
+                lines.append("  minimal unsat core:")
+                for lit in fresh.unsat_core():
+                    lines.append(f"    {by_name.get(lit.decl().name(), lit)}")
+        except Exception as exc:
+            lines.append(f"  (fresh-solver diagnosis failed: {exc!r})")
+        lines.append("  assertions:")
+        for assertion in assertions:
+            lines.append(f"    {assertion}")
+        return "\n".join(lines)
 
     def find_model_value(self, expr: z3.ExprRef, choice_conformity=1.0) -> Any:
         with NoTracing():

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -14,6 +14,10 @@ Next Version
    zeros), which could also trip an "Unexpected unsat" error while reporting the
    result. Float ``==``/``!=`` now use IEEE equality; ordered comparisons were
    already correct.
+ * When the solver unexpectedly reports ``unsat`` while realizing a symbolic (an
+   internal ``CrossHairInternal`` error), include the minimal contradicting
+   subset of the path's constraints in the error message, to make such issues
+   easier to diagnose.
  * Run the ``bytes`` and ``bytearray`` search/match methods symbolically instead
    of realizing the whole value first. ``find``, ``rfind``, ``index``, ``rindex``,
    ``count``, ``replace``, ``startswith``, ``endswith``, ``removeprefix``, and

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,6 +6,14 @@ Changelog
 Next Version
 ---------------
 
+ * Fix symbolic floats treating ``0.0`` and ``-0.0`` as unequal (and ``nan`` as
+   equal to itself). Equality on the IEEE float representation used z3's structural
+   comparison rather than IEEE equality, so e.g. ``0 == -0.0`` could evaluate to
+   ``False``. This surfaced as an unsound counterexample for
+   ``st.lists(st.sampled_from([0, 0.0]), unique=True, min_size=1)`` (two "distinct"
+   zeros), which could also trip an "Unexpected unsat" error while reporting the
+   result. Float ``==``/``!=`` now use IEEE equality; ordered comparisons were
+   already correct.
  * Run the ``bytes`` and ``bytearray`` search/match methods symbolically instead
    of realizing the whole value first. ``find``, ``rfind``, ``index``, ``rindex``,
    ``count``, ``replace``, ``startswith``, ``endswith``, ``removeprefix``, and


### PR DESCRIPTION
Investigative branch: combines the IEEE float-equality fix (#470) with the unsat-core/fresh-solver diagnostics (#473) to capture the assertion dump for test_issue_2247_regression *with* the fix applied. Not for merge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)