### PR TITLE
Model read-only symbolic memoryviews

### DIFF
--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -5426,7 +5426,10 @@ def make_registrations():
     # Text: (elsewhere - identical to str)
     register_type(bytes, make_byte_string)
     register_type(bytearray, lambda p: SymbolicByteArray(p(bytes)))
-    register_type(memoryview, lambda p: SymbolicMemoryView(p(bytearray)))
+    register_type(
+        memoryview,
+        lambda p: SymbolicMemoryView(make_union_choice(p, bytes, bytearray)),
+    )
     # AnyStr,  (it's a type var)
 
     register_type(typing.BinaryIO, lambda p: io.BytesIO(p(bytes)))

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -4127,10 +4127,23 @@ def test_memoryview_toreadonly():
         mv = proxy_for_type(memoryview, "mv")
         space.add(mv.__len__() == 1)
         mv2 = mv.toreadonly()
-        mv[0] = 12
-        assert mv2[0] == 12
+        if not mv.readonly:
+            mv[0] = 12
+            assert mv2[0] == 12
         with pytest.raises(TypeError):
             mv2[0] = 24
+
+
+def test_memoryview_can_be_readonly():
+    def f(view: memoryview) -> None:
+        """
+        pre: len(view) > 0
+        post: True
+        """
+        view[0] = 0
+
+    actual, expected = check_exec_err(f, "TypeError")
+    assert actual == expected
 
 
 def test_memoryview_properties():

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 Next Version
 ---------------
 
+ * Model both writable and read-only symbolic ``memoryview`` values. Symbolic
+   memory views were always backed by a ``bytearray``, so ``readonly`` was always
+   false and writes could not raise the read-only ``TypeError`` produced by
+   ``memoryview(bytes(...))``.
  * Fix out-of-range symbolic subscripts of concrete sequences silently returning
    an element instead of raising ``IndexError``. Indexing a concrete list or tuple
    with a symbolic key forced the key into the set of valid indices, so an


### PR DESCRIPTION
## Summary

- I made symbolic `memoryview` inputs choose between `bytes` and `bytearray` backing so both read-only and writable views are reachable.
- I added regression coverage showing that writes to a generated read-only view raise `TypeError`.
- I updated the existing `toreadonly()` test and changelog for the new input model.

## Validation

- `PYTHONHASHSEED=0 python -m pytest -q crosshair/libimpl/builtinslib_test.py` (514 passed, 2 skipped)
- `PYTHONHASHSEED=0 python -m pytest -q crosshair/libimpl/builtinslib_ch_test.py -k 'memoryview or buffer_setitem'` (5 passed)
- `black --check crosshair/libimpl/builtinslib.py crosshair/libimpl/builtinslib_test.py`
- `isort --check-only crosshair/libimpl/builtinslib.py crosshair/libimpl/builtinslib_test.py`
- `flake8 crosshair/libimpl/builtinslib.py crosshair/libimpl/builtinslib_test.py`
- `python -m doctest doc/source/changelog.rst`
- `git diff --check`

The full cross-platform suite is left to CI.

Fixes #445
