### PR TITLE
Faster symbolic indexing into some concrete sequences

### DIFF
--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -422,28 +422,6 @@ def test_int_eq_ieee_negative_zero():
             assert not (neg_zero != zero_int)
 
 
-def test_int_eq_ieee_nan():
-    # An int never equals nan, in either operand order.
-    with standalone_statespace as space:
-        with NoTracing():
-            space.extra(ModelingDirector).global_representations[
-                float
-            ] = PreciseIeeeSymbolicFloat
-            some_int = SymbolicInt("some_int")
-            nan = PreciseIeeeSymbolicFloat(
-                z3.fpNaN(PreciseIeeeSymbolicFloat._ch_smt_sort())
-            )
-        with ResumedTracing():
-            # The comparisons hold for any int, but z3 answers "unknown" (not sat)
-            # when asked for a model of Not(fpEQ(fpToFP(ToReal(x)), NaN)) with x
-            # unconstrained, so constrain x to keep the queries decidable:
-            space.add(some_int == 3)
-            assert not (some_int == nan)
-            assert some_int != nan
-            assert not (nan == some_int)
-            assert nan != some_int
-
-
 def test_apply_smt_ieee_equality():
     # apply_smt must implement IEEE (not z3's structural) equality on floats:
     # +0.0 == -0.0 and nan != nan. eq/ne need a special-case because z3 leaves

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -417,6 +417,28 @@ def test_int_eq_ieee_negative_zero():
             space.add(zero_int == 0)
             assert zero_int == neg_zero
             assert not (zero_int != neg_zero)
+            # ... and the reflected operand order:
+            assert neg_zero == zero_int
+            assert not (neg_zero != zero_int)
+
+
+def test_int_eq_ieee_nan():
+    # An int never equals nan, in either operand order.
+    with standalone_statespace as space:
+        with NoTracing():
+            space.extra(ModelingDirector).global_representations[
+                float
+            ] = PreciseIeeeSymbolicFloat
+            some_int = SymbolicInt("some_int")
+            nan = PreciseIeeeSymbolicFloat(
+                z3.fpNaN(PreciseIeeeSymbolicFloat._ch_smt_sort())
+            )
+        with ResumedTracing():
+            space.add(some_int == 3)
+            assert not (some_int == nan)
+            assert some_int != nan
+            assert not (nan == some_int)
+            assert nan != some_int
 
 
 def test_apply_smt_ieee_equality():

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -434,6 +434,9 @@ def test_int_eq_ieee_nan():
                 z3.fpNaN(PreciseIeeeSymbolicFloat._ch_smt_sort())
             )
         with ResumedTracing():
+            # The comparisons hold for any int, but z3 answers "unknown" (not sat)
+            # when asked for a model of Not(fpEQ(fpToFP(ToReal(x)), NaN)) with x
+            # unconstrained, so constrain x to keep the queries decidable:
             space.add(some_int == 3)
             assert not (some_int == nan)
             assert some_int != nan

--- a/crosshair/opcode_intercept.py
+++ b/crosshair/opcode_intercept.py
@@ -75,27 +75,26 @@ _DEEPLY_CONCRETE_KEY_TYPES = (
 
 
 @assert_tracing(False)
-def index_sign_reachability(key: AtomicSymbolicValue) -> Tuple[bool, bool]:
-    """Return whether the key can be negative / non-negative on the current path."""
-    minimum = getattr(key, "_ch_minimum", None)
-    maximum = getattr(key, "_ch_maximum", None)
-    if minimum is not None and minimum >= 0:
-        return (False, True)
-    if maximum is not None and maximum < 0:
-        return (True, False)
-    try:
-        with ResumedTracing():
-            key_is_negative = key < 0
-    except TypeError:
-        return (True, True)
-    if isinstance(key_is_negative, SymbolicBool):
-        space = context_statespace()
-        if not space.is_possible(key_is_negative.var):
-            return (False, True)
-        return (True, space.is_possible(z3Not(key_is_negative.var)))
-    if isinstance(key_is_negative, bool):
-        return (key_is_negative, not key_is_negative)
-    return (True, True)
+def reachable_sequence_pairs(
+    key: AtomicSymbolicValue, container: Union[list, tuple]
+) -> List[Tuple[int, Any]]:
+    """The (index, value) pairs a symbolic key can reach in a concrete sequence.
+
+    A sequence element is reachable by both its non-negative and its negative
+    index, so a symbolic key may match either; the sign half the key provably
+    cannot reach is omitted. Non-negative indices come first.
+    """
+    space = context_statespace()
+    length = len(container)
+    with ResumedTracing():
+        neg_reachable = space.is_possible(key < 0)
+        nonneg_reachable = (not neg_reachable) or space.is_possible(key >= 0)
+    pairs: List[Tuple[int, Any]] = []
+    if nonneg_reachable:
+        pairs += [(i, v) for i, v in enumerate(container)]
+    if neg_reachable:
+        pairs += [(i - length, v) for i, v in enumerate(container)]
+    return pairs
 
 
 class MultiSubscriptableContainer:
@@ -111,16 +110,7 @@ class MultiSubscriptableContainer:
             if isinstance(container, Mapping):
                 kv_pairs: Iterable[Tuple[Any, Any]] = container.items()
             else:
-                # A sequence element is reachable by both its non-negative index
-                # and its negative index, so a symbolic key may match either.
-                # Skip whichever half the key provably cannot reach.
-                length = len(container)
-                neg_reachable, nonneg_reachable = index_sign_reachability(key)
-                kv_pairs = []
-                if nonneg_reachable:
-                    kv_pairs += [(i, v) for i, v in enumerate(container)]
-                if neg_reachable:
-                    kv_pairs += [(i - length, v) for i, v in enumerate(container)]
+                kv_pairs = reachable_sequence_pairs(key, container)
 
             values_by_type = defaultdict(list)
             values_by_id = {}

--- a/crosshair/opcode_intercept.py
+++ b/crosshair/opcode_intercept.py
@@ -37,6 +37,7 @@ from crosshair.util import (
     CROSSHAIR_EXTRA_ASSERTS,
     CrossHairInternal,
     CrossHairValue,
+    assert_tracing,
     debug,
 )
 from crosshair.z3util import z3Not, z3Or
@@ -73,6 +74,30 @@ _DEEPLY_CONCRETE_KEY_TYPES = (
 )
 
 
+@assert_tracing(False)
+def index_sign_reachability(key: AtomicSymbolicValue) -> Tuple[bool, bool]:
+    """Return whether the key can be negative / non-negative on the current path."""
+    minimum = getattr(key, "_ch_minimum", None)
+    maximum = getattr(key, "_ch_maximum", None)
+    if minimum is not None and minimum >= 0:
+        return (False, True)
+    if maximum is not None and maximum < 0:
+        return (True, False)
+    try:
+        with ResumedTracing():
+            key_is_negative = key < 0
+    except TypeError:
+        return (True, True)
+    if isinstance(key_is_negative, SymbolicBool):
+        space = context_statespace()
+        if not space.is_possible(key_is_negative.var):
+            return (False, True)
+        return (True, space.is_possible(z3Not(key_is_negative.var)))
+    if isinstance(key_is_negative, bool):
+        return (key_is_negative, not key_is_negative)
+    return (True, True)
+
+
 class MultiSubscriptableContainer:
     """Used for indexing a symbolic (non-slice) key into a concrete container"""
 
@@ -87,10 +112,15 @@ class MultiSubscriptableContainer:
                 kv_pairs: Iterable[Tuple[Any, Any]] = container.items()
             else:
                 # A sequence element is reachable by both its non-negative index
-                # and its negative index, so a symbolic key must match either.
+                # and its negative index, so a symbolic key may match either.
+                # Skip whichever half the key provably cannot reach.
                 length = len(container)
-                kv_pairs = [(i, v) for i, v in enumerate(container)]
-                kv_pairs += [(i - length, v) for i, v in enumerate(container)]
+                neg_reachable, nonneg_reachable = index_sign_reachability(key)
+                kv_pairs = []
+                if nonneg_reachable:
+                    kv_pairs += [(i, v) for i, v in enumerate(container)]
+                if neg_reachable:
+                    kv_pairs += [(i - length, v) for i, v in enumerate(container)]
 
             values_by_type = defaultdict(list)
             values_by_id = {}

--- a/crosshair/opcode_intercept_test.py
+++ b/crosshair/opcode_intercept_test.py
@@ -11,9 +11,11 @@ from crosshair.libimpl.builtinslib import (
     ModelingDirector,
     RealBasedSymbolicFloat,
     SymbolicBool,
+    SymbolicBoundedInt,
     SymbolicInt,
     SymbolicType,
 )
+from crosshair.opcode_intercept import index_sign_reachability
 from crosshair.statespace import POST_FAIL
 from crosshair.test_util import check_states
 from crosshair.tracers import ResumedTracing
@@ -41,6 +43,50 @@ def test_sequence_symbolic_index_finds_negative():
         return a[i] != -5
 
     check_states(f, POST_FAIL)
+
+
+def test_index_sign_reachability_unconstrained(space):
+    idx = proxy_for_type(int, "idx")
+    assert index_sign_reachability(idx) == (True, True)
+
+
+def test_index_sign_reachability_nonnegative(space):
+    idx = proxy_for_type(int, "idx")
+    with ResumedTracing():
+        space.add(idx >= 0)
+    assert index_sign_reachability(idx) == (False, True)
+
+
+def test_index_sign_reachability_negative(space):
+    idx = proxy_for_type(int, "idx")
+    with ResumedTracing():
+        space.add(idx < 0)
+    assert index_sign_reachability(idx) == (True, False)
+
+
+def test_index_sign_reachability_tracked_bounds(space):
+    nonneg = SymbolicBoundedInt("nonneg", int, 0, 5)
+    assert index_sign_reachability(nonneg) == (False, True)
+    neg = SymbolicBoundedInt("neg", int, -5, -1)
+    assert index_sign_reachability(neg) == (True, False)
+
+
+def test_index_sign_reachability_bool_key(space):
+    b = proxy_for_type(bool, "b")
+    assert index_sign_reachability(b) == (False, True)
+
+
+def test_sequence_subscript_with_negative_only_key(space):
+    a = (5, -5, -2)
+    i = proxy_for_type(int, "i")
+    with ResumedTracing():
+        space.add(i < 0)
+        space.add(i >= -3)
+        result = a[i]
+        assert space.is_possible(result == 5)
+        assert space.is_possible(result == -2)
+        space.add(i == -1)
+        assert not space.is_possible(result == 5)
 
 
 def test_dict_index():

--- a/crosshair/opcode_intercept_test.py
+++ b/crosshair/opcode_intercept_test.py
@@ -15,7 +15,7 @@ from crosshair.libimpl.builtinslib import (
     SymbolicInt,
     SymbolicType,
 )
-from crosshair.opcode_intercept import index_sign_reachability
+from crosshair.opcode_intercept import reachable_sequence_pairs
 from crosshair.statespace import POST_FAIL
 from crosshair.test_util import check_states
 from crosshair.tracers import ResumedTracing
@@ -45,35 +45,45 @@ def test_sequence_symbolic_index_finds_negative():
     check_states(f, POST_FAIL)
 
 
-def test_index_sign_reachability_unconstrained(space):
+def _reachable_indices(key):
+    return [i for i, _ in reachable_sequence_pairs(key, ("a", "b", "c"))]
+
+
+def test_reachable_pairs_unconstrained(space):
     idx = proxy_for_type(int, "idx")
-    assert index_sign_reachability(idx) == (True, True)
+    assert _reachable_indices(idx) == [0, 1, 2, -3, -2, -1]
 
 
-def test_index_sign_reachability_nonnegative(space):
+def test_reachable_pairs_nonnegative(space):
     idx = proxy_for_type(int, "idx")
     with ResumedTracing():
         space.add(idx >= 0)
-    assert index_sign_reachability(idx) == (False, True)
+    assert reachable_sequence_pairs(idx, ("a", "b", "c")) == [
+        (0, "a"),
+        (1, "b"),
+        (2, "c"),
+    ]
 
 
-def test_index_sign_reachability_negative(space):
+def test_reachable_pairs_negative(space):
     idx = proxy_for_type(int, "idx")
     with ResumedTracing():
         space.add(idx < 0)
-    assert index_sign_reachability(idx) == (True, False)
+    assert reachable_sequence_pairs(idx, ("a", "b", "c")) == [
+        (-3, "a"),
+        (-2, "b"),
+        (-1, "c"),
+    ]
 
 
-def test_index_sign_reachability_tracked_bounds(space):
-    nonneg = SymbolicBoundedInt("nonneg", int, 0, 5)
-    assert index_sign_reachability(nonneg) == (False, True)
-    neg = SymbolicBoundedInt("neg", int, -5, -1)
-    assert index_sign_reachability(neg) == (True, False)
+def test_reachable_pairs_tracked_bounds(space):
+    assert _reachable_indices(SymbolicBoundedInt("nonneg", int, 0, 5)) == [0, 1, 2]
+    assert _reachable_indices(SymbolicBoundedInt("neg", int, -5, -1)) == [-3, -2, -1]
 
 
-def test_index_sign_reachability_bool_key(space):
+def test_reachable_pairs_bool_key(space):
     b = proxy_for_type(bool, "b")
-    assert index_sign_reachability(b) == (False, True)
+    assert _reachable_indices(b) == [0, 1, 2]
 
 
 def test_sequence_subscript_with_negative_only_key(space):

--- a/crosshair/statespace.py
+++ b/crosshair/statespace.py
@@ -879,6 +879,8 @@ class StateSpace:
         with NoTracing():
             if hasattr(expr, "var"):
                 expr = expr.var
+            if isinstance(expr, bool):
+                return expr
             debug("is possible?", expr)
         return solver_is_sat(self.solver, expr)
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -13,6 +13,12 @@ Next Version
    ``st.lists(st.sampled_from([0, 0.0]), unique=True, min_size=1)`` (two "distinct"
    zeros), which could also trip an "Unexpected unsat" error while reporting the
    result.
+ * Speed up symbolic subscripts of concrete sequences. Version 0.0.108 added
+   negative-index support by including both the non-negative and negative index
+   of every element in the generated disjunction, roughly doubling solve costs
+   on subscript-heavy workloads. The index's sign is now checked first, and only
+   the reachable half is included (indexes constrained to ``0 <= i < len(seq)``
+   generate half as many disjuncts).
  * Run the ``bytes`` and ``bytearray`` search/match methods symbolically instead
    of realizing the whole value first. ``find``, ``rfind``, ``index``, ``rindex``,
    ``count``, ``replace``, ``startswith``, ``endswith``, ``removeprefix``, and

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,10 +15,11 @@ Next Version
    result.
  * Speed up symbolic subscripts of concrete sequences. Version 0.0.108 added
    negative-index support by including both the non-negative and negative index
-   of every element in the generated disjunction, roughly doubling solve costs
-   on subscript-heavy workloads. The index's sign is now checked first, and only
-   the reachable half is included (indexes constrained to ``0 <= i < len(seq)``
-   generate half as many disjuncts).
+   of every element when indexing with a symbolic key. When the index's sign is
+   known (e.g. constrained to ``0 <= i < len(seq)``), only the reachable half is
+   now generated. This roughly halves the solver cost of indexing into a
+   concrete table of numbers or strings; indexing sequences of other objects
+   sees a smaller improvement.
  * Run the ``bytes`` and ``bytearray`` search/match methods symbolically instead
    of realizing the whole value first. ``find``, ``rfind``, ``index``, ``rindex``,
    ``count``, ``replace``, ``startswith``, ``endswith``, ``removeprefix``, and


### PR DESCRIPTION
While looking at follow-ups to #470, I stumbled across an upstream issue and opened https://github.com/Z3Prover/z3/issues/10162.

The remain patch is an additional test case, and some speedups to skip consideration of negative indices.