### PR TITLE
Model read-only memoryviews

### DIFF
--- a/crosshair/libimpl/builtinslib.py
+++ b/crosshair/libimpl/builtinslib.py
@@ -4511,13 +4511,15 @@ class SymbolicMemoryView(BytesLike):
         sliced = self._sliced
         obj, start, stop = self.obj, sliced.start, sliced.stop
         self.obj = obj
-        return memoryview(realize(obj))[realize(start) : realize(stop)]
+        ret = memoryview(realize(obj))[realize(start) : realize(stop)]
+        return ret.toreadonly() if self.readonly else ret
 
     def __ch_deep_realize__(self, memo):
         sliced = self._sliced
         obj, start, stop = self.obj, sliced.start, sliced.stop
         self.obj = obj
-        return memoryview(deep_realize(obj, memo))[realize(start) : realize(stop)]
+        ret = memoryview(deep_realize(obj, memo))[realize(start) : realize(stop)]
+        return ret.toreadonly() if self.readonly else ret
 
     def __ch_pytype__(self):
         return memoryview
@@ -4551,14 +4553,14 @@ class SymbolicMemoryView(BytesLike):
     def __getitem__(self, key):
         if isinstance(key, slice):
             newslice = self._sliced[key]
-            if isinstance(newslice, SliceView):
-                with NoTracing():
+            with NoTracing():
+                if isinstance(newslice, SliceView):
                     ret = SymbolicMemoryView(self.obj)
                     ret._sliced = newslice
+                    ret.readonly = self.readonly
                     return ret
-            else:
-                # Give up when there's a step in the slice:
-                return realize(self).__getitem__(key)
+            # Give up when there's a step in the slice:
+            return realize(self).__getitem__(key)
         else:
             return self._sliced[key]
 
@@ -4593,6 +4595,12 @@ class SymbolicMemoryView(BytesLike):
 
     def cast(self, *a):
         return realize(self).cast(*map(realize, a))
+
+
+def make_memoryview(creator: SymbolicFactory) -> SymbolicMemoryView:
+    if creator.space.smt_fork(desc=f"{creator.varname}_readonly"):
+        return SymbolicMemoryView(creator(bytes))
+    return SymbolicMemoryView(creator(bytearray))
 
 
 _PYTYPE_TO_WRAPPER_TYPE = {
@@ -5426,7 +5434,7 @@ def make_registrations():
     # Text: (elsewhere - identical to str)
     register_type(bytes, make_byte_string)
     register_type(bytearray, lambda p: SymbolicByteArray(p(bytes)))
-    register_type(memoryview, lambda p: SymbolicMemoryView(p(bytearray)))
+    register_type(memoryview, make_memoryview)
     # AnyStr,  (it's a type var)
 
     register_type(typing.BinaryIO, lambda p: io.BytesIO(p(bytes)))

--- a/crosshair/libimpl/builtinslib_test.py
+++ b/crosshair/libimpl/builtinslib_test.py
@@ -4124,11 +4124,12 @@ def test_memoryview_cast():
 def test_memoryview_toreadonly():
     """post: _"""
     with standalone_statespace as space:
-        mv = proxy_for_type(memoryview, "mv")
+        mv = memoryview(proxy_for_type(bytearray, "mv"))
         space.add(mv.__len__() == 1)
         mv2 = mv.toreadonly()
         mv[0] = 12
         assert mv2[0] == 12
+        assert mv2[0:1].readonly
         with pytest.raises(TypeError):
             mv2[0] = 24
 
@@ -4138,7 +4139,7 @@ def test_memoryview_properties():
     with standalone_statespace as space:
         symbolic_mv = proxy_for_type(memoryview, "symbolic_mv")
         space.add(symbolic_mv.__len__() == 1)
-        concrete_mv = memoryview(bytearray(b"a"))
+        concrete_mv = memoryview(b"a" if symbolic_mv.readonly else bytearray(b"a"))
         assert symbolic_mv.contiguous == concrete_mv.contiguous
         assert symbolic_mv.c_contiguous == concrete_mv.c_contiguous
         assert symbolic_mv.f_contiguous == concrete_mv.f_contiguous
@@ -4150,6 +4151,31 @@ def test_memoryview_properties():
         assert symbolic_mv.shape == concrete_mv.shape
         assert symbolic_mv.strides == concrete_mv.strides
         assert symbolic_mv.suboffsets == concrete_mv.suboffsets
+
+
+def test_memoryview_readonly_write_raises():
+    with standalone_statespace as space:
+        mv = memoryview(proxy_for_type(bytes, "mv"))
+        space.add(mv.__len__() == 1)
+        assert mv.readonly
+        with pytest.raises(TypeError):
+            mv[0] = 12
+
+
+def test_proxied_memoryview_can_be_readonly():
+    def f(mv: memoryview) -> bool:
+        """post: not _"""
+        return mv.readonly
+
+    check_states(f, POST_FAIL)
+
+
+def test_proxied_memoryview_can_be_writable():
+    def f(mv: memoryview) -> bool:
+        """post: _"""
+        return mv.readonly
+
+    check_states(f, POST_FAIL)
 
 
 def test_chr(space):

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,6 +6,14 @@ Changelog
 Next Version
 ---------------
 
+ * Model read-only ``memoryview``\ s. A symbolic ``memoryview`` was always
+   backed by a mutable ``bytearray``, so its ``readonly`` flag was never
+   ``True`` and writes always succeeded — where a concrete
+   ``memoryview(b"...")`` raises ``TypeError``. Symbolic memoryviews now
+   choose between a ``bytes`` (read-only) and ``bytearray`` (writable)
+   backing. Slicing and realization also preserve the ``readonly`` flag
+   (previously a slice of a ``toreadonly()`` view was writable again), and
+   slices with a unit step now stay symbolic instead of realizing.
  * Fix out-of-range symbolic subscripts of concrete sequences silently returning
    an element instead of raising ``IndexError``. Indexing a concrete list or tuple
    with a symbolic key forced the key into the set of valid indices, so an


### PR DESCRIPTION
Fixes #445.

## The problem
`register_type(memoryview, ...)` always backed a symbolic memoryview with a mutable `SymbolicByteArray`, so `readonly` was never `True` and writes always succeeded — where a concrete `memoryview(b"...")` raises `TypeError`. The `__setitem__` guard was already correct; the flag just had no way to become `True` through `proxy_for_type`.

## The fix
- `proxy_for_type(memoryview)` now forks between a `bytes` (read-only) and `bytearray` (writable) backing (`make_memoryview`, following the `datetimelib` `smt_fork` registration pattern). `__init__`'s existing `isinstance(obj, bytes)` derivation does the rest under tracing.
- While testing the flag I found two adjacent leaks and fixed them too:
  - **Slicing dropped `readonly`** — and it turned out the symbolic slice branch in `__getitem__` was dead code: it checked `isinstance(newslice, SliceView)` under tracing, where `SliceView` reports its emulated type (`tuple`), so every unit-step slice silently took the `realize` path. The check now runs under `NoTracing`, and the new view inherits the parent's `readonly` (matching CPython, where a slice of a `toreadonly()` view stays read-only).
  - **Realization dropped `readonly`** — `__ch_realize__`/`__ch_deep_realize__` rebuilt from the backing object, so realizing a `toreadonly()` view over a bytearray produced a writable concrete view. Both now apply `.toreadonly()` when the symbolic view is read-only.

## Verification
- New `test_proxied_memoryview_can_be_readonly` (`post: not mv.readonly` → `POST_FAIL`) fails on `main` (CrossHair confirms the postcondition because no readonly view exists) and passes with the fix; `test_proxied_memoryview_can_be_writable` guards the other side of the fork.
- New slice assertion in `test_memoryview_toreadonly` fails on `main` (slice came back writable) and passes with the fix. Both failures were observed before applying the source change.
- `test_memoryview_toreadonly` now builds its view over an explicit `bytearray` proxy and `test_memoryview_properties` compares against a backing-matched concrete view, so both are deterministic under the new fork.
- Full suite (`CROSSHAIR_EXTRA_ASSERTS=1 PYTHONHASHSEED=0 pytest -n auto --dist worksteal crosshair`): 14193 passed; the handful of failures (demo_overrides encoding, datetime astimezone, one flaky decimal case) fail identically on unmodified `main` in this Windows environment.
- black / isort / flake8 / mypy: no new findings.