### PR TITLE
Fix patch invalidation when imported_alternative restores modules

### DIFF
--- a/crosshair/libimpl/heapqlib_test.py
+++ b/crosshair/libimpl/heapqlib_test.py
@@ -2,16 +2,10 @@ import heapq
 import sys
 from typing import List
 
-import pytest
-
 from crosshair.core import proxy_for_type
 from crosshair.tracers import ResumedTracing
 
 
-# TODO https://github.com/pschanely/CrossHair/issues/298
-@pytest.mark.skip(
-    reason="heapq get reloaded somehow in parallel ci run, ruining the intercepts",
-)
 def test_heapify(space):
     items = proxy_for_type(List[int], "items")
 

--- a/crosshair/util.py
+++ b/crosshair/util.py
@@ -373,13 +373,23 @@ def imported_alternative(name: str, suppress: Tuple[str, ...] = ()):
     """Load an alternative version of a module with some modules suppressed."""
     modules = sys.modules
     orig_module = importlib.import_module(name)  # Ensure the regular version is loaded
+    # Save the original suppressed modules so we can restore the *same* module
+    # objects afterwards. If we instead deleted them and let the final reload
+    # re-import them, C extension modules would be re-initialized with brand-new
+    # function objects, invalidating any patches registered against the originals
+    # (see https://github.com/pschanely/CrossHair/issues/298).
+    _MISSING = object()
+    saved = {k: modules.get(k, _MISSING) for k in suppress}
     modules.update({k: None for k in suppress})  # type: ignore
     alternative = importlib.reload(orig_module)
     try:
         yield
     finally:
-        for k in suppress:
-            del modules[k]
+        for k, orig in saved.items():
+            if orig is _MISSING:
+                del modules[k]
+            else:
+                modules[k] = orig
         importlib.reload(alternative)
 
 

--- a/crosshair/util.py
+++ b/crosshair/util.py
@@ -389,7 +389,7 @@ def imported_alternative(name: str, suppress: Tuple[str, ...] = ()):
             if orig is _MISSING:
                 del modules[k]
             else:
-                modules[k] = orig
+                modules[k] = orig  # type: ignore
         importlib.reload(alternative)
 
 


### PR DESCRIPTION
imported_alternative suppressed modules by setting them to None in
sys.modules and deleting them afterwards, letting the final reload
re-import them. For C extension modules (e.g. _heapq) this minted
brand-new function objects, so patches registered against the original
C builtins no longer matched at call time and interception silently
broke. This surfaced in parallel CI runs whenever a test that reloads
heapq ran in the same worker before heapqlib_test.test_heapify.

Save and restore the original suppressed module objects instead, so
function identities are preserved and existing patches keep matching.
Un-skips test_heapify.

Refs: https://github.com/pschanely/CrossHair/issues/298

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ASXNUcpNNiccjaBVn9bjEx