### PR TITLE
Bind inherited static/class method receivers by method kind

### DIFF
--- a/crosshair/condition_parser.py
+++ b/crosshair/condition_parser.py
@@ -486,8 +486,18 @@ class ConcreteConditionParser(ConditionParser):
             method = cls.__dict__.get(method_name, None)
             super_method_conditions = super_methods.get(method_name)
             if super_method_conditions is not None:
-                # Re-type the super's `self` argument to be this class:
-                revised_sig = set_first_arg_type(super_method_conditions.sig, cls)
+                # Re-type the super's receiver argument to be this class.
+                # A staticmethod has no receiver; its first argument is an
+                # ordinary parameter and is left alone.
+                descriptor = inspect.getattr_static(cls, method_name, None)
+                if isinstance(descriptor, staticmethod):
+                    revised_sig = super_method_conditions.sig
+                elif isinstance(descriptor, classmethod):
+                    revised_sig = set_first_arg_type(
+                        super_method_conditions.sig, Type[cls]
+                    )
+                else:
+                    revised_sig = set_first_arg_type(super_method_conditions.sig, cls)
                 super_method_conditions = replace(
                     super_method_conditions, sig=revised_sig
                 )

--- a/crosshair/condition_parser_test.py
+++ b/crosshair/condition_parser_test.py
@@ -1,7 +1,7 @@
 import inspect
 import json
 import sys
-from typing import List
+from typing import List, Type
 
 import pytest
 
@@ -111,6 +111,31 @@ class SubClassExample(BaseClassExample):
         return 5
 
 
+class ReceiverKindsExample:
+    def instance_method(self) -> int:
+        """post: True"""
+        return 1
+
+    @staticmethod
+    def static_method(n: int) -> bool:
+        """post: implies(n >= 0, _)"""
+        return n >= 0
+
+    @classmethod
+    def class_method(cls) -> str:
+        """post: len(_) >= 0"""
+        return cls.__name__
+
+    @staticmethod
+    def static_method_without_args() -> bool:
+        """post: _"""
+        return True
+
+
+class InheritsReceiverKinds(ReceiverKindsExample):
+    pass
+
+
 def test_parse_sections_variants() -> None:
     parsed = parse_sections([(1, " :post: True ")], ("post",), "")
     assert set(parsed.sections.keys()) == {"post"}
@@ -190,6 +215,22 @@ class TestPep316Parser:
         assert set([c.expr_source for c in method.pre]) == {"True"}
         assert len(method.post) == 2
         assert set([c.expr_source for c in method.post]) == {"True", "False"}
+
+    def test_inherited_receivers_are_rebound_by_kind(self) -> None:
+        methods = Pep316Parser().get_class_conditions(InheritsReceiverKinds).methods
+
+        def first_arg(method_name):
+            return list(methods[method_name].sig.parameters.values())[0]
+
+        assert first_arg("instance_method").annotation is InheritsReceiverKinds
+        assert first_arg("class_method").annotation == Type[InheritsReceiverKinds]
+        static_arg = first_arg("static_method")
+        assert static_arg.name == "n"
+        assert static_arg.annotation is int
+
+    def test_inherited_static_method_without_args(self) -> None:
+        methods = Pep316Parser().get_class_conditions(InheritsReceiverKinds).methods
+        assert list(methods["static_method_without_args"].sig.parameters) == []
 
     def test_invariant_applies_to_init(self) -> None:
         class_conditions = Pep316Parser().get_class_conditions(BaseClassExample)

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -52,6 +52,13 @@ Next Version
    ``bytes`` case mapping is ASCII-only (unlike ``str``, which needs the full
    Unicode tables), these stay symbolic with plain byte arithmetic, so e.g.
    ``a.lower() == b'hi'`` is now solvable for a symbolic ``bytes``.
+ * Fix analysis of ``@staticmethod`` and ``@classmethod`` contracts inherited by a
+   subclass that does not override them. Inherited methods have their receiver
+   re-typed to the subclass; that rewrite was applied regardless of method kind, so
+   a staticmethod's leading ordinary parameter was replaced (``snn(n: int)`` became
+   ``snn(n: Subclass)``) and a classmethod received an *instance* where it expected
+   the class. Both produced spurious ``EXEC_ERR`` results. An inherited staticmethod
+   taking no arguments raised ``IndexError`` outright.
 
 
 Version 0.0.108

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -126,3 +126,4 @@ In order of initial commit. Many thanks!
 * `Tony Dang <https://github.com/Dang-Hoang-Tung>`_
 * `Michael Schvarcz <https://github.com/michael-schvarcz>`_
 * `Antonin Peronnet <https://github.com/rambip>`_ (with help from Claude)
+* `Rahul Kuchhadia <https://github.com/rahul188>`_


### PR DESCRIPTION
Closes #451.

### Root cause

In `ConcreteConditionParser.get_class_conditions`, a method picked up from a base
class has its first argument re-typed to the class under analysis:

```python
# Re-type the super's `self` argument to be this class:
revised_sig = set_first_arg_type(super_method_conditions.sig, cls)
```

That is right for instance methods, but it ran for every method kind, and
`set_first_arg_type` just rewrites the annotation of parameter 0. Comparing the
signatures the parser produces for the issue's repro shows what happens:

| method | `Base` | `Concrete` (before) |
|---|---|---|
| `area` (instance) | `(self: Base)` | `(self: Concrete)` — correct |
| `lbl` (classmethod) | `(cls: Type[Base])` | `(cls: Concrete)` — lost `Type[...]` |
| `snn` (staticmethod) | `(n: int)` | `(n: Concrete)` — clobbered a real parameter |

So the staticmethod's own leading parameter was overwritten, and the classmethod
was handed an *instance* where it expected the class — hence
`snn(Concrete())` / `lbl(Concrete())` and the spurious `EXEC_ERR`s. The base class
analyzed fine because its methods come from `cls.__dict__` and never take this path.

A related crash falls out of the same line: an inherited staticmethod with no
parameters made `set_first_arg_type` index an empty list, raising
`IndexError: list index out of range` out of `analyze_class`.

### Fix

Branch on the descriptor kind (`inspect.getattr_static`) before rebinding:
classmethods get `Type[cls]`, staticmethods are left alone, instance methods keep
the existing behavior.

### Testing

The issue's repro now reports `CONFIRMED` for all four methods instead of two
`EXEC_ERR`s, and `Concrete`'s signatures mirror `Base`'s with the class substituted:

```
area: (self: Concrete) -> int
lbl:  (cls: Type[Concrete]) -> str
snn:  (n: int) -> bool
```

Added two tests to `condition_parser_test.py` asserting the first argument for each
of the three method kinds, and covering the zero-parameter inherited staticmethod.
Both fail on `main` (the second with the `IndexError`) and pass with the change.

`crosshair/{core,fnutil,condition_parser,main}_test.py`: 159 passed, 3 skipped.
Smoke suite: 13 passed. black, isort, and flake8 clean.

Changelog entry added under *Next Version*.
