### PR TITLE
Subscript, contain-check, and index ranges symbolically

### DIFF
--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -2510,6 +2510,14 @@ class SymbolicRange:
                             raise ValueError
                 self.start, self.stop, self.step = a, b, c
 
+    @classmethod
+    def _from_concrete_range(cls, concrete: range) -> "SymbolicRange":
+        ret = cls.__new__(cls)
+        ret.start = concrete.start
+        ret.stop = concrete.stop
+        ret.step = concrete.step
+        return ret
+
     def __ch_realize__(self):
         start, stop, step = self.start, self.stop, self.step
         return range(realize(start), realize(stop), realize(step))
@@ -2519,7 +2527,62 @@ class SymbolicRange:
 
     def __getitem__(self, idx_or_slice):
         # TODO: compose ranges (Python does this; e.g. `range(10)[:5] == range(5)`)
-        return realize(self).__getitem__(idx_or_slice)
+        with NoTracing():
+            if isinstance(idx_or_slice, slice):
+                return realize(self).__getitem__(idx_or_slice)
+            i = idx_or_slice
+            if not isinstance(i, (int, SymbolicIntable)):
+                index_method = getattr(type(i), "__index__", None)
+                if index_method is None:
+                    raise TypeError(
+                        "range indices must be integers or slices, not "
+                        + name_of_type(type(i))
+                    )
+                with ResumedTracing():
+                    i = index_method(i)
+        length = self.__len__()
+        i = i + (i < 0) * length
+        if any([i < 0, i >= length]):
+            raise IndexError("range object index out of range")
+        return self.start + self.step * i
+
+    def __contains__(self, value):
+        with NoTracing():
+            value_is_int = type(value) in (int, bool) or isinstance(
+                value, SymbolicIntable
+            )
+        if not value_is_int:
+            return any([item == value for item in self])
+        start, stop, step = self.start, self.stop, self.step
+        if step > 0:
+            return all([start <= value, value < stop, (value - start) % step == 0])
+        else:
+            return all([stop < value, value <= start, (value - start) % step == 0])
+
+    def count(self, value):
+        with NoTracing():
+            value_is_int = type(value) in (int, bool) or isinstance(
+                value, SymbolicIntable
+            )
+        if value_is_int:
+            return self.__contains__(value).__int__()
+        return sum([item == value for item in self])
+
+    def index(self, value):
+        with NoTracing():
+            value_is_int = type(value) in (int, bool) or isinstance(
+                value, SymbolicIntable
+            )
+        if value_is_int:
+            if value in self:
+                return (value - self.start) // self.step
+        else:
+            idx = 0
+            for item in self:
+                if item == value:
+                    return idx
+                idx += 1
+        raise ValueError("value is not in range")
 
     def __iter__(self):
         start, stop, step = self.start, self.stop, self.step
@@ -5042,6 +5105,38 @@ def _range(*a):
     return SymbolicRange(*a)
 
 
+def _range_contains(self, value):
+    with NoTracing():
+        if not isinstance(self, range):
+            raise TypeError
+        symbolic_self = SymbolicRange._from_concrete_range(self)
+    return symbolic_self.__contains__(value)
+
+
+def _range_getitem(self, idx_or_slice):
+    with NoTracing():
+        if not isinstance(self, range):
+            raise TypeError
+        symbolic_self = SymbolicRange._from_concrete_range(self)
+    return symbolic_self[idx_or_slice]
+
+
+def _range_count(self, value):
+    with NoTracing():
+        if not isinstance(self, range):
+            raise TypeError
+        symbolic_self = SymbolicRange._from_concrete_range(self)
+    return symbolic_self.count(value)
+
+
+def _range_index(self, value):
+    with NoTracing():
+        if not isinstance(self, range):
+            raise TypeError
+        symbolic_self = SymbolicRange._from_concrete_range(self)
+    return symbolic_self.index(value)
+
+
 def _repr(obj: object) -> str:
     """
     post[]: True
@@ -5518,6 +5613,12 @@ def make_registrations():
     # TODO: dict.update (concrete w/ symbolic argument), __getitem__, & more?
     register_patch(dict.get, _dict_get)
     register_patch(dict.values, with_checked_self(dict, "values"))
+
+    # Patches on range
+    register_patch(range.__contains__, _range_contains)
+    register_patch(range.__getitem__, _range_getitem)
+    register_patch(range.count, _range_count)
+    register_patch(range.index, _range_index)
 
     # Patches on set/frozenset
     register_patch(set.__repr__, _set_repr)

--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -2511,11 +2511,13 @@ class SymbolicRange:
                 self.start, self.stop, self.step = a, b, c
 
     @classmethod
-    def _from_concrete_range(cls, concrete: range) -> "SymbolicRange":
+    def _ch_create_from_literal(cls, val: object) -> Optional["SymbolicRange"]:
+        if not isinstance(val, range):
+            return None
         ret = cls.__new__(cls)
-        ret.start = concrete.start
-        ret.stop = concrete.stop
-        ret.step = concrete.step
+        ret.start = val.start
+        ret.stop = val.stop
+        ret.step = val.step
         return ret
 
     def __ch_realize__(self):
@@ -2547,11 +2549,7 @@ class SymbolicRange:
         return self.start + self.step * i
 
     def __contains__(self, value):
-        with NoTracing():
-            value_is_int = type(value) in (int, bool) or isinstance(
-                value, SymbolicIntable
-            )
-        if not value_is_int:
+        if not isinstance(value, int):
             return any([item == value for item in self])
         start, stop, step = self.start, self.stop, self.step
         if step > 0:
@@ -2560,20 +2558,12 @@ class SymbolicRange:
             return all([stop < value, value <= start, (value - start) % step == 0])
 
     def count(self, value):
-        with NoTracing():
-            value_is_int = type(value) in (int, bool) or isinstance(
-                value, SymbolicIntable
-            )
-        if value_is_int:
+        if isinstance(value, int):
             return self.__contains__(value).__int__()
         return sum([item == value for item in self])
 
     def index(self, value):
-        with NoTracing():
-            value_is_int = type(value) in (int, bool) or isinstance(
-                value, SymbolicIntable
-            )
-        if value_is_int:
+        if isinstance(value, int):
             if value in self:
                 return (value - self.start) // self.step
         else:
@@ -5105,38 +5095,6 @@ def _range(*a):
     return SymbolicRange(*a)
 
 
-def _range_contains(self, value):
-    with NoTracing():
-        if not isinstance(self, range):
-            raise TypeError
-        symbolic_self = SymbolicRange._from_concrete_range(self)
-    return symbolic_self.__contains__(value)
-
-
-def _range_getitem(self, idx_or_slice):
-    with NoTracing():
-        if not isinstance(self, range):
-            raise TypeError
-        symbolic_self = SymbolicRange._from_concrete_range(self)
-    return symbolic_self[idx_or_slice]
-
-
-def _range_count(self, value):
-    with NoTracing():
-        if not isinstance(self, range):
-            raise TypeError
-        symbolic_self = SymbolicRange._from_concrete_range(self)
-    return symbolic_self.count(value)
-
-
-def _range_index(self, value):
-    with NoTracing():
-        if not isinstance(self, range):
-            raise TypeError
-        symbolic_self = SymbolicRange._from_concrete_range(self)
-    return symbolic_self.index(value)
-
-
 def _repr(obj: object) -> str:
     """
     post[]: True
@@ -5615,10 +5573,14 @@ def make_registrations():
     register_patch(dict.values, with_checked_self(dict, "values"))
 
     # Patches on range
-    register_patch(range.__contains__, _range_contains)
-    register_patch(range.__getitem__, _range_getitem)
-    register_patch(range.count, _range_count)
-    register_patch(range.index, _range_index)
+    register_patch(
+        range.__contains__, with_symbolic_self(SymbolicRange, range.__contains__)
+    )
+    register_patch(
+        range.__getitem__, with_symbolic_self(SymbolicRange, range.__getitem__)
+    )
+    register_patch(range.count, with_symbolic_self(SymbolicRange, range.count))
+    register_patch(range.index, with_symbolic_self(SymbolicRange, range.index))
 
     # Patches on set/frozenset
     register_patch(set.__repr__, _set_repr)

--- a/crosshair/libimpl/builtinslib_ch_test.py
+++ b/crosshair/libimpl/builtinslib_ch_test.py
@@ -265,6 +265,34 @@ def check_range_reversed(start: int, stop: int, step: int) -> ResultComparison:
     )
 
 
+def check_range_getitem(start: int, stop: int, step: int, idx: int) -> ResultComparison:
+    """post: _"""
+    return compare_results(lambda a, o, e, i: range(a, o, e)[i], start, stop, step, idx)
+
+
+def check_range_contains(
+    start: int, stop: int, step: int, value: int
+) -> ResultComparison:
+    """post: _"""
+    return compare_results(
+        lambda a, o, e, v: v in range(a, o, e), start, stop, step, value
+    )
+
+
+def check_range_index(start: int, stop: int, step: int, value: int) -> ResultComparison:
+    """post: _"""
+    return compare_results(
+        lambda a, o, e, v: range(a, o, e).index(v), start, stop, step, value
+    )
+
+
+def check_range_count(start: int, stop: int, step: int, value: int) -> ResultComparison:
+    """post: _"""
+    return compare_results(
+        lambda a, o, e, v: range(a, o, e).count(v), start, stop, step, value
+    )
+
+
 def check_reversed(obj: Union[List[int], Tuple[int]]) -> ResultComparison:
     """post: _"""
     return compare_results(lambda o: list(reversed(o)), obj)

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -2079,6 +2079,119 @@ def test_range_realization(space) -> None:
         assert hash(realized_range) == hash(rng)
 
 
+def test_concrete_range_getitem_symbolic_index(space):
+    rng = range(3, 103, 2)
+    i = proxy_for_type(int, "i")
+    with ResumedTracing():
+        space.add(i >= 0)
+        space.add(i < 50)
+        x = rng[i]
+    assert isinstance(x, SymbolicInt)
+    with ResumedTracing():
+        assert space.is_possible(x == 3)
+        assert space.is_possible(x == 101)
+        assert not space.is_possible(x == 4)
+        assert not space.is_possible(x == 103)
+
+
+def test_concrete_range_getitem_symbolic_negative_index(space):
+    rng = range(3, 103, 2)
+    i = proxy_for_type(int, "i")
+    with ResumedTracing():
+        space.add(i == -1)
+        x = rng[i]
+        assert space.is_possible(x == 101)
+        assert not space.is_possible(x != 101)
+
+
+def test_concrete_range_getitem_symbolic_index_out_of_bounds(space):
+    rng = range(50)
+    i = proxy_for_type(int, "i")
+    with ResumedTracing():
+        space.add(i >= 50)
+        with pytest.raises(IndexError):
+            rng[i]
+
+
+def test_concrete_range_contains_symbolic_value(space):
+    rng = range(4, 100, 3)
+    x = proxy_for_type(int, "x")
+    with ResumedTracing():
+        result = rng.__contains__(x)
+    assert isinstance(result, SymbolicBool)
+    with ResumedTracing():
+        space.add(result)
+        assert space.is_possible(x == 7)
+        assert space.is_possible(x == 97)
+        assert not space.is_possible(x == 8)
+        assert not space.is_possible(x == 1)
+        assert not space.is_possible(x == 100)
+
+
+def test_concrete_range_contains_op_symbolic_value(space):
+    rng = range(4, 100, 3)
+    x = proxy_for_type(int, "x")
+    y = proxy_for_type(int, "y")
+    with ResumedTracing():
+        space.add(x == 7)
+        space.add(y == 8)
+        assert x in rng
+        assert y not in rng
+
+
+def test_concrete_range_count_symbolic_value(space):
+    rng = range(4, 100, 3)
+    x = proxy_for_type(int, "x")
+    with ResumedTracing():
+        ct = rng.count(x)
+    assert isinstance(ct, SymbolicInt)
+    with ResumedTracing():
+        assert space.is_possible((ct == 1) & (x == 7))
+        assert not space.is_possible((ct == 1) & (x == 8))
+        assert space.is_possible((ct == 0) & (x == 8))
+
+
+def test_concrete_range_index_symbolic_value(space):
+    rng = range(4, 100, 3)
+    x = proxy_for_type(int, "x")
+    with ResumedTracing():
+        space.add(x == 10)
+        idx = rng.index(x)
+        assert space.is_possible(idx == 2)
+        assert not space.is_possible(idx != 2)
+
+
+def test_concrete_range_index_symbolic_value_not_found(space):
+    rng = range(4, 100, 3)
+    x = proxy_for_type(int, "x")
+    with ResumedTracing():
+        space.add(x == 9)
+        with pytest.raises(ValueError):
+            rng.index(x)
+
+
+def test_symbolic_range_getitem_stays_symbolic(space):
+    rng = proxy_for_type(range, "rng")
+    with ResumedTracing():
+        space.add(rng.start == 3)
+        space.add(rng.stop == 40)
+        space.add(rng.step == 2)
+        x = rng[4]
+        assert space.is_possible(x == 11)
+        assert not space.is_possible(x != 11)
+
+
+def test_range_getitem_symbolic_index_ch() -> None:
+    def f(i: int) -> int:
+        """
+        pre: 0 <= i < 25
+        post: _ != 42
+        """
+        return range(0, 100, 2)[i]
+
+    check_states(f, POST_FAIL)
+
+
 @pytest.mark.demo
 def test_list___contains___method() -> None:
     def f(a: int, b: List[int]) -> bool:

--- a/crosshair/opcode_intercept.py
+++ b/crosshair/opcode_intercept.py
@@ -21,6 +21,7 @@ from crosshair.libimpl.builtinslib import (
     SymbolicBool,
     SymbolicInt,
     SymbolicList,
+    SymbolicRange,
     python_types_using_atomic_symbolics,
 )
 from crosshair.simplestructs import LinearSet, ShellMutableSet, SimpleDict, SliceView
@@ -232,6 +233,8 @@ class SymbolicSubscriptInterceptor(TracingModule):
         ):
             wrapped_container = MultiSubscriptableContainer(container)
             frame_stack_write(frame, -2, wrapped_container)
+        elif isinstance(key, AtomicSymbolicValue) and container_type is range:
+            frame_stack_write(frame, -2, SymbolicRange._from_concrete_range(container))
         elif container_type is dict:
             # SimpleDict won't hash the keys it's given!
             wrapped_dict = SimpleDict(list(container.items()))
@@ -371,6 +374,8 @@ class ContainmentInterceptor(TracingModule):
             new_container = ShellMutableSet(LinearSet(container))
         elif containertype is dict:
             new_container = SimpleDict(list(container.items()))
+        elif containertype is range:
+            new_container = SymbolicRange._from_concrete_range(container)
 
         if new_container is not None:
             frame_stack_write(frame, -1, new_container)

--- a/crosshair/opcode_intercept.py
+++ b/crosshair/opcode_intercept.py
@@ -234,7 +234,9 @@ class SymbolicSubscriptInterceptor(TracingModule):
             wrapped_container = MultiSubscriptableContainer(container)
             frame_stack_write(frame, -2, wrapped_container)
         elif isinstance(key, AtomicSymbolicValue) and container_type is range:
-            frame_stack_write(frame, -2, SymbolicRange._from_concrete_range(container))
+            frame_stack_write(
+                frame, -2, SymbolicRange._ch_create_from_literal(container)
+            )
         elif container_type is dict:
             # SimpleDict won't hash the keys it's given!
             wrapped_dict = SimpleDict(list(container.items()))
@@ -375,7 +377,7 @@ class ContainmentInterceptor(TracingModule):
         elif containertype is dict:
             new_container = SimpleDict(list(container.items()))
         elif containertype is range:
-            new_container = SymbolicRange._from_concrete_range(container)
+            new_container = SymbolicRange._ch_create_from_literal(container)
 
         if new_container is not None:
             frame_stack_write(frame, -1, new_container)

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,6 +6,16 @@ Changelog
 Next Version
 ---------------
 
+ * Run subscripting, ``in``, and ``.index()`` on ``range`` objects symbolically
+   when given a symbolic argument. ``range(50)[i]`` with a symbolic ``i``
+   previously realized ``i`` (a solver query per subscript, and the result was
+   pinned to a single concrete value); it now returns the symbolic
+   ``start + step * i`` as an O(1) constraint. Likewise ``x in range(...)`` and
+   ``range(...).index(x)`` now use closed-form bounds-and-divisibility
+   constraints instead of realizing or iterating. This applies both to concrete
+   ``range`` objects (a hot path for ``hypothesis`` users via
+   ``st.sampled_from(range(...))``) and to symbolic ranges with a non-slice
+   index.
  * Fix symbolic ``bytes.fromhex``/``bytearray.fromhex`` rejecting uppercase hex
    digits (``A``-``F``) as "non-hexadecimal", where concrete Python accepts them.
    This also made ``urllib.parse.unquote`` unusable symbolically (it builds a

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,10 +6,10 @@ Changelog
 Next Version
 ---------------
 
- * Run subscripting, ``in``, and ``.index()`` on ``range`` objects symbolically
-   when given a symbolic argument. ``range(50)[i]`` with a symbolic ``i``
-   previously realized ``i`` (a solver query per subscript, and the result was
-   pinned to a single concrete value); it now returns the symbolic
+ * Run subscripting, ``in``, ``.index()``, and ``.count()`` on ``range`` objects
+   symbolically when given a symbolic argument. ``range(50)[i]`` with a symbolic
+   ``i`` previously realized ``i`` (a solver query per subscript, and the result
+   was pinned to a single concrete value); it now returns the symbolic
    ``start + step * i`` as an O(1) constraint. Likewise ``x in range(...)`` and
    ``range(...).index(x)`` now use closed-form bounds-and-divisibility
    constraints instead of realizing or iterating. This applies both to concrete


### PR DESCRIPTION
Subscripting a concrete range with a symbolic int previously realized the index, pinning the element to a concrete value and forcing a solver query per subscript. `SymbolicRange.__getitem__` likewise realized the whole range for non-slice indexes.

This is a hot path for hypothesis-crosshair users via `st.sampled_from(range(...))`: with `sets(sampled_from(range(n)), min_size=n)`, the range pool now performs on par with (slightly better than) the equivalent tuple pool instead of realizing every draw, and properties over the drawn elements remain solvable.

(should be complementary to https://github.com/pschanely/CrossHair/pull/482 and https://github.com/HypothesisWorks/hypothesis/pull/4802; this is the last of my current set of perf improvements)