### PR TITLE
Catch tokenize.TokenError in get_directives

### DIFF
--- a/crosshair/codeconfig.py
+++ b/crosshair/codeconfig.py
@@ -25,13 +25,18 @@ def get_directives(source_text: str) -> Iterable[Tuple[int, int, str]]:
     """
     ret = []
     tokens = tokenize.generate_tokens(StringIO(source_text).readline)
-    # TODO catch tokenize.TokenError ... just in case?
-    for toktyp, tokval, begin, _, _ in tokens:
-        linenum, colnum = begin
-        if toktyp == tokenize.COMMENT:
-            directive = _COMMENT_TOKEN_RE.sub(r"\1", tokval)
-            if tokval != directive:
-                ret.append((linenum, colnum, directive))
+    try:
+        for toktyp, tokval, begin, _, _ in tokens:
+            linenum, colnum = begin
+            if toktyp == tokenize.COMMENT:
+                directive = _COMMENT_TOKEN_RE.sub(r"\1", tokval)
+                if tokval != directive:
+                    ret.append((linenum, colnum, directive))
+    except tokenize.TokenError:
+        # The source text is incomplete or malformed (e.g. an unterminated
+        # multi-line string). Just return the directives we found before
+        # tokenization broke down.
+        pass
     return ret
 
 

--- a/crosshair/codeconfig_test.py
+++ b/crosshair/codeconfig_test.py
@@ -94,6 +94,14 @@ def test_get_directives_multiline_string() -> None:
     assert list(get_directives(foo)) == []
 
 
+def test_get_directives_unterminated_string() -> None:
+    # Malformed/incomplete source (e.g. a file being edited) can cause tokenize to
+    # raise a TokenError; we should recover gracefully rather than crash, returning
+    # any directives found before tokenization broke down.
+    source = '# crosshair: off\nx = """unterminated'
+    assert get_directives(source) == [(1, 0, "off")]
+
+
 def test_collection_options() -> None:
     this_module = sys.modules[__name__]
     assert collect_options(this_module) == AnalysisOptionSet(enabled=False)


### PR DESCRIPTION
## Summary

Resolves a TODO in `crosshair/codeconfig.py`: `get_directives` tokenizes source text to find `# crosshair: ...` directive comments, but didn't handle `tokenize.TokenError`, which `tokenize.generate_tokens` raises for malformed/incomplete source (e.g. an unterminated multi-line string). This could crash directive collection instead of degrading gracefully.

- Wrap the tokenization loop in `get_directives` with `try/except tokenize.TokenError`, returning whatever directives were found before tokenization broke down.

## Test plan

- Added `test_get_directives_unterminated_string`, confirming directives found before an unterminated triple-quoted string are still returned instead of raising.
- Ran `pytest crosshair/codeconfig_test.py` — all 9 tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_011RdKyc1tx5s7eKresSikbt)_