### PR TITLE
Raise IndexError/KeyError for out-of-range symbolic subscripts

### DIFF
--- a/crosshair/fuzz_core_test.py
+++ b/crosshair/fuzz_core_test.py
@@ -43,7 +43,6 @@ KNOWN_FAILURES = {
     "int.to_bytes": "[3.11+] symbolic int.to_bytes ignores its now-optional args -> TypeError",
     "bool.to_bytes": "[3.11+] symbolic bool.to_bytes ignores its now-optional args -> TypeError",
     "str.__format__": "format(symbolic_str) diverges from concrete",
-    "tuple.__getitem__": "symbolic tuple[i] wraps the index modulo len instead of raising IndexError",
     "float.__floordiv__": "symbolic float // float returns an int instead of a float",
     "float.__divmod__": "symbolic divmod(float, float) returns an int quotient instead of a float",
     "float.__mod__": "symbolic float % float diverges from concrete on extreme values",

--- a/crosshair/opcode_intercept.py
+++ b/crosshair/opcode_intercept.py
@@ -40,7 +40,7 @@ from crosshair.util import (
     assert_tracing,
     debug,
 )
-from crosshair.z3util import z3Not, z3Or
+from crosshair.z3util import z3And, z3Not, z3Or
 
 BINARY_SUBSCR = dis.opmap.get("BINARY_SUBSCR", 256)
 BINARY_SLICE = dis.opmap.get("BINARY_SLICE", 256)
@@ -107,6 +107,7 @@ class MultiSubscriptableContainer:
         with NoTracing():
             space = context_statespace()
             container = self.container
+            is_mapping = isinstance(container, Mapping)
             if isinstance(container, Mapping):
                 kv_pairs: Iterable[Tuple[Any, Any]] = container.items()
             else:
@@ -136,18 +137,25 @@ class MultiSubscriptableContainer:
                 # No symbolics cover this value, but we might still find repeated values:
                 values_by_id[id(cur_value)] = cur_value
                 keys_by_value_id[id(cur_value)].append(cur_key)
+
+            # Each option is a (key-match guard, result) pair; the key is in bounds
+            # iff one guard holds.  A symbolic key that matches no entry is out of
+            # range (e.g. a negative index past -len, or a missing dict key), so we
+            # fork that possibility and raise -- returning a value there would let an
+            # out-of-range index read an element instead of raising.
+            options: List[Tuple[ExprRef, object]] = []
             for value_type, cur_pairs in values_by_type.items():
                 hypothetical_result = symbolic_for_pytype(value_type)(
                     "item_" + space.uniq(), value_type
                 )
+                match_terms = []
                 with ResumedTracing():
-                    condition_pairs = []
                     for cur_key, cur_val in cur_pairs:
                         keys_equal = key == cur_key
                         values_equal = hypothetical_result == cur_val
                         with NoTracing():
                             if isinstance(keys_equal, SymbolicBool):
-                                condition_pairs.append((keys_equal, values_equal))
+                                match_terms.append((keys_equal, values_equal))
                             elif keys_equal is False:
                                 pass
                             else:
@@ -155,26 +163,34 @@ class MultiSubscriptableContainer:
                                 raise CrossHairInternal(
                                     f"key comparison type: {type(keys_equal)} {keys_equal}"
                                 )
-                    if any(keys_equal for keys_equal, _ in condition_pairs):
-                        space.add(any([all(pair) for pair in condition_pairs]))
-                        return hypothetical_result
+                if match_terms:
+                    type_guard = z3Or(*[ke.var for ke, _ in match_terms])
+                    # When the key selects this group, pin the result to the value
+                    # at the matching key:
+                    space.add(
+                        z3Or(
+                            z3Not(type_guard),
+                            *[z3And(ke.var, ve.var) for ke, ve in match_terms],
+                        )
+                    )
+                    options.append((type_guard, hypothetical_result))
 
-            exprs_and_values: List[Tuple[ExprRef, object]] = []
             for value_id, value in values_by_id.items():
                 keys_for_value = keys_by_value_id[value_id]
                 with ResumedTracing():
                     is_match = any([key == k for k in keys_for_value])
                 if isinstance(is_match, SymbolicBool):
-                    exprs_and_values.append((is_match.var, value))
+                    options.append((is_match.var, value))
                 elif is_match:
                     return value
-            if exprs_and_values:
-                return space.smt_fanout(exprs_and_values, desc="multi_subscript")
 
-            if type(container) is dict:
-                raise KeyError  # ( f"Key {key} not found in dict")
-            else:
-                raise IndexError  # (f"Index {key} out of range for list/tuple of length {len(container)}")
+            raise_type = KeyError if is_mapping else IndexError
+            if not options:
+                raise raise_type
+            any_match = z3Or(*[guard for guard, _ in options])
+            if not space.smt_fork(any_match, desc="subscript_in_bounds"):
+                raise raise_type
+            return space.smt_fanout(options, desc="multi_subscript")
 
 
 class LoadCommonConstantInterceptor(TracingModule):

--- a/crosshair/opcode_intercept.py
+++ b/crosshair/opcode_intercept.py
@@ -7,7 +7,7 @@ from sys import version_info
 from types import CodeType, FrameType
 from typing import Any, Callable, Iterable, List, Mapping, Tuple, Union
 
-from z3 import ExprRef  # type: ignore
+from z3 import ExprRef, If  # type: ignore
 
 from crosshair.core import (
     ATOMIC_IMMUTABLE_TYPES,
@@ -40,7 +40,7 @@ from crosshair.util import (
     assert_tracing,
     debug,
 )
-from crosshair.z3util import z3And, z3Not, z3Or
+from crosshair.z3util import z3Not, z3Or
 
 BINARY_SUBSCR = dis.opmap.get("BINARY_SUBSCR", 256)
 BINARY_SLICE = dis.opmap.get("BINARY_SLICE", 256)
@@ -145,17 +145,19 @@ class MultiSubscriptableContainer:
             # out-of-range index read an element instead of raising.
             options: List[Tuple[ExprRef, object]] = []
             for value_type, cur_pairs in values_by_type.items():
-                hypothetical_result = symbolic_for_pytype(value_type)(
-                    "item_" + space.uniq(), value_type
-                )
-                match_terms = []
+                ch_type = symbolic_for_pytype(value_type)
+                conds_and_values = []
                 with ResumedTracing():
                     for cur_key, cur_val in cur_pairs:
                         keys_equal = key == cur_key
-                        values_equal = hypothetical_result == cur_val
                         with NoTracing():
                             if isinstance(keys_equal, SymbolicBool):
-                                match_terms.append((keys_equal, values_equal))
+                                conds_and_values.append(
+                                    (
+                                        keys_equal.var,
+                                        ch_type._smt_promote_literal(cur_val),
+                                    )
+                                )
                             elif keys_equal is False:
                                 pass
                             else:
@@ -163,17 +165,18 @@ class MultiSubscriptableContainer:
                                 raise CrossHairInternal(
                                     f"key comparison type: {type(keys_equal)} {keys_equal}"
                                 )
-                if match_terms:
-                    type_guard = z3Or(*[ke.var for ke, _ in match_terms])
-                    # When the key selects this group, pin the result to the value
-                    # at the matching key:
-                    space.add(
-                        z3Or(
-                            z3Not(type_guard),
-                            *[z3And(ke.var, ve.var) for ke, ve in match_terms],
-                        )
-                    )
-                    options.append((type_guard, hypothetical_result))
+                if conds_and_values:
+                    type_guard = z3Or(*[cond for cond, _ in conds_and_values])
+                    # Select the matching element with an ITE chain (linear for the
+                    # solver, unlike a flat disjunction) and wrap it directly, so
+                    # nothing lingers on the path's assertion stack.  The chain's
+                    # final else is reached only when type_guard holds and every
+                    # earlier arm is false -- i.e. the last key matches -- so its
+                    # value is the correct default.
+                    smt_result = conds_and_values[-1][1]
+                    for cond, smt_val in reversed(conds_and_values[:-1]):
+                        smt_result = If(cond, smt_val, smt_result)
+                    options.append((type_guard, ch_type(smt_result, value_type)))
 
             for value_id, value in values_by_id.items():
                 keys_for_value = keys_by_value_id[value_id]

--- a/crosshair/opcode_intercept.py
+++ b/crosshair/opcode_intercept.py
@@ -24,7 +24,7 @@ from crosshair.libimpl.builtinslib import (
     python_types_using_atomic_symbolics,
 )
 from crosshair.simplestructs import LinearSet, ShellMutableSet, SimpleDict, SliceView
-from crosshair.statespace import context_statespace
+from crosshair.statespace import NONE_OF_THE_ABOVE, context_statespace
 from crosshair.tracers import (
     COMPOSITE_TRACER,
     NoTracing,
@@ -190,10 +190,14 @@ class MultiSubscriptableContainer:
             raise_type = KeyError if is_mapping else IndexError
             if not options:
                 raise raise_type
-            any_match = z3Or(*[guard for guard, _ in options])
-            if not space.smt_fork(any_match, desc="subscript_in_bounds"):
+            # A symbolic key that matches no entry is out of range; smt_fanout
+            # gives that case its own weighted branch and returns the sentinel.
+            result = space.smt_fanout(
+                options, desc="multi_subscript", none_of_the_above_weight=1.0
+            )
+            if result is NONE_OF_THE_ABOVE:
                 raise raise_type
-            return space.smt_fanout(options, desc="multi_subscript")
+            return result
 
 
 class LoadCommonConstantInterceptor(TracingModule):

--- a/crosshair/opcode_intercept_test.py
+++ b/crosshair/opcode_intercept_test.py
@@ -16,7 +16,7 @@ from crosshair.libimpl.builtinslib import (
     SymbolicType,
 )
 from crosshair.opcode_intercept import reachable_sequence_pairs
-from crosshair.statespace import POST_FAIL
+from crosshair.statespace import POST_FAIL, MessageType
 from crosshair.test_util import check_states
 from crosshair.tracers import ResumedTracing
 from crosshair.z3util import z3And
@@ -97,6 +97,37 @@ def test_sequence_subscript_with_negative_only_key(space):
         assert space.is_possible(result == -2)
         space.add(i == -1)
         assert not space.is_possible(result == 5)
+
+
+def test_sequence_subscript_out_of_range_negative_raises(space):
+    a = (2, 0, 5)
+    i = proxy_for_type(int, "i")
+    with ResumedTracing():
+        space.add(i == -4)
+        with pytest.raises(IndexError):
+            a[i]
+
+
+def test_sequence_subscript_out_of_range_positive_raises(space):
+    a = (2, 0, 5)
+    i = proxy_for_type(int, "i")
+    with ResumedTracing():
+        space.add(i == 3)
+        with pytest.raises(IndexError):
+            a[i]
+
+
+def test_sequence_subscript_out_of_range_is_reachable():
+    a = (2, 0, 5)
+
+    def f(i: int) -> int:
+        """
+        pre: i < 4
+        post: True
+        """
+        return a[i]
+
+    check_states(f, MessageType.EXEC_ERR)
 
 
 def test_dict_index():

--- a/crosshair/statespace.py
+++ b/crosshair/statespace.py
@@ -152,6 +152,10 @@ class CallAnalysis:
 HeapRef = z3.DeclareSort("HeapRef")
 SnapshotRef = NewType("SnapshotRef", int)
 
+# Returned by StateSpace.smt_fanout on the branch where no supplied expression
+# holds (only reachable when called with none_of_the_above_weight > 0).
+NONE_OF_THE_ABOVE = object()
+
 _PREVENT_FORKS = contextvars.ContextVar("in_no_fork", default=False)
 if CROSSHAIR_EXTRA_ASSERTS:
 
@@ -1181,9 +1185,19 @@ class StateSpace:
         weights: Optional[Sequence[float]] = None,
         none_of_the_above_weight: float = 0.0,
     ):
-        """Performs a weighted binary search over the given SMT expressions."""
+        """Performs a weighted binary search over the given SMT expressions.
+
+        With ``none_of_the_above_weight > 0`` the expressions need not be
+        exhaustive: the remaining case (no expression holds) becomes a weighted
+        branch that returns ``NONE_OF_THE_ABOVE``.
+        """
         exprs = [e for (e, _) in exprs_and_results]
-        final_weights = [1.0] * len(exprs) if weights is None else weights
+        results = [r for (_, r) in exprs_and_results]
+        final_weights = list([1.0] * len(exprs) if weights is None else weights)
+        if none_of_the_above_weight > 0:
+            exprs = exprs + [z3Not(z3Or(*exprs))]
+            results = results + [NONE_OF_THE_ABOVE]
+            final_weights = final_weights + [none_of_the_above_weight]
         if CROSSHAIR_EXTRA_ASSERTS:
             if len(final_weights) != len(exprs):
                 raise CrossHairInternal("inconsistent smt_fanout exprs and weights")
@@ -1201,7 +1215,7 @@ class StateSpace:
         def attempt(start: int, end: int):
             size = end - start
             if size == 1:
-                return exprs_and_results[start][1]
+                return results[start]
             mid = (start + end) // 2
             left_exprs = exprs[start:mid]
             left_weight = sum(final_weights[start:mid])

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -13,6 +13,13 @@ Next Version
    element rather than raising. The out-of-range case is now an explicit,
    reachable path. The same correction applies to indexing a concrete ``dict``
    with a symbolic key that may be absent (now reachably raises ``KeyError``).
+ * Speed up symbolic subscripts of concrete sequences with primitive elements
+   (``int``/``str``/``float``/``bool``). The matching element is now selected with
+   an if-then-else chain wrapped directly around the result symbolic, instead of a
+   flat disjunction asserted onto the path. The disjunction scaled superlinearly
+   with the container size and lingered on the assertion stack to tax every later
+   solve on the path; the new encoding is roughly linear and adds no assertion, so
+   e.g. ``sampled_from`` over a large table is markedly cheaper.
  * Fix symbolic ``bytes.fromhex``/``bytearray.fromhex`` rejecting uppercase hex
    digits (``A``-``F``) as "non-hexadecimal", where concrete Python accepts them.
    This also made ``urllib.parse.unquote`` unusable symbolically (it builds a

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,6 +6,13 @@ Changelog
 Next Version
 ---------------
 
+ * Fix out-of-range symbolic subscripts of concrete sequences silently returning
+   an element instead of raising ``IndexError``. Indexing a concrete list or tuple
+   with a symbolic key forced the key into the set of valid indices, so an
+   out-of-range index (e.g. a negative one past ``-len``) could read a wrapped
+   element rather than raising. The out-of-range case is now an explicit,
+   reachable path. The same correction applies to indexing a concrete ``dict``
+   with a symbolic key that may be absent (now reachably raises ``KeyError``).
  * Fix symbolic floats treating ``0`` (integer) and ``-0.0`` (float) as unequal.
    Cross-type equality involving IEEE float representation used z3's structural
    comparison rather than IEEE equality, so e.g. ``0 == -0.0`` could evaluate to


### PR DESCRIPTION
Indexing a concrete list/tuple/dict with a symbolic key in
MultiSubscriptableContainer.__getitem__ forced the key into the set of
valid indices/keys and always returned a value. An out-of-range symbolic
index (e.g. a negative one past -len) was therefore normalized into range
and read a wrapped element instead of raising, and a possibly-absent dict
key never reached KeyError.

The two return paths caused this:
 - the values_by_type branch collapsed the intended symbolic disjunction
   via Python any()/all() over SymbolicBool (which fork rather than build
   an expression) and constrained the key into that group; and
 - smt_fanout assumes its guards are exhaustive, so with no matching guard
   it returned an arbitrary leaf value.

Collect all (key-match guard, result) options, then fork on whether any
guard holds: the no-match branch now raises IndexError (sequences) or
KeyError (mappings), and only the in-bounds branch fans out (so the guards
are exhaustive). This also fixes heterogeneous containers, where returning
the first matching type-group previously discarded keys of other types.

Removes the tuple.__getitem__ entry from fuzz_core_test KNOWN_FAILURES.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DEWUTDaNSZ4CDvbewAbg92