### PR TITLE
Run bytes/bytearray ASCII case+whitespace transforms symbolically

### DIFF
--- a/crosshair/core.py
+++ b/crosshair/core.py
@@ -197,6 +197,7 @@ def suspected_proxy_intolerance_exception(exc_value: Exception) -> bool:
     if (
         atomic_symbolic
         or "SymbolicStr" in exc_str
+        or "SymbolicBytes" in exc_str
         or "__hash__ method should return an integer" in exc_str
         or "expected string or bytes-like object" in exc_str
     ):

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -4026,6 +4026,63 @@ class BytesLike(Buffer, AbcString, CrossHairValue):
             return [operand]
         return self._ch_operand_points(operand)
 
+    # ---- ASCII case / whitespace transforms ------------------------------
+    # Unlike str (whose case mapping needs the full Unicode tables, via
+    # UnicodeMaskCache), bytes/bytearray only case-map ASCII: A-Z (0x41-0x5A)
+    # <-> a-z (0x61-0x7A).  So these stay symbolic with plain byte arithmetic,
+    # overriding AbcString's realizing ``self.data.<op>()`` versions and
+    # building the result through the _ch_make hook (bytes -> bytes,
+    # bytearray -> bytearray).
+    def _ch_swap_ascii_case(self, byte, do_lower, do_upper):
+        if do_lower and 0x41 <= byte <= 0x5A:
+            return byte + 0x20
+        if do_upper and 0x61 <= byte <= 0x7A:
+            return byte - 0x20
+        return byte
+
+    def lower(self):
+        return self._ch_make(
+            [self._ch_swap_ascii_case(b, True, False) for b in self._ch_codepoints]
+        )
+
+    def upper(self):
+        return self._ch_make(
+            [self._ch_swap_ascii_case(b, False, True) for b in self._ch_codepoints]
+        )
+
+    def swapcase(self):
+        return self._ch_make(
+            [self._ch_swap_ascii_case(b, True, True) for b in self._ch_codepoints]
+        )
+
+    def _ch_strip_targets(self, chars):
+        # None means "ASCII whitespace"; otherwise chars must be a bytes-like
+        # object (a plain int is rejected, matching CPython bytes.strip).
+        return None if chars is None else self._ch_operand_points(chars)
+
+    def _ch_is_stripped(self, byte, targets):
+        if targets is None:
+            return is_ascii_space_ord(byte)
+        return any(byte == t for t in targets)
+
+    def lstrip(self, chars=None):
+        targets = self._ch_strip_targets(chars)
+        for idx, byte in enumerate(self._ch_codepoints):
+            if not self._ch_is_stripped(byte, targets):
+                return self[idx:]
+        return self[:0]
+
+    def rstrip(self, chars=None):
+        targets = self._ch_strip_targets(chars)
+        if len(self) == 0:
+            return self[:0]
+        if self._ch_is_stripped(self[-1], targets):
+            return self[:-1].rstrip(chars)
+        return self._ch_make(self._ch_codepoints)
+
+    def strip(self, chars=None):
+        return self.lstrip(chars).rstrip(chars)
+
     if version_info >= (3, 12):
 
         def __buffer__(self, flags: int):

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -4034,11 +4034,19 @@ class BytesLike(Buffer, AbcString, CrossHairValue):
     # building the result through the _ch_make hook (bytes -> bytes,
     # bytearray -> bytearray).
     def _ch_swap_ascii_case(self, byte, do_lower, do_upper):
-        if do_lower and 0x41 <= byte <= 0x5A:
-            return byte + 0x20
-        if do_upper and 0x61 <= byte <= 0x7A:
-            return byte - 0x20
-        return byte
+        # Branch-free per byte (see AGENTS.md: avoid forking the state space).
+        # An if/elif on the symbolic byte would fork on *every* character, so
+        # instead fold the case shift into one SMT expression: ``&`` (not the
+        # short-circuiting ``and``) keeps it a single symbolic bool, and
+        # ``0x20 * <bool>`` turns it into the 0/+-0x20 delta with no branch.
+        # (``do_lower``/``do_upper`` are concrete per-op flags, so branching on
+        # them is a normal Python choice, not a state-space fork.)
+        delta = 0
+        if do_lower:
+            delta = delta + 0x20 * ((0x41 <= byte) & (byte <= 0x5A))
+        if do_upper:
+            delta = delta - 0x20 * ((0x61 <= byte) & (byte <= 0x7A))
+        return byte + delta
 
     def lower(self):
         return self._ch_make(

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -1195,6 +1195,70 @@ def test_symbolic_bytearray_count_inverts():
     check_states(f, POST_FAIL)
 
 
+def test_symbolic_bytes_lower_inverts():
+    # bytes/bytearray case + whitespace transforms now run symbolically (ASCII
+    # only -- no UnicodeMaskCache), instead of realizing the whole value, so
+    # CrossHair can invert them.
+    def f(a: bytes) -> bytes:
+        """
+        pre: len(a) == 2
+        post: _ != b'hi'
+        """
+        return a.lower()
+
+    check_states(f, POST_FAIL)
+
+
+def test_symbolic_bytes_strip_inverts():
+    def f(a: bytes) -> bytes:
+        """
+        pre: len(a) == 4
+        post: _ != b'ab'
+        """
+        return a.strip()
+
+    check_states(f, POST_FAIL)
+
+
+def test_symbolic_bytearray_swapcase_inverts():
+    def f(a: bytearray) -> bytearray:
+        """
+        pre: len(a) == 2
+        post: _ != bytearray(b'aB')
+        """
+        return a.swapcase()
+
+    check_states(f, POST_FAIL)
+
+
+def test_bytes_transforms_match_cpython(space):
+    # The symbolic transforms must agree with CPython (ASCII-only case mapping;
+    # whitespace = {\\t \\n \\v \\f \\r space}).  Pin a symbolic 3-byte value and
+    # compare each op against the realized concrete result.
+    for idx, raw in enumerate((b"Ab \t", b"xYz", b"\x00A z", b"   ", b"")):
+        sym = proxy_for_type(bytes, f"s{idx}")  # fresh name: don't pile
+        with ResumedTracing():                  # contradictory constraints on one space
+            space.add(len(sym) == len(raw))
+            for i, byte in enumerate(raw):
+                space.add(sym[i] == byte)
+            assert realize(sym.lower()) == raw.lower()
+            assert realize(sym.upper()) == raw.upper()
+            assert realize(sym.swapcase()) == raw.swapcase()
+            assert realize(sym.strip()) == raw.strip()
+            assert realize(sym.lstrip()) == raw.lstrip()
+            assert realize(sym.rstrip()) == raw.rstrip()
+            assert realize(sym.strip(b"ab")) == raw.strip(b"ab")
+
+
+def test_bytes_strip_rejects_int_chars(space):
+    # Unlike the search family, strip does NOT accept an int -- chars must be a
+    # bytes-like object (matching CPython bytes.strip).
+    b = proxy_for_type(bytes, "b")
+    with ResumedTracing():
+        with pytest.raises(TypeError):
+            b.strip(0)
+
+
 def test_bytes_search_accepts_int_byte_value(space):
     # bytes/bytearray find/index/count accept a single int byte value (unlike
     # startswith/replace); an out-of-range int is a ValueError.

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -1237,7 +1237,7 @@ def test_bytes_transforms_match_cpython(space):
     # compare each op against the realized concrete result.
     for idx, raw in enumerate((b"Ab \t", b"xYz", b"\x00A z", b"   ", b"")):
         sym = proxy_for_type(bytes, f"s{idx}")  # fresh name: don't pile
-        with ResumedTracing():                  # contradictory constraints on one space
+        with ResumedTracing():  # contradictory constraints on one space
             space.add(len(sym) == len(raw))
             for i, byte in enumerate(raw):
                 space.add(sym[i] == byte)

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -20,6 +20,13 @@ Next Version
    ``bytes`` -- so CrossHair could only fuzz them, never solve for an input. These
    now share the same symbolic codepoint algorithms as ``str``, so e.g.
    ``a.find(b'xy') == 2`` is solvable for a symbolic ``bytes``.
+ * Run the ``bytes`` and ``bytearray`` ASCII case and whitespace transforms
+   symbolically instead of realizing the whole value first. ``lower``, ``upper``,
+   ``swapcase``, ``strip``, ``lstrip``, and ``rstrip`` previously materialized the
+   symbolic value to concrete ``bytes``, so CrossHair could only fuzz them. Because
+   ``bytes`` case mapping is ASCII-only (unlike ``str``, which needs the full
+   Unicode tables), these stay symbolic with plain byte arithmetic, so e.g.
+   ``a.lower() == b'hi'`` is now solvable for a symbolic ``bytes``.
 
 
 Version 0.0.108


### PR DESCRIPTION
lower/upper/swapcase/strip/lstrip/rstrip on symbolic bytes and bytearray
previously fell through to AbcString's realizing self.data.<op>() path,
materializing the whole symbolic value to concrete bytes -- so CrossHair
could only fuzz them, never solve backward for an input. str overrides
these with symbolic versions (via the Unicode case tables); bytes did not.

Since bytes case mapping is ASCII-only (A-Z <-> a-z), these stay symbolic
with plain byte arithmetic over the shared _ch_codepoints/_ch_make hooks,
no UnicodeMaskCache needed -- so e.g. a.lower() == b'hi' is now solvable.

Also teach suspected_proxy_intolerance_exception to recognize SymbolicBytes:
a concrete bytes/bytearray C method rejecting a symbolic-bytes argument
raises TypeError mentioning SymbolicBytes, which was not detected as proxy
intolerance. The support-map measurement then misread the swallowed result
as an unsound "unsat" and graded such cells black; recognizing it grades
them red (unsupported) instead.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FtV853GPM3eU1iXdTmNjnX