### PR TITLE
Unify typeshed signature lookup; widen the driven operation surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,12 @@ The repo ships a **devcontainer** (`.devcontainer/`) that matches CI (dev deps, 
 - **Pre-commit** runs black, isort, flake8, mypy, and pytest
 - **Type annotations**: Required for all non-test code. Generally avoid type annotations in tests.
 - **Naming**: Name functions and parameters by what they **do**, not by how they're used. Rename as function behaviors evolve.
-- **Doc strings**:  Drop anything that requires (or refers to) external context. Describe current behaviors only - no rationales.
+- **Doc strings**:  Drop anything that requires (or refers to) external context. Describe current behaviors only - no rationales. Must make sense when read by fresh eyes.
 - **Code comments**: Use a **very high bar** - very surpising or confusing behaviors only. Do not include historical context or litigate design decisions. **Never** explain decisions or changes in comments. (you can and should do this in PR descriptions however)
+
+## Development Philosophy
+
+- **No myopic fixes.** Ensure you understand a few layers of code above, below, and adjacent to any potential change. Actively **Seek out scope creep** in the name of proper design, streamlining, and clarity. Prioritize and propose tangential refactorings that could benefit your more immediate task.
 
 ## Must-Know Technical Background
 

--- a/crosshair/behavior_compare.py
+++ b/crosshair/behavior_compare.py
@@ -6,7 +6,10 @@ mutation), and compare two runs with symbolic-friendly equality.
 Used by CrossHair-on-CrossHair tests (``compare_results``/``compare_returns``),
 the ``diffbehavior`` command (``flexible_equal``), and the single-operation
 differential shared by ``fuzz_core_test`` and the support measurement
-(``run_differential``).
+(``run_differential`` over a ``CallSpec``).
+
+Nothing here reaches for ``crosshair.inputgen``, which needs hypothesis (a dev-only
+extra): a caller builds the ``CallSpec`` and supplies its inputs.
 """
 
 from collections.abc import Set as AbcSet
@@ -15,6 +18,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from time import process_time
 from typing import (
+    Any,
     Callable,
     Collection,
     Dict,
@@ -355,6 +359,40 @@ _DIFF_MAX_PIN_ITERS = 80
 _DIFF_PIN_TIMEOUT = 10.0
 
 
+@dataclass(frozen=True)
+class CallSpec:
+    """How to call one operation.
+
+    ``expr`` is eval-able source over ``arg_names`` (a method's receiver comes first
+    and is named ``a``).  It is source rather than a callable because operators MUST
+    be applied with operator syntax: ``list.__ge__(a, b)`` rejects a symbolic
+    receiver, where ``a >= b`` does not.
+
+    ``crosshair.inputgen.op_call``/``func_call`` build these, and
+    ``crosshair.inputgen.inputs_for`` generates argument tuples for one.
+    """
+
+    fn: Any  # the underlying callable, for signature-based input generation
+    expr: str
+    arg_names: Tuple[str, ...]
+    eval_globals: Mapping[str, Any]  # names ``expr`` needs beyond ``arg_names``
+    # How many typeshed arguments ``expr`` passes, NOT counting a method's
+    # synthesized receiver -- i.e. which overload shape this spec drives.  An op
+    # whose overloads differ in argument count needs one spec per shape (pow's 2-
+    # and 3-argument forms).
+    arity: int
+
+    def accepts(self, values: Sequence[Any]) -> bool:
+        """Whether an argument tuple fits this expression."""
+        return len(values) == len(self.arg_names)
+
+    def invoke(self, values: Sequence[Any]) -> Any:
+        """Evaluate the operation on one argument tuple."""
+        return eval(
+            self.expr, dict(self.eval_globals), dict(zip(self.arg_names, values))
+        )
+
+
 @dataclass
 class Divergence:
     args: tuple  # the concrete inputs that diverged
@@ -486,40 +524,28 @@ def run_symbolic_pinned(
 
 
 def run_differential(
-    fn: Callable,
-    expr: str,
-    arg_names: Sequence[str],
-    eval_globals: Mapping[str, object],
-    k: int = 3,
-    seed: int = 0,
+    call: CallSpec,
+    inputs: Sequence[Sequence[object]],
     max_pin_iters: int = _DIFF_MAX_PIN_ITERS,
-    seedkey: Optional[str] = None,
 ) -> DiffResult:
-    """Drive one operation on up to ``k`` valid inputs, comparing a symbolic run
-    (args pinned to the input) against a concrete run.  Returns a ``DiffResult``
-    with the count of inputs actually driven and the first ``Divergence`` (or
-    None if all matched).  ``max_pin_iters`` bounds the per-input pin search; use
-    a small value when speed matters more than pinning every container shape (an
-    input that can't pin in budget is simply skipped).  ``seedkey`` is the op's
-    catalog identity, forwarded to ``valid_inputs`` so a CUSTOM_INPUTS override
-    (e.g. aliased ``x is x``) applies.
+    """Drive one operation on each of ``inputs``, comparing a symbolic run (args
+    pinned to the input) against a concrete run.  Returns a ``DiffResult`` with the
+    count of inputs actually driven and the first ``Divergence`` (or None if all
+    matched).  ``max_pin_iters`` bounds the per-input pin search; use a small value
+    when speed matters more than pinning every container shape (an input that can't
+    pin in budget is simply skipped).
 
-    ``expr`` is eval'd over ``arg_names`` (plus ``eval_globals``); see
-    ``crosshair.inputgen.op_call``/``func_call`` for building these."""
-    from crosshair.inputgen import valid_inputs
+    Generate ``inputs`` with ``crosshair.inputgen.inputs_for(call)``, which fits
+    them to ``call``'s overload shape."""
+    arg_names = call.arg_names
 
     def applier(*vs):
-        return eval(expr, dict(eval_globals), dict(zip(arg_names, vs)))
+        return call.invoke(vs)
 
-    inputs = [
-        t
-        for t in valid_inputs(fn, k=k, seed=seed, seedkey=seedkey)
-        if len(t) == len(arg_names)
-    ]
     checked = 0
     unsupported = 0
     for vals in inputs:
-        debug("differential:", expr, "with", vals)
+        debug("differential:", call.expr, "with", vals)
         symbolic = run_symbolic_pinned(applier, arg_names, vals, max_pin_iters)
         if symbolic is _UNPINNED:
             continue

--- a/crosshair/core_regestered_types_test.py
+++ b/crosshair/core_regestered_types_test.py
@@ -19,12 +19,7 @@ import typing_inspect  # type: ignore
 from crosshair.core import _SIMPLE_PROXIES, proxy_for_type
 from crosshair.dynamic_typing import origin_of
 from crosshair.tracers import ResumedTracing
-from crosshair.util import (
-    CrosshairUnsupported,
-    IgnoreAttempt,
-    debug,
-    name_of_type,
-)
+from crosshair.util import CrosshairUnsupported, IgnoreAttempt, debug, name_of_type
 
 """
 Tests that the builtin and standard library types behave like their

--- a/crosshair/fuzz_core_test.py
+++ b/crosshair/fuzz_core_test.py
@@ -25,7 +25,7 @@ import pytest
 
 import crosshair.core_and_libs  # noqa: F401  -- ensure patches/plugins load
 from crosshair.behavior_compare import run_differential
-from crosshair.inputgen import catalog
+from crosshair.inputgen import catalog, inputs_for
 
 # Inputs checked per operation (each pinned symbolic-vs-concrete).  Small for CI.
 INPUTS_PER_OP = 3
@@ -242,15 +242,22 @@ def _windows_skip_reason(seedkey):
     return None
 
 
-def _check(label, call, seedkey):
-    """Assert symbolic == concrete across this op's valid inputs."""
-    fn, expr, names, eval_globals = call
-    result = run_differential(
-        fn, expr, names, eval_globals, k=INPUTS_PER_OP, seedkey=seedkey
-    )
-    if result.checked == 0:
+def _check(label, op):
+    """Assert symbolic == concrete across this op's valid inputs, for EVERY overload
+    shape it offers.  An op whose overloads differ in argument count needs one drive
+    per shape (`pow(base, exp)` is a different code path from
+    `pow(base, exp, mod)`), and the interesting behavior often lives outside the
+    primary sig."""
+    checked = 0
+    for call in op.drives():
+        inputs = inputs_for(call, k=INPUTS_PER_OP, seedkey=op.seedkey)
+        result = run_differential(call, inputs)
+        checked += result.checked
+        assert (
+            result.divergence is None
+        ), f"{label} diverges on `{call.expr}` {result.divergence.describe()}"
+    if checked == 0:
         pytest.skip(f"no drivable inputs for {label}")
-    assert result.divergence is None, f"{label} diverges {result.divergence.describe()}"
 
 
 def _op_marks(op):
@@ -312,4 +319,4 @@ def _catalog_params():
 def test_op(key):
     """Symbolic-vs-concrete differential for one catalogued operation."""
     op = _CATALOG[key]
-    _check(key, op.call, op.seedkey)
+    _check(key, op)

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -33,6 +33,7 @@ from typing import (
     FrozenSet,
     Iterator,
     List,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -44,6 +45,7 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 from crosshair.auditwall import SideEffectDetected, enabled_auditwall
+from crosshair.behavior_compare import CallSpec
 from crosshair.typeshed_lookup import (
     method_funcdefs,
     module_funcdefs,
@@ -205,19 +207,33 @@ def receiver_name(argnames: Sequence[str]) -> str:
 def call_expr(method: str, argnames: Sequence[str], recv: str = "a") -> Optional[str]:
     """The source expression invoking ``method`` on receiver ``recv`` with the
     given argument names, or None when an operator form needs an argument the
-    signature doesn't supply."""
-    if method in _BINOP:
-        return f"{recv} {_BINOP[method]} {argnames[0]}" if argnames else None
-    if method == "__divmod__":
-        return f"divmod({recv}, {argnames[0]})" if argnames else None
+    signature doesn't supply.
+
+    Every name in ``argnames`` appears in the result: the operator syntaxes place
+    exactly one operand, so an overload supplying more (``int.__pow__``'s
+    ``(x, modulo)``) uses the explicit dunder form rather than silently dropping
+    the extra argument.  Callers rely on this to pair an argument tuple with an
+    expression that consumes all of it."""
+    takes_one_operand = method in _BINOP or method in (
+        "__divmod__",
+        "__contains__",
+        "__getitem__",
+    )
+    if takes_one_operand and not argnames:  # no operand to apply the operator to
+        return None
+    if len(argnames) == 1:
+        if method in _BINOP:
+            return f"{recv} {_BINOP[method]} {argnames[0]}"
+        if method == "__divmod__":
+            return f"divmod({recv}, {argnames[0]})"
+        if method == "__contains__":
+            return f"{argnames[0]} in {recv}"
+        if method == "__getitem__":
+            return f"{recv}[{argnames[0]}]"
     if method in _UNARY and not argnames:
         return _UNARY[method].format(a=recv)
     if method in _CALLOP and not argnames:
         return _CALLOP[method].format(a=recv)
-    if method == "__contains__":
-        return f"{argnames[0]} in {recv}" if argnames else None
-    if method == "__getitem__":
-        return f"{recv}[{argnames[0]}]" if argnames else None
     return f"{recv}.{method}({', '.join(argnames)})"
 
 
@@ -761,7 +777,9 @@ def _overload_sigs(
 
     A *args op (set.update(*s), math.gcd(*ints), ...) with no required positionals
     also gets a candidate that passes one expanded vararg, so consumers that only
-    take *args become drivable."""
+    take *args become drivable.  That expansion REPLACES the bare no-argument form
+    of the same overload: passing nothing to a purely variadic op exercises none of
+    it (``s.difference_update()`` is a no-op), so it is not a shape worth driving."""
     out, seen = [], set()
     for fn in overloads:
         required = list(params(fn, is_method=is_method).required_positional)
@@ -779,11 +797,11 @@ def _overload_sigs(
         if fn.args.vararg is not None and fn.args.vararg.annotation is not None:
             try:
                 va = fn.args.vararg
-                variants.append(
-                    sig + ((va.arg,) + _map_arg(va.annotation, binds, module),)
-                )
+                expanded = sig + ((va.arg,) + _map_arg(va.annotation, binds, module),)
             except _Unsupported:
                 pass
+            else:
+                variants = [expanded] if not sig else [sig, expanded]
         for v in variants:
             if v not in seen:
                 seen.add(v)
@@ -938,10 +956,30 @@ def _module_alias_annstr(module: str) -> Dict[str, str]:
     return _ALIAS_ANNSTR[module]
 
 
-def _literal_const(node: Any) -> Any:
-    """The concrete value of a Literal element -- a bare constant or a negated
-    numeric one (``Literal[-1]`` parses as ``UnaryOp(USub, Constant(1))``, not a
-    ``Constant(-1)``).  ``Literal[None]`` and non-constants yield None (dropped)."""
+def _dotted_path(node: Any) -> Optional[List[str]]:
+    """The attribute path a Name/Attribute chain spells (``a.b.c`` -> ["a","b","c"]),
+    or None for any other shape."""
+    parts: List[str] = []
+    while isinstance(node, _ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if not isinstance(node, _ast.Name):
+        return None
+    parts.append(node.id)
+    return list(reversed(parts))
+
+
+def _literal_const(node: Any, module: Optional[str] = None) -> Any:
+    """The concrete value of a Literal element, or None when it can't be produced.
+
+    Handles a bare constant, a negated numeric one (``Literal[-1]`` parses as
+    ``UnaryOp(USub, Constant(1))``, not a ``Constant(-1)``), and a dotted member
+    reference (``Literal[RegexFlag.IGNORECASE]``, an ``Attribute``) resolved against
+    the live ``module``.  ``Literal[None]`` yields None, i.e. is dropped.
+
+    A dotted element the runtime spells differently than typeshed does yields None:
+    typeshed models ``dataclasses._MISSING_TYPE`` as an ``Enum`` carrying a
+    ``MISSING`` member, but the runtime class has no such attribute."""
     if isinstance(node, _ast.Constant):
         return node.value
     if (
@@ -951,6 +989,17 @@ def _literal_const(node: Any) -> Any:
         and isinstance(node.operand.value, (int, float, complex))
     ):
         return -node.operand.value
+    if isinstance(node, _ast.Attribute) and module:
+        path = _dotted_path(node)
+        if path is None:
+            return None
+        try:
+            value: Any = importlib.import_module(module)
+            for part in path:
+                value = getattr(value, part)
+        except Exception:
+            return None
+        return value
     return None
 
 
@@ -967,7 +1016,9 @@ def _literal_values(node: Any, module: str) -> Tuple[Any, ...]:
             elts = (
                 node.slice.elts if isinstance(node.slice, _ast.Tuple) else [node.slice]
             )
-            return tuple(v for v in map(_literal_const, elts) if v is not None)
+            return tuple(
+                v for v in (_literal_const(e, module) for e in elts) if v is not None
+            )
     if isinstance(node, _ast.Name):
         return _module_literal_aliases(module).get(node.id, ())
     if isinstance(node, _ast.BinOp) and isinstance(node.op, _ast.BitOr):  # unions
@@ -1305,20 +1356,58 @@ def _module_classes(module: str) -> List[type]:
 # ---------------------------------------------------------------------------
 # public bridge: a native callable -> concrete, valid argument tuples
 # ---------------------------------------------------------------------------
+def _method_owner(fn: Any) -> Optional[type]:
+    """The class ``fn`` is a method of, or None when it is a free function.
+
+    A C-level descriptor names its class in ``__objclass__``.  A method of a class
+    written in Python carries no such attribute, so the owner is the innermost class
+    its ``__qualname__`` walks through -- the LONGEST leading prefix that resolves to
+    a type, which also finds the class behind a method built by a closure
+    (``fractions.Fraction.__add__`` is ``Fraction._operator_fallbacks.<locals>.\
+forward``)."""
+    objclass = getattr(fn, "__objclass__", None)
+    if isinstance(objclass, type):
+        return objclass
+    qualname = getattr(fn, "__qualname__", "")
+    module = getattr(fn, "__module__", None)
+    if not module:
+        return None
+    try:
+        step_into: Any = importlib.import_module(module)
+    except Exception:
+        return None
+    owner = None
+    for step in qualname.split(".")[:-1]:
+        if step == "<locals>":  # a function scope; getattr can't descend into it
+            break
+        step_into = getattr(step_into, step, None)
+        if step_into is None:
+            break
+        if isinstance(step_into, type):
+            owner = step_into
+    return owner
+
+
 def _sig_for(fn: Any) -> Optional[Tuple[str, Any, str, Any]]:
-    """('method', typ, name, sigs) | ('func', module, name, sigs) | None."""
-    objcls = getattr(fn, "__objclass__", None)
-    if objcls in RECV and getattr(fn, "__name__", None):
-        module = getattr(objcls, "__module__", "builtins")
-        return (
-            "method",
-            objcls,
-            fn.__name__,
-            _candidate_sigs(objcls, fn.__name__, module),
-        )
-    mod, name = getattr(fn, "__module__", None), getattr(fn, "__name__", None)
-    if mod and name:
-        return ("func", mod, name, _func_candidate_sigs(mod, name))
+    """('method', typ, name, sigs) | ('func', module, name, sigs) | None.
+
+    A method whose receiver type has no construction strategy resolves to None
+    rather than to the free-function branch: a module often exports a function
+    sharing a method's name (``gettext.install`` beside
+    ``NullTranslations.install``), and borrowing that signature would bind the
+    receiver to an argument of an unrelated function."""
+    name = getattr(fn, "__name__", None)
+    if not name:
+        return None
+    owner = _method_owner(fn)
+    if owner is not None:
+        if owner not in RECV:
+            return None
+        module = getattr(owner, "__module__", "builtins")
+        return ("method", owner, name, _candidate_sigs(owner, name, module))
+    module = getattr(fn, "__module__", None)
+    if module:
+        return ("func", module, name, _func_candidate_sigs(module, name))
     return None
 
 
@@ -1330,22 +1419,30 @@ def primary_sig(sigs: Sequence[Any]) -> Any:
     return next((s for s in sigs if s), sigs[0])
 
 
-def _specs_for(fn: Any) -> Optional[List[Any]]:
-    """Per-arg fuzz specs (and, for methods, a leading receiver spec), or None."""
-    all_specs = _candidate_specs_for(fn)
-    return all_specs[0] if all_specs else None
+def candidate_arities(sigs: Sequence[Any]) -> List[int]:
+    """The distinct argument counts the candidate overloads offer, the primary
+    sig's first and the rest widest-first.  Each is drivable with its own
+    expression, so a caller that walks these covers every overload shape rather
+    than only the primary's (``pow(base, exp)`` as well as
+    ``pow(base, exp, mod)``)."""
+    primary = len(primary_sig(sigs))
+    others = {len(s) for s in sigs} - {primary}
+    return [primary] + sorted(others, reverse=True)
 
 
-def _candidate_specs_for(fn: Any) -> Optional[List[List[Any]]]:
-    """One per-arg fuzz-spec list per candidate overload sharing the primary
-    sig's arity (methods carry a leading receiver spec), or None.  Off-arity
-    overloads are dropped -- the driven ``expr`` comes from the primary sig, so
-    their tuples wouldn't fit."""
+def _candidate_specs_for(
+    fn: Any, arity: Optional[int] = None
+) -> Optional[List[List[Any]]]:
+    """One per-arg fuzz-spec list per candidate overload of the requested arity --
+    the primary sig's when ``arity`` is None -- or None.  Methods carry a leading
+    receiver spec.  Overloads of other arities are excluded: the driven ``expr``
+    fixes one argument count, so their tuples wouldn't fit it."""
     info = _sig_for(fn)
     if not info or not info[3]:
         return None
     kind, sigs = info[0], info[3]
-    arity = len(primary_sig(sigs))
+    if arity is None:
+        arity = len(primary_sig(sigs))
     if kind == "method":
         typ, name = info[1], info[2]
         module = getattr(typ, "__module__", "builtins")
@@ -1381,6 +1478,7 @@ def valid_inputs(
     develop: bool = True,
     size: int = 3,
     seedkey: Optional[str] = None,
+    arity: Optional[int] = None,
 ) -> List[Tuple[Any, ...]]:
     """Up to ``k`` concrete, valid argument tuples for ``fn`` (a builtin function
     or method descriptor).  Deterministic given ``seed``.  ``develop`` drops the
@@ -1389,14 +1487,16 @@ def valid_inputs(
     an op cliffs.  ``seedkey`` is the op's catalog identity -- pass it to enable a
     :data:`CUSTOM_INPUTS` override (correlated / aliased / roundtrip inputs); a
     caller with only ``fn`` (which can't recover the public seedkey -- ``operator``
-    funcs report ``__module__ == "_operator"``) simply omits it.  Returns [] when no
+    funcs report ``__module__ == "_operator"``) simply omits it.  ``arity`` selects
+    the overload shape to generate for, defaulting to the primary sig's -- pass one
+    of :func:`candidate_arities` to drive a different overload.  Returns [] when no
     signature can be resolved."""
-    specs_list = _candidate_specs_for(fn)
+    specs_list = _candidate_specs_for(fn, arity)
     if not specs_list:
         return []
     if seedkey and seedkey in CUSTOM_INPUTS:
         # A correlated/aliased/roundtrip override drives its own shape off the
-        # primary sig; don't fan it out across overloads.
+        # first candidate; don't fan it out across overloads.
         strat = tuple_strategy(seedkey, specs_list[0], size)
     else:
         strat = st.one_of(
@@ -1422,43 +1522,89 @@ def valid_inputs(
     return (out[1 : k + 1] or out[:k]) if develop else out[:k]
 
 
-# How to *call* one operation -- shared by the differential test and the support
-# measurement so both drive an op the same way.  Returns (fn, expr, arg_names,
-# eval_globals): ``fn`` for input generation, and ``expr`` an eval-able source
-# over ``arg_names`` (receiver named ``a`` for methods) -- operators MUST use
-# operator syntax, so we eval rather than call the dunder descriptor.
+def can_synthesize_inputs(call: CallSpec) -> bool:
+    """Whether arguments for a call spec's overload shape are constructable at all.
+    Static: it resolves the strategies without generating a value."""
+    return _candidate_specs_for(call.fn, call.arity) is not None
+
+
+def inputs_for(
+    call: CallSpec,
+    k: int = 5,
+    seed: int = 0,
+    size: int = 3,
+    seedkey: Optional[str] = None,
+) -> List[Tuple[Any, ...]]:
+    """Up to ``k`` concrete argument tuples fitting a call spec's expression.  Tuples
+    the expression can't take are dropped, so a CUSTOM_INPUTS override built for
+    another overload shape can't be driven through the wrong one."""
+    return [
+        t
+        for t in valid_inputs(
+            call.fn, k=k, seed=seed, size=size, seedkey=seedkey, arity=call.arity
+        )
+        if call.accepts(t)
+    ]
+
+
+def _sig_of_arity(sigs: Sequence[Any], arity: Optional[int]) -> Optional[Any]:
+    """The candidate overload to build a call expression from: the primary sig when
+    ``arity`` is None, else the first overload taking that many arguments."""
+    if arity is None:
+        return primary_sig(sigs)
+    return next((s for s in sigs if len(s) == arity), None)
+
+
 def op_call(
-    typ: type, method: str, module: str = "builtins"
-) -> Optional[Tuple[Any, str, List[str], Dict[str, Any]]]:
+    typ: type, method: str, module: str = "builtins", arity: Optional[int] = None
+) -> Optional[CallSpec]:
     """Call spec for a (type, method), or None if not drivable.  ``module`` is the
-    type's owning module (``"builtins"`` for the builtin types)."""
+    type's owning module (``"builtins"`` for the builtin types).  ``arity`` selects
+    which overload shape to drive (default: the primary sig's)."""
     if method in SKIP_DUNDERS:
         return None
     sigs = _candidate_sigs(typ, method, module)
     if not sigs:
         return None
-    argnames = [n for n, _, _ in primary_sig(sigs)]
+    sig = _sig_of_arity(sigs, arity)
+    if sig is None:
+        return None
+    argnames = [n for n, _, _ in sig]
     recv = receiver_name(argnames)
     expr = call_expr(method, argnames, recv)
     if expr is None:  # operator form needs an arg the signature doesn't supply
         return None
-    return (getattr(typ, method), expr, [recv] + argnames, {})
+    return CallSpec(
+        fn=getattr(typ, method),
+        expr=expr,
+        arg_names=(recv, *argnames),
+        eval_globals={},
+        arity=len(argnames),
+    )
 
 
 def func_call(
-    module: str, name: str
-) -> Optional[Tuple[Any, str, List[str], Dict[str, Any]]]:
-    """Call spec for a module-level free function, or None if not drivable."""
+    module: str, name: str, arity: Optional[int] = None
+) -> Optional[CallSpec]:
+    """Call spec for a module-level free function, or None if not drivable.
+    ``arity`` selects which overload shape to drive (default: the primary sig's)."""
     fn = getattr(importlib.import_module(module), name, None)
     if fn is None:
         return None
     fsigs = _func_candidate_sigs(module, name)
     if not fsigs:
         return None
-    argnames = [n for n, _, _ in primary_sig(fsigs)]
-    if not argnames:  # nothing to vary
+    sig = _sig_of_arity(fsigs, arity)
+    if not sig:  # unknown arity, or nothing to vary
         return None
-    return (fn, f"_fn({', '.join(argnames)})", argnames, {"_fn": fn})
+    argnames = [n for n, _, _ in sig]
+    return CallSpec(
+        fn=fn,
+        expr=f"_fn({', '.join(argnames)})",
+        arg_names=tuple(argnames),
+        eval_globals={"_fn": fn},
+        arity=len(argnames),
+    )
 
 
 def func_surface(module: str) -> List[str]:
@@ -1500,7 +1646,8 @@ class Operation:
       synthesized for it (typically an unconstructable receiver -- a class not in
       :data:`RECV` -- so ``valid_inputs`` is always empty).  Neither consumer can
       exercise it; this marks an input-generation gap rather than a property of the
-      op.  Detected statically via :func:`_specs_for` (no live run needed).
+      op.  Detected statically via :func:`can_synthesize_inputs` (no live
+      run needed).
     * ``not_value_function`` -- drivable, but its output isn't a deterministic,
       value-comparable function of the inputs (unordered-container ordering, an
       arbitrary popped element, an identity-eq result, reflection), so the forward
@@ -1522,13 +1669,15 @@ class Operation:
     module: str  # owning module ("builtins" for the builtin types)
     owner: str  # type name (methods) or module name (funcs)
     name: str
-    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]]
+    call: Optional[CallSpec]
     skip_reason: Optional[str] = None  # statically not drivable
     out_of_scope: Optional[str] = None  # OS-layer handle; never modelable
     no_inputs: Optional[str] = None  # signature present but no inputs synthesizable
     not_value_function: Optional[str] = None  # output not a comparable value fn
     side_effect: Optional[str] = None  # audit event the concrete op reaches for
     probe_hazard: Optional[str] = None  # op blocks/crashes the concrete probe
+    # One spec per overload shape OTHER than ``call``'s (see CallSpec.arity).
+    alt_calls: Tuple[CallSpec, ...] = ()
 
     @property
     def drivable(self) -> bool:
@@ -1539,13 +1688,17 @@ class Operation:
             and self.no_inputs is None
         )
 
-    def inputs(self, k: int = 5, seed: int = 0, size: int = 3) -> List[Tuple[Any, ...]]:
-        """Concrete valid argument tuples for this op at the given ``size``."""
+    def drives(self) -> List[CallSpec]:
+        """Every call spec this op can be driven with, the primary shape first."""
         if self.call is None:
             return []
-        return valid_inputs(
-            self.call[0], k=k, seed=seed, size=size, seedkey=self.seedkey
-        )
+        return [self.call, *self.alt_calls]
+
+    def inputs(self, k: int = 5, seed: int = 0, size: int = 3) -> List[Tuple[Any, ...]]:
+        """Concrete valid argument tuples for this op's primary shape."""
+        if self.call is None:
+            return []
+        return inputs_for(self.call, k=k, seed=seed, size=size, seedkey=self.seedkey)
 
 
 # Parameter NAMES that denote an OS-layer handle.  typeshed annotates all of these
@@ -1567,15 +1720,12 @@ _OS_HANDLE_PARAMS: Dict[str, str] = {
 }
 
 
-def _out_of_scope_reason(
-    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
-) -> Optional[str]:
+def _out_of_scope_reason(call: Optional[CallSpec]) -> Optional[str]:
     """Why this op is fundamentally out of CrossHair's scope, or None.  Currently:
     it takes an OS-layer handle (a file descriptor) we can never model."""
     if call is None:
         return None
-    _fn, _expr, argnames, _eg = call
-    for name in argnames:
+    for name in call.arg_names:
         reason = _OS_HANDLE_PARAMS.get(name)
         if reason is not None:
             return reason
@@ -2161,7 +2311,7 @@ CRASH = "unprobeable: concrete probe crashed the interpreter"
 
 
 def probe_side_effect(
-    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+    call: Optional[CallSpec],
     seedkey: Optional[str] = None,
     k: int = 3,
     seed: int = 0,
@@ -2182,13 +2332,7 @@ def probe_side_effect(
         return None
     if seedkey is not None and seedkey in PROBE_HAZARD_OVERRIDES:
         return PROBE_HAZARD_OVERRIDES[seedkey]
-    fn, expr, argnames, eval_globals = call
-    inputs = valid_inputs(fn, k=k, seed=seed, size=size)
-    if not inputs:
-        return None
-    for vals in inputs:
-        if len(vals) != len(argnames):
-            continue
+    for vals in inputs_for(call, k=k, seed=seed, size=size):
         try:
             with enabled_auditwall(
                 reject_prefixes=PROBE_REJECT_EVENTS
@@ -2197,7 +2341,7 @@ def probe_side_effect(
             ):
                 stdin, sys.stdin = sys.stdin, io.StringIO()
                 try:
-                    eval(expr, dict(eval_globals), dict(zip(argnames, vals)))
+                    call.invoke(vals)
                 finally:
                     sys.stdin = stdin
         except SideEffectDetected as exc:
@@ -2209,7 +2353,7 @@ def probe_side_effect(
     return None
 
 
-def _probe_child(call: Any, seedkey: Optional[str], q: Any) -> None:
+def _probe_child(call: Optional[CallSpec], seedkey: Optional[str], q: Any) -> None:
     try:
         q.put(("ok", probe_side_effect(call, seedkey)))
     except BaseException as exc:  # the probe itself blew up (not the op's own error)
@@ -2217,7 +2361,7 @@ def _probe_child(call: Any, seedkey: Optional[str], q: Any) -> None:
 
 
 def probe_side_effect_isolated(
-    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+    call: Optional[CallSpec],
     seedkey: Optional[str] = None,
     timeout: float = 5.0,
 ) -> Optional[str]:
@@ -2251,7 +2395,7 @@ def probe_side_effect_isolated(
 
 
 def _probe(
-    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+    call: Optional[CallSpec],
     seedkey: str,
     mode: Any,
 ) -> Tuple[Optional[str], Optional[str]]:
@@ -2273,7 +2417,7 @@ def _probe(
 
 
 def _classify(
-    call: Optional[Tuple[Any, str, List[str], Dict[str, Any]]],
+    call: Optional[CallSpec],
     seedkey: str,
     probe: Any,
 ) -> Tuple[
@@ -2297,7 +2441,7 @@ def _classify(
     oos = _out_of_scope_reason(call)
     if oos is not None:  # never modelable -> don't waste a probe on it
         return (None, oos, None, None, None, None)
-    if _specs_for(call[0]) is None:  # signature exists but no inputs synthesizable
+    if not can_synthesize_inputs(call):  # signature exists, arguments don't
         return (
             None,
             None,
@@ -2319,6 +2463,25 @@ def _classify(
     return (None, None, None, None, side_effect, hazard)
 
 
+def _alt_calls(
+    build: Callable[[int], Optional[CallSpec]],
+    sigs: Sequence[Any],
+) -> Tuple[CallSpec, ...]:
+    """A spec for every non-primary overload shape that is drivable in its own
+    right.  A shape whose expression can't place its arguments, that takes an
+    OS-layer handle, or that has no synthesizable inputs is left out -- the same
+    bars the primary call clears."""
+    out = []
+    for arity in candidate_arities(sigs)[1:]:
+        call = build(arity)
+        if call is None or _out_of_scope_reason(call) is not None:
+            continue
+        if not can_synthesize_inputs(call):
+            continue
+        out.append(call)
+    return tuple(out)
+
+
 def _method_op(module: str, typ: type, meth: str, probe: Any) -> Operation:
     call = op_call(typ, meth, module)
     if module == "builtins":
@@ -2328,6 +2491,13 @@ def _method_op(module: str, typ: type, meth: str, probe: Any) -> Operation:
         key = f"{module}.{typ.__name__}_{meth}_method"
         seedkey = f"{module}.{typ.__name__}.{meth}"
     skip, oos, no_inputs, nvf, side_effect, hazard = _classify(call, seedkey, probe)
+    alts = (
+        _alt_calls(
+            lambda n: op_call(typ, meth, module, n), _candidate_sigs(typ, meth, module)
+        )
+        if call is not None and skip is None and oos is None and no_inputs is None
+        else ()
+    )
     return Operation(
         key=key,
         seedkey=seedkey,
@@ -2336,6 +2506,7 @@ def _method_op(module: str, typ: type, meth: str, probe: Any) -> Operation:
         owner=typ.__name__,
         name=meth,
         call=call,
+        alt_calls=alts,
         skip_reason=skip,
         out_of_scope=oos,
         no_inputs=no_inputs,
@@ -2349,6 +2520,13 @@ def _func_op(module: str, name: str, probe: Any) -> Operation:
     call = func_call(module, name)
     seedkey = f"{module}.{name}"
     skip, oos, no_inputs, nvf, side_effect, hazard = _classify(call, seedkey, probe)
+    alts = (
+        _alt_calls(
+            lambda n: func_call(module, name, n), _func_candidate_sigs(module, name)
+        )
+        if call is not None and skip is None and oos is None and no_inputs is None
+        else ()
+    )
     return Operation(
         key=seedkey,
         seedkey=seedkey,
@@ -2357,6 +2535,7 @@ def _func_op(module: str, name: str, probe: Any) -> Operation:
         owner=module,
         name=name,
         call=call,
+        alt_calls=alts,
         skip_reason=skip,
         out_of_scope=oos,
         no_inputs=no_inputs,

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -2162,6 +2162,12 @@ GLOBAL_STATE_OVERRIDES: Dict[str, str] = {
     "mimetypes.add_type": "mutates the global MIME-types registry",
     "modulefinder.AddPackagePath": "mutates modulefinder's global package-path table",
     "modulefinder.ReplacePackage": "mutates modulefinder's global replace-package map",
+    # Caches the pointer type it builds in a module-level dict KEYED BY ITS
+    # ARGUMENT, so driving it symbolically leaves a symbolic key in ctypes' cache.
+    # A later lookup then compares against that key outside any state space
+    # ([3.14+] "Not in a statespace context" from the concrete run).
+    "ctypes.POINTER": "caches by argument in ctypes' global pointer-type table",
+    "ctypes.SetPointerType": "mutates ctypes' global pointer-type table",
 }
 
 

--- a/crosshair/inputgen.py
+++ b/crosshair/inputgen.py
@@ -35,9 +35,7 @@ from typing import (
     List,
     Optional,
     Sequence,
-    Set,
     Tuple,
-    cast,
 )
 
 from hypothesis import HealthCheck, given
@@ -46,6 +44,12 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 from crosshair.auditwall import SideEffectDetected, enabled_auditwall
+from crosshair.typeshed_lookup import (
+    method_funcdefs,
+    module_funcdefs,
+    params,
+    stub_names,
+)
 
 # ---------------------------------------------------------------------------
 # the operation surface: builtin types + their methods
@@ -486,147 +490,10 @@ def _arg_strategy(spec: Any, n: int) -> "st.SearchStrategy[Any]":
     return sized(spec, n)
 
 
-# --- typeshed access, pinned to the RUNNING interpreter --------------------
-# get_stub_names evaluates `sys.version_info`/`sys.platform` guards for the given
-# search context, so the surface matches what THIS interpreter actually has: no
-# version skew (no math.fma on 3.12), no manual `if` descent, and re-exports
-# (bisect_left <- _bisect) and class members come pre-resolved.
-_SEARCH_CTX: Any = None
-_STUB_NAMES: Dict[str, Dict[str, Any]] = {}  # module -> {name: NameInfo}
-# builtins holds the concrete types + object; typing holds the ABC bases
-# (MutableSequence/Mapping/...) where typeshed declares inherited methods.
-_STUB_CLASS_MODULES = ("builtins", "typing")
-
-
-def _search_ctx() -> Any:
-    global _SEARCH_CTX
-    if _SEARCH_CTX is None:
-        import typeshed_client as _tc
-
-        _SEARCH_CTX = _tc.get_search_context(
-            version=sys.version_info[:2], platform=sys.platform
-        )
-    return _SEARCH_CTX
-
-
-def _stub_names(module: str) -> Dict[str, Any]:
-    """Lazily fetch the version/platform-resolved {name: NameInfo} for a module."""
-    if module not in _STUB_NAMES:
-        import typeshed_client as _tc
-
-        try:
-            _STUB_NAMES[module] = (
-                _tc.get_stub_names(module, search_context=_search_ctx()) or {}
-            )
-        except Exception:
-            _STUB_NAMES[module] = {}
-    return _STUB_NAMES[module]
-
-
-def _funcdefs(ni: Any, _depth: int = 0) -> List[Any]:
-    """FunctionDefs behind a NameInfo: a plain def, an @overload group, or a
-    re-export (followed across modules), else []."""
-    if ni is None or _depth > 4:
-        return []
-    import typeshed_client as _tc
-
-    node = ni.ast
-    if isinstance(node, (_ast.FunctionDef, _ast.AsyncFunctionDef)):
-        return [node]
-    if isinstance(node, _tc.OverloadedName):
-        return [
-            d
-            for d in node.definitions
-            if isinstance(d, (_ast.FunctionDef, _ast.AsyncFunctionDef))
-        ]
-    if isinstance(
-        node, _tc.ImportedName
-    ):  # re-export, e.g. bisect.bisect_left <- _bisect
-        return _funcdefs(
-            _stub_names(".".join(node.module_name)).get(cast(str, node.name)),
-            _depth + 1,
-        )
-    return []
-
-
-def _stub_class(name: str, module: str = "builtins", _depth: int = 0) -> Optional[Any]:
-    """The version-resolved (class NameInfo, defining module) for ``name``, searched
-    in ``(module, "builtins", "typing")`` and following cross-module re-exports
-    (e.g. ``fractions.Fraction``'s base ``Rational`` -> ``numbers.Rational``).
-    Returns the module the ClassDef actually lives in so base-following can search
-    there next."""
-    if _depth > 4:
-        return None
-    import typeshed_client as _tc
-
-    for mod in (module, *_STUB_CLASS_MODULES):
-        ni = _stub_names(mod).get(name)
-        if ni is None:
-            continue
-        if isinstance(ni.ast, _ast.ClassDef):
-            return (ni, mod)
-        if isinstance(ni.ast, _tc.ImportedName):  # re-export -> follow to its module
-            return _stub_class(
-                cast(str, ni.ast.name or name),
-                ".".join(ni.ast.module_name),
-                _depth + 1,
-            )
-    return None
-
-
-def _base_ref(base: Any, default_mod: str) -> Optional[Tuple[str, str]]:
-    """(base_class_name, module_to_resolve_it_in) for a base-class AST node.
-
-    A bare ``Name`` (``class Fraction(Rational)``) resolves in the current class's
-    module (and _stub_class follows any re-export from there).  A dotted
-    ``Attribute`` (``class RegexFlag(enum.IntFlag)``) resolves its final attr in the
-    *qualifier* module -- ``enum`` here, ``os.path`` for ``os.path.X`` -- so bases
-    imported as ``import enum`` (not ``from enum import IntFlag``) still follow to
-    where the class is actually defined instead of dead-ending in the child module."""
-    if isinstance(base, _ast.Name):
-        return (base.id, default_mod)
-    if isinstance(base, _ast.Attribute):
-        parts = []
-        node: Any = base.value
-        while isinstance(node, _ast.Attribute):
-            parts.append(node.attr)
-            node = node.value
-        if isinstance(node, _ast.Name):
-            parts.append(node.id)
-            return (base.attr, ".".join(reversed(parts)))
-    return None
-
-
-def _class_chain(cls_name: str, module: str = "builtins") -> List[Any]:
-    """Typeshed MRO for cls_name: derived-first class NameInfos, following declared
-    bases (subscripts stripped), with ``object`` always last.  ``module`` is the
-    class's owning module; each base resolves in the module named by its qualifier
-    (dotted bases) or the module where the current class was found (bare names)."""
-    chain: List[Any] = []
-    seen: Set[str] = set()
-
-    def visit(name: str, mod: str) -> None:
-        if name in seen:
-            return
-        res = _stub_class(name, mod)
-        if res is None:
-            return
-        ni, found_mod = res
-        seen.add(name)
-        chain.append(ni)
-        for b in ni.ast.bases:
-            base = b.value if isinstance(b, _ast.Subscript) else b
-            ref = _base_ref(base, found_mod)
-            if ref and ref[0] not in ("Generic", "Protocol"):
-                visit(*ref)
-
-    visit(cls_name, module)
-    if "object" not in seen:
-        obj = _stub_class("object")
-        if obj is not None:
-            chain.append(obj[0])
-    return chain
-
+# --- typeshed access -------------------------------------------------------
+# Resolution (version/platform guards, @overload grouping, re-exports, the
+# typeshed MRO) lives in crosshair.typeshed_lookup; what a typeshed annotation
+# means for FUZZING is this module's job.
 
 # The generatable type for every unconstrained "object-like" slot: a bare
 # object/Any parameter, an unbound element TypeVar, or a generic container's element
@@ -882,25 +749,14 @@ def _map_ann(node: Any, binds: Dict[str, str]) -> str:
     raise _Unsupported(type(node).__name__)
 
 
-def _method_overloads(typ: type, method: str, module: str = "builtins") -> List[Any]:
-    """typeshed FunctionDefs for typ.method, resolved up the MRO: the first class
-    in the chain that defines it wins (so a derived override beats an inherited
-    base), returning all (version-resolved) overloads from that class."""
-    for ni in _class_chain(typ.__name__, module):
-        fns = _funcdefs((ni.child_nodes or {}).get(method))
-        if fns:
-            return fns
-    return []
-
-
 def _overload_sigs(
     overloads: List[Any],
     binds: Dict[str, str],
     module: str,
-    drop: Tuple[str, ...],
+    is_method: bool,
 ) -> List[List[Tuple[str, str, Tuple[Any, ...]]]]:
-    """Map each overload's required positional args (receiver/names in ``drop``
-    excluded) to [(argname, annotation_str, literal_values), ...], de-duplicated.
+    """Map each overload's required positional args (the receiver excluded) to
+    [(argname, annotation_str, literal_values), ...], de-duplicated.
     An empty inner list means a zero-arg call; [] means no overload could be mapped.
 
     A *args op (set.update(*s), math.gcd(*ints), ...) with no required positionals
@@ -908,10 +764,7 @@ def _overload_sigs(
     take *args become drivable."""
     out, seen = [], set()
     for fn in overloads:
-        pos = fn.args.posonlyargs + fn.args.args
-        ndef = len(fn.args.defaults)
-        required = pos[: len(pos) - ndef] if ndef else pos
-        required = [a for a in required if a.arg not in drop]
+        required = list(params(fn, is_method=is_method).required_positional)
         try:
             sig = tuple(
                 (a.arg,) + _map_arg(a.annotation, binds, module)
@@ -962,9 +815,8 @@ def _candidate_sigs(
     binds = {"Self": recv_ann, **recv_binds}
     if method in _REFLEXIVE_CMP:  # measure ==/!=/ordering against the SAME type
         binds = {**binds, "object": recv_ann, "Any": recv_ann}
-    return _overload_sigs(
-        _method_overloads(typ, method, module), binds, module, ("self",)
-    )
+    overloads, _ = method_funcdefs(typ.__name__, method, module)
+    return _overload_sigs(overloads, binds, module, True)
 
 
 @functools.lru_cache(maxsize=None)
@@ -1013,7 +865,7 @@ def _module_literal_aliases(module: str) -> Dict[str, Tuple[Any, ...]]:
     if module not in _LIT_ALIASES:
         amap: Dict[str, Tuple[Any, ...]] = {}
         _LIT_ALIASES[module] = amap  # store first (guards alias->alias re-entry)
-        for name, ni in _stub_names(module).items():
+        for name, ni in stub_names(module).items():
             node = ni.ast
             val = (
                 node.value if isinstance(node, (_ast.Assign, _ast.AnnAssign)) else None
@@ -1050,7 +902,7 @@ def _module_alias_annstr(module: str) -> Dict[str, str]:
         except Exception:
             mod = None
         if mod is not None:
-            for cname, cni in _stub_names(module).items():
+            for cname, cni in stub_names(module).items():
                 # Skip names _NAME_MAP already handles: it deliberately simplifies
                 # some builtins (object/memoryview -> int/bytes) to keep fuzzing
                 # cheap, and seeding "builtins.object" here would override that and
@@ -1062,7 +914,7 @@ def _module_alias_annstr(module: str) -> Dict[str, str]:
                 ):
                     resolved[cname] = f"{module}.{cname}"
         raw: Dict[str, Any] = {}
-        for name, ni in _stub_names(module).items():
+        for name, ni in stub_names(module).items():
             node = ni.ast
             val = (
                 node.value if isinstance(node, (_ast.Assign, _ast.AnnAssign)) else None
@@ -1404,15 +1256,9 @@ _MODULE_FUNCS: Dict[str, Dict[str, List[Any]]] = {}
 
 
 def _module_funcs(module: str) -> Dict[str, List[Any]]:
-    """Lazily map name -> [FunctionDef overloads] for a module's free functions,
-    version/platform-resolved, with @overloads grouped and re-exports followed."""
+    """Lazily map name -> [FunctionDef overloads] for a module's free functions."""
     if module not in _MODULE_FUNCS:
-        funcs: Dict[str, List[Any]] = {}
-        for name, ni in _stub_names(module).items():
-            defs = _funcdefs(ni)
-            if defs:
-                funcs[name] = defs
-        _MODULE_FUNCS[module] = funcs
+        _MODULE_FUNCS[module] = module_funcdefs(module)
     return _MODULE_FUNCS[module]
 
 
@@ -1421,9 +1267,7 @@ def _func_candidate_sigs(
     module: str, func: str
 ) -> List[List[Tuple[str, str, Tuple[Any, ...]]]]:
     """Candidate signatures per overload of module.func (see _overload_sigs)."""
-    return _overload_sigs(
-        _module_funcs(module).get(func, []), {}, module, ("self", "cls")
-    )
+    return _overload_sigs(_module_funcs(module).get(func, []), {}, module, False)
 
 
 def _module_classes(module: str) -> List[type]:
@@ -1437,7 +1281,7 @@ def _module_classes(module: str) -> List[type]:
     except Exception:
         return []
     out: List[type] = []
-    for name, ni in _stub_names(module).items():
+    for name, ni in stub_names(module).items():
         if name.startswith("_") or not isinstance(ni.ast, _ast.ClassDef):
             continue
         obj = getattr(mod, name, None)

--- a/crosshair/inputgen_test.py
+++ b/crosshair/inputgen_test.py
@@ -1,7 +1,10 @@
 """Tests for crosshair.inputgen -- the operation catalog and input generation."""
 
+import ast
+import gettext
 import multiprocessing
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -13,9 +16,20 @@ from statistics import NormalDist
 import pytest
 
 from crosshair.inputgen import (
+    _candidate_sigs,
+    _func_candidate_sigs,
+    _literal_const,
+    _literal_values,
+    _method_owner,
+    _sig_for,
+    call_expr,
+    can_synthesize_inputs,
+    candidate_arities,
+    catalog,
     catalog_modules,
     documented_stdlib_modules,
     func_call,
+    inputs_for,
     op_call,
     valid_inputs,
 )
@@ -199,14 +213,14 @@ def test_uncategorized_ops_probe_cleanly():
 def test_ops_with_unconventional_receivers_resolve(typ, method, module, expr):
     call = op_call(typ, method, module)
     assert call is not None, f"{typ.__name__}.{method} resolved no signature"
-    assert call[1] == expr
+    assert call.expr == expr
 
 
 def test_free_function_parameter_named_cls_is_not_dropped():
     """In builtins.issubclass(cls, class_or_tuple), `cls` is an argument."""
     call = func_call("builtins", "issubclass")
     assert call is not None
-    assert call[2] == ["cls", "class_or_tuple"]
+    assert call.arg_names == ("cls", "class_or_tuple")
 
 
 def test_undrivable_zero_arg_call_is_not_synthesized():
@@ -282,3 +296,196 @@ def test_bytes_strip_inputs_mostly_trim_and_keep_type(fn, seedkey):
     recv_type = type(tuples[0][0])
     assert all(isinstance(t[0], recv_type) for t in tuples)
     assert _fraction(tuples, lambda t: bytes(t[0]).strip() != bytes(t[0])) >= 0.6
+
+
+# Overload shapes that differ in ARGUMENT COUNT: an op is driven once per shape, so
+# the behavior in a non-primary overload isn't hidden behind the primary's arity.
+
+
+def test_candidate_arities_lists_primary_first():
+    # pow's primary sig is the 3-argument (base, exp, mod) form; the 2-argument form
+    # carries the float/complex bases and the negative-exponent Literals.
+    assert candidate_arities(_func_candidate_sigs("builtins", "pow")) == [3, 2]
+
+
+def test_candidate_arities_is_single_when_all_overloads_agree():
+    assert candidate_arities(_candidate_sigs(str, "center")) == [1]
+
+
+@pytest.mark.parametrize(
+    "arity,expect_expr",
+    [(None, "_fn(base, exp, mod)"), (3, "_fn(base, exp, mod)"), (2, "_fn(base, exp)")],
+)
+def test_func_call_builds_the_requested_shape(arity, expect_expr):
+    call = func_call("builtins", "pow", arity)
+    assert call is not None and call.expr == expect_expr
+
+
+def test_unknown_arity_is_not_drivable():
+    assert func_call("builtins", "pow", 7) is None
+
+
+@pytest.mark.parametrize("arity,width", [(2, 2), (3, 3)])
+def test_valid_inputs_matches_the_requested_arity(arity, width):
+    tuples = valid_inputs(pow, k=6, arity=arity)
+    assert tuples and all(len(t) == width for t in tuples)
+
+
+def test_two_argument_pow_reaches_negative_exponents():
+    """The 2-arg overloads carry Literal[-1..-20]; 3-arg pow rejects a negative
+    exponent outright, so this coverage exists only off the primary sig."""
+    exponents = [t[1] for t in valid_inputs(pow, k=60, seed=1, arity=2)]
+    assert any(isinstance(e, int) and e < 0 for e in exponents)
+    # and the complex/float bases that only the 2-arg overloads declare
+    bases = [t[0] for t in valid_inputs(pow, k=60, seed=1, arity=2)]
+    assert any(isinstance(b, (float, complex)) for b in bases)
+
+
+def test_catalog_drives_every_overload_shape():
+    ops = {op.key: op for op in catalog(probe=False)}
+    assert [c.expr for c in ops["builtins.pow"].alt_calls] == ["_fn(base, exp)"]
+    assert [c.arity for c in ops["builtins.pow"].drives()] == [3, 2]
+    # getattr's optional `default` lives in a 3-argument overload.
+    assert [c.expr for c in ops["builtins.getattr"].alt_calls] == [
+        "_fn(o, name, default)"
+    ]
+
+
+def test_every_drive_consumes_all_of_its_arguments():
+    """A generated argument the expression can't place would be silently discarded,
+    so every argument name must appear in the expression that drives it."""
+    unplaced = []
+    for op in catalog(probe=False):
+        for call in op.drives():
+            if any(name not in call.expr for name in call.arg_names):
+                unplaced.append((op.key, call.expr, call.arg_names))
+    assert not unplaced, f"arguments generated but never passed: {unplaced[:5]}"
+
+
+def test_call_spec_arity_excludes_a_methods_receiver():
+    """arity counts typeshed arguments; the synthesized receiver isn't one, so it
+    lines up with what valid_inputs generates for that shape."""
+    method = op_call(dict, "get", "builtins")
+    assert method.arg_names == ("a", "key") and method.arity == 1
+    free = func_call("builtins", "pow")
+    assert free.arg_names == ("base", "exp", "mod") and free.arity == 3
+
+
+def test_call_spec_invokes_its_expression():
+    assert func_call("builtins", "pow").invoke((2, 10, 1000)) == 24
+    assert op_call(dict, "get", "builtins").invoke(({"k": 7}, "k")) == 7
+    assert op_call(int, "__add__").invoke((2, 3)) == 5
+
+
+@pytest.mark.parametrize("arity,width", [(2, 2), (3, 3)])
+def test_call_spec_generates_inputs_its_expression_accepts(arity, width):
+    """A spec supplies its own inputs, so the shape it drives and the shape it
+    generates for can't drift apart."""
+    call = func_call("builtins", "pow", arity)
+    tuples = inputs_for(call, k=6)
+    assert tuples and all(len(t) == width and call.accepts(t) for t in tuples)
+
+
+def test_method_spec_generates_a_receiver_plus_its_arguments():
+    call = op_call(dict, "get", "builtins")
+    tuples = inputs_for(call, k=4)
+    assert tuples
+    assert all(len(t) == 2 and isinstance(t[0], dict) for t in tuples)
+
+
+def test_method_does_not_borrow_a_same_named_module_function():
+    """A module often exports a function sharing a method's name.  Resolving the
+    method to that function would bind the RECEIVER to the function's first argument
+    -- driving ``NullTranslations.install()`` on a plain ``str``.  An unconstructable
+    receiver yields no signature at all instead."""
+    assert _method_owner(gettext.NullTranslations.install) is gettext.NullTranslations
+    assert _sig_for(gettext.NullTranslations.install) is None
+    assert valid_inputs(gettext.NullTranslations.install, k=3) == []
+    call = op_call(gettext.NullTranslations, "install", "gettext")
+    assert call.expr == "a.install()" and call.arity == 0
+    assert not can_synthesize_inputs(call)
+    # the module-level function of the same name is itself resolvable
+    assert _sig_for(gettext.install)[0] == "func"
+    assert valid_inputs(gettext.install, k=3)
+
+
+def test_method_owner_found_through_a_closure_qualname():
+    """fractions.Fraction's operators are built by a closure, so their qualname is
+    ``Fraction._operator_fallbacks.<locals>.forward``.  The owner is the longest
+    leading prefix that resolves to a type."""
+    assert _method_owner(Fraction.__add__) is Fraction
+    assert _method_owner(Fraction.__neg__) is Fraction
+    receivers = [t[0] for t in valid_inputs(Fraction.__add__, k=3)]
+    assert receivers and all(isinstance(r, Fraction) for r in receivers)
+
+
+def test_local_function_has_no_method_owner():
+    def outer():
+        def inner():
+            pass
+
+        return inner
+
+    assert _method_owner(outer()) is None
+
+
+def test_can_synthesize_inputs_reports_unconstructable_arguments():
+    assert can_synthesize_inputs(func_call("builtins", "pow"))
+    # A receiver CrossHair has no construction strategy for yields no inputs.
+    unconstructable = [
+        op for op in catalog(probe=False) if op.no_inputs and op.call is not None
+    ]
+    assert unconstructable, "expected some ops with unconstructable arguments"
+    assert not can_synthesize_inputs(unconstructable[0].call)
+
+
+def test_operator_syntax_yields_to_the_dunder_form_when_it_cannot_place_args():
+    # `a ** x` has room for one operand; int.__pow__'s (value, mod) overload needs
+    # the explicit form rather than dropping `mod`.
+    assert call_expr("__pow__", ["x"]) == "a ** x"
+    assert call_expr("__pow__", ["value", "mod"]) == "a.__pow__(value, mod)"
+    assert call_expr("__pow__", []) is None  # no operand to apply
+
+
+# Literal[...] elements that aren't bare constants.
+
+
+def test_literal_const_reads_negated_numerics():
+    node = ast.parse("-3", mode="eval").body
+    assert _literal_const(node) == -3
+
+
+def test_literal_const_resolves_a_dotted_member():
+    node = ast.parse("RegexFlag.IGNORECASE", mode="eval").body
+    assert _literal_const(node, "re") is re.RegexFlag.IGNORECASE
+
+
+def test_literal_values_reads_enum_members():
+    src = "Literal[RegexFlag.IGNORECASE, RegexFlag.MULTILINE]"
+    node = ast.parse(src, mode="eval").body
+    assert _literal_values(node, "re") == (
+        re.RegexFlag.IGNORECASE,
+        re.RegexFlag.MULTILINE,
+    )
+
+
+def test_literal_values_drops_a_member_the_runtime_lacks():
+    """typeshed models dataclasses._MISSING_TYPE as an Enum with a MISSING member;
+    the runtime class has no such attribute, so no value can be produced."""
+    node = ast.parse("Literal[_MISSING_TYPE.MISSING]", mode="eval").body
+    assert _literal_values(node, "dataclasses") == ()
+
+
+def test_purely_variadic_op_offers_only_its_expanded_form():
+    """`s.difference_update()` passes nothing to a *args-only op, exercising none of
+    it, so the expanded form replaces the bare one rather than joining it."""
+    assert candidate_arities(_candidate_sigs(set, "difference_update")) == [1]
+    assert candidate_arities(_func_candidate_sigs("math", "gcd")) == [1]
+
+
+def test_declared_zero_arg_overload_is_still_driven():
+    """re.Match.group()'s no-argument form is a real overload (not a *args artifact),
+    and returns the whole match rather than a group -- worth driving."""
+    arities = candidate_arities(_candidate_sigs(re.Match, "group", "re"))
+    assert 0 in arities
+    assert op_call(re.Match, "group", "re", 0).expr == "a.group()"

--- a/crosshair/inputgen_test.py
+++ b/crosshair/inputgen_test.py
@@ -7,12 +7,16 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+from fractions import Fraction
+from statistics import NormalDist
 
 import pytest
 
 from crosshair.inputgen import (
     catalog_modules,
     documented_stdlib_modules,
+    func_call,
+    op_call,
     valid_inputs,
 )
 
@@ -172,6 +176,43 @@ def test_uncategorized_ops_probe_cleanly():
         "uncategorized ops don't probe cleanly (I/O side effect, or a hang/crash); "
         "categorize them so the concrete sweep skips them:\n  " + detail
     )
+
+
+# Receivers typeshed doesn't name `self`: fractions.pyi writes its operators as
+# `def __add__(a, b: int | Fraction)`, so a name-based receiver rule reads `a` as an
+# unannotated argument and discards the whole operator surface.
+
+
+@pytest.mark.parametrize(
+    "typ,method,module,expr",
+    [
+        (Fraction, "__neg__", "fractions", "-a"),
+        (Fraction, "__add__", "fractions", "a + b"),
+        (Fraction, "__mod__", "fractions", "a % b"),
+        (NormalDist, "__mul__", "statistics", "a * x2"),
+        # A @staticmethod's leading parameter is a real argument, not a receiver.
+        (str, "maketrans", "builtins", "a.maketrans(x)"),
+        # A @classmethod's `cls` IS the receiver.
+        (dict, "fromkeys", "builtins", "a.fromkeys(iterable)"),
+    ],
+)
+def test_ops_with_unconventional_receivers_resolve(typ, method, module, expr):
+    call = op_call(typ, method, module)
+    assert call is not None, f"{typ.__name__}.{method} resolved no signature"
+    assert call[1] == expr
+
+
+def test_free_function_parameter_named_cls_is_not_dropped():
+    """In builtins.issubclass(cls, class_or_tuple), `cls` is an argument."""
+    call = func_call("builtins", "issubclass")
+    assert call is not None
+    assert call[2] == ["cls", "class_or_tuple"]
+
+
+def test_undrivable_zero_arg_call_is_not_synthesized():
+    """functools.total_ordering(cls) takes a required argument, so a zero-arg
+    candidate would only raise; it reports as undrivable instead."""
+    assert func_call("functools", "total_ordering") is None
 
 
 # Correlated CUSTOM_INPUTS: the transforming regime should dominate, while the

--- a/crosshair/stubs_parser.py
+++ b/crosshair/stubs_parser.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
 
 import ast
+import functools
 import re
 import sys
 from collections.abc import __all__ as abc_all
 from importlib import import_module
 from inspect import Parameter, Signature, signature
-from pathlib import Path
 from types import ClassMethodDescriptorType, MethodDescriptorType, WrapperDescriptorType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 from typing import __all__ as typing_all  # type: ignore
 
-from typeshed_client import get_stub_ast  # type: ignore
-from typeshed_client import get_search_context, get_stub_file
-
 from crosshair.fnutil import resolve_signature
+from crosshair.typeshed_lookup import FunctionDef as _FunctionDef
+from crosshair.typeshed_lookup import qualname_funcdefs, stub_module_ast, stub_source
 from crosshair.util import debug
 
 
@@ -29,9 +28,6 @@ def signature_from_stubs(fn: Callable) -> Tuple[List[Signature], bool]:
         If the boolean is False, signatures returned might be incomplete (some error\
         occured while parsing).
     """
-    # ast.get_source_segment requires Python 3.8
-    if sys.version_info < (3, 8):
-        return [], True
     if getattr(fn, "__module__", None) and getattr(fn, "__qualname__", None):
         module_name = fn.__module__
     else:
@@ -50,42 +46,52 @@ def signature_from_stubs(fn: Callable) -> Tuple[List[Signature], bool]:
 
     # Use the `qualname` to find the function inside its module.
     path_in_module: List[str] = fn.__qualname__.split(".")
-    # Find the stub_file and corresponding AST using `typeshed_client`.
-    search_path = [Path(path) for path in sys.path if path]
-    search_context = get_search_context(search_path=search_path)
-    stub_file = get_stub_file(module_name, search_context=search_context)
-    module = get_stub_ast(module_name, search_context=search_context)
-    if not stub_file or not module or not isinstance(module, ast.Module):
-        debug("No stub found for module", module_name)
+    fn_defs, defining_module = qualname_funcdefs(module_name, path_in_module)
+    if not fn_defs:
+        debug("No stub found for", module_name, fn.__qualname__)
         return [], True
-    glo = globals().copy()
-    return _sig_from_ast(module.body, path_in_module, stub_file.read_text(), glo)
+    stub_text = stub_source(defining_module)
+    if stub_text is None:
+        debug("No stub source for module", defining_module)
+        return [], True
+
+    sigs: List[Signature] = []
+    is_valid = True
+    glo = dict(_stub_namespace(defining_module))
+    for fn_def in fn_defs:
+        sig, valid = _sig_from_functiondef(fn_def, stub_text, glo)
+        if sig:
+            sigs.append(sig)
+        is_valid = is_valid and valid
+    return sigs, is_valid
 
 
 def _get_source_segment(source: str, node: ast.AST) -> Optional[str]:
     """Get source code segment of the *source* that generated *node*."""
-    if sys.version_info >= (3, 8):
-        return ast.get_source_segment(source, node)
-    raise NotImplementedError("ast.get_source_segment not available for python < 3.8.")
+    return ast.get_source_segment(source, node)
 
 
-def _sig_from_ast(
-    stmts: List[ast.stmt],
-    next_steps: List[str],
-    stub_text: str,
-    glo: Dict[str, Any],
-) -> Tuple[List[Signature], bool]:
-    """Lookup in the given ast for a function signature, following `next_steps` path."""
-    if len(next_steps) == 0:
-        return [], True
+@functools.lru_cache(maxsize=None)
+def _stub_namespace(module: str) -> Dict[str, Any]:
+    """The namespace a module's stub annotations resolve against: this module's
+    globals plus the stub's own imports and TypeVar definitions."""
+    glo = globals().copy()
+    stub_text = stub_source(module)
+    module_ast = stub_module_ast(module)
+    if stub_text is not None and module_ast is not None:
+        _exec_stub_definitions(module_ast.body, stub_text, glo)
+    return glo
 
-    # First walk through the nodes to execute imports and assignments
+
+def _exec_stub_definitions(
+    stmts: List[ast.stmt], stub_text: str, glo: Dict[str, Any]
+) -> None:
+    """Execute a stub's imports and TypeVar assignments into ``glo``, descending into
+    the branch of each ``sys``-dependent ``if`` that this interpreter takes."""
     for node in stmts:
-        # If we encounter an import statement, add it to the namespace
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             _exec_import(node, glo)
 
-        # If we encounter the definition of a `TypeVar`, add it to the namespace
         elif isinstance(node, ast.Assign):
             value_text = _get_source_segment(stub_text, node.value)
             if value_text and "TypeVar" in value_text:
@@ -96,53 +102,18 @@ def _sig_from_ast(
                     except Exception:
                         debug("Not able to evaluate TypeVar assignment:", assign_text)
 
-    # Walk through the nodes to find the next node
-    next_node_name = next_steps[0]
-    sigs = []
-    is_valid = True
-    for node in stmts:
-        # Only one step remaining => look for the function itself
-        if (
-            len(next_steps) == 1
-            and isinstance(node, ast.FunctionDef)
-            and node.name == next_node_name
-        ):
-            sig, valid = _sig_from_functiondef(node, stub_text, glo)
-            if sig:
-                sigs.append(sig)
-            is_valid = is_valid and valid
-
-        # More than one step remaining => look for the next step
-        elif (
-            isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef))
-            and node.name == next_node_name
-        ):
-            new_sigs, valid = _sig_from_ast(node.body, next_steps[1:], stub_text, glo)
-            sigs.extend(new_sigs)
-            is_valid = is_valid and valid
-
-    # Additionally, we might need to look for the next node into if statements
-    for node in stmts:
-        if isinstance(node, (ast.If)):
-            assign_text = _get_source_segment(stub_text, node.test)
-            # Some function depends on the execution environment
-            if assign_text and "sys." in assign_text:
-                condition = None
-                try:
-                    condition = eval(assign_text, glo)
-                except Exception:
-                    debug("Not able to evaluate condition:", assign_text)
-                if condition is not None:
-                    new_sigs, valid = _sig_from_ast(
-                        node.body if condition else node.orelse,
-                        next_steps,
-                        stub_text,
-                        glo,
-                    )
-                    sigs.extend(new_sigs)
-                    is_valid = is_valid and valid
-
-    return sigs, is_valid
+        elif isinstance(node, ast.If):
+            test_text = _get_source_segment(stub_text, node.test)
+            if not test_text:
+                continue
+            try:
+                condition = eval(test_text, glo)
+            except Exception:
+                debug("Not able to evaluate condition:", test_text)
+                continue
+            _exec_stub_definitions(
+                node.body if condition else node.orelse, stub_text, glo
+            )
 
 
 def _exec_import(imp: Union[ast.Import, ast.ImportFrom], glo: Dict[str, Any]):
@@ -195,7 +166,7 @@ _REPLACE_TYPESHED: Dict[str, Tuple[str, str]] = {
 
 
 def _sig_from_functiondef(
-    fn_def: ast.FunctionDef, stub_text: str, glo: Dict[str, Any]
+    fn_def: _FunctionDef, stub_text: str, glo: Dict[str, Any]
 ) -> Tuple[Optional[Signature], bool]:
     """Given an ast FunctionDef, return the corresponding signature."""
     # Get the source text for the function stub and parse the signature from it.

--- a/crosshair/stubs_parser_test.py
+++ b/crosshair/stubs_parser_test.py
@@ -1,3 +1,5 @@
+import codecs
+import json
 import re
 import sys
 from random import Random
@@ -23,6 +25,20 @@ if sys.version_info < (3, 9):
         glo = dict()
         assert expect == _rewrite_with_typing_types(test_str, glo)
         assert "typing" in glo
+
+
+def test_inherited_method_resolves_from_a_base_class():
+    """typeshed declares getstate on IncrementalDecoder, not on the subclass."""
+    sigs, valid = signature_from_stubs(codecs.BufferedIncrementalDecoder.getstate)
+    assert valid
+    assert [str(s) for s in sigs] == ["(self) -> tuple[bytes, int]"]
+
+
+def test_inherited_method_resolves_across_modules():
+    """JSONDecodeError inherits __reduce__ from builtins.object."""
+    sigs, valid = signature_from_stubs(json.JSONDecodeError.__reduce__)
+    assert valid and len(sigs) == 1
+    assert list(sigs[0].parameters) == ["self"]
 
 
 def test_signature_from_stubs():

--- a/crosshair/tools/measure_support.py
+++ b/crosshair/tools/measure_support.py
@@ -64,7 +64,7 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 import crosshair.core_and_libs  # noqa: F401  -- loads opcode patches / registrations
-from crosshair.behavior_compare import _is_opaque, run_differential
+from crosshair.behavior_compare import CallSpec, _is_opaque, run_differential
 from crosshair.core import suspected_proxy_intolerance_exception
 from crosshair.core_and_libs import analyze_function, run_checkables
 from crosshair.inputgen import (  # shared surface + valid-input generation
@@ -79,6 +79,7 @@ from crosshair.inputgen import (  # shared surface + valid-input generation
     call_expr,
     catalog,
     func_call,
+    inputs_for,
     is_deterministic,
     op_call,
     receiver_name,
@@ -616,7 +617,7 @@ DIFF_K = 3  # valid inputs to try in the forward-soundness check
 DIFF_MAX_PIN_ITERS = 12
 
 
-def _diff_demo(call: Any, div: Any) -> Optional[str]:
+def _diff_demo(call: CallSpec, div: Any) -> Optional[str]:
     """A runnable crosshair-web source that reproduces a forward divergence: pin
     the inputs to the divergent values and assert the CORRECT (concrete) result,
     so CrossHair visibly returns the wrong answer (or raises) on it.  Returns None
@@ -624,7 +625,7 @@ def _diff_demo(call: Any, div: Any) -> Optional[str]:
     repr-round-trip."""
     if div.concrete.exc is not None:  # "should have raised" isn't a simple post
         return None
-    fn, expr, names = call[0], call[1], call[2]
+    fn, expr, names = call.fn, call.expr, call.arg_names
     ret = div.concrete.ret
     if not _repr_ok(ret):
         return None
@@ -649,7 +650,9 @@ def _diff_demo(call: Any, div: Any) -> Optional[str]:
     )
 
 
-def _diff_black(label: str, call: Any) -> Optional[Tuple[str, str, Optional[str]]]:
+def _diff_black(
+    label: str, call: Optional[CallSpec]
+) -> Optional[Tuple[str, str, Optional[str]]]:
     """If the op's symbolic FORWARD execution disagrees with concrete Python on
     any valid input, it's unsound -> return a black ``(color, verdict, example)``.
     Else None (let the holdout decide green/yellow/red and inverse-soundness).
@@ -660,16 +663,11 @@ def _diff_black(label: str, call: Any) -> Optional[Tuple[str, str, Optional[str]
     output legitimately varies (order/identity) are left to the holdout."""
     if call is None or label in NOT_VALUE_FUNCTION:
         return None
-    fn, expr, names, eval_globals = call
     try:
         result = run_differential(
-            fn,
-            expr,
-            names,
-            eval_globals,
-            k=DIFF_K,
+            call,
+            inputs_for(call, k=DIFF_K, seedkey=label),
             max_pin_iters=DIFF_MAX_PIN_ITERS,
-            seedkey=label,
         )
     except BaseException:
         return None  # never let the soundness probe break measurement

--- a/crosshair/typeshed_lookup.py
+++ b/crosshair/typeshed_lookup.py
@@ -1,0 +1,313 @@
+"""
+Typeshed stub resolution: module name -> the function definitions it declares.
+
+Everything here stops at the AST. Callers decide what a typeshed annotation
+*means*: :mod:`crosshair.stubs_parser` turns it into a faithful
+:class:`inspect.Signature`, while :mod:`crosshair.inputgen` maps it to a
+generatable approximation.
+
+Lookups run against a search context pinned to the running interpreter, so
+``sys.version_info`` / ``sys.platform`` guards in the stubs are already resolved
+and the surface matches what this interpreter actually has. ``@overload`` groups
+arrive grouped, and re-exports (``bisect.bisect_left`` <- ``_bisect``) are
+followed to where the definition really lives.
+"""
+
+import ast
+import functools
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import (
+    Dict,
+    FrozenSet,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+import typeshed_client as tc  # type: ignore
+
+FunctionDef = Union[ast.FunctionDef, ast.AsyncFunctionDef]
+_FUNCTION_DEFS = (ast.FunctionDef, ast.AsyncFunctionDef)
+
+# Following re-exports and base classes walks a graph that stubs can make cyclic;
+# every recursive resolver is bounded by this.
+_MAX_DEPTH = 4
+
+# Fallback modules for a class name that the requested module doesn't declare.
+# builtins holds the concrete types and object; typing holds the ABC bases
+# (MutableSequence, Mapping, ...) that typeshed names as bases and on which it
+# declares inherited methods.
+_CLASS_FALLBACK_MODULES = ("builtins", "typing")
+
+
+@functools.lru_cache(maxsize=1)
+def search_context() -> tc.SearchContext:
+    """The typeshed search context for the running interpreter: this process's
+    ``sys.path``, at its version and platform.
+
+    Passing ``search_path`` matters -- without it ``typeshed_client`` recovers the
+    path by spawning ``sys.executable``, which the auditwall rejects.
+    """
+    return tc.get_search_context(search_path=[Path(p) for p in sys.path if p])
+
+
+@functools.lru_cache(maxsize=None)
+def stub_names(module: str) -> Mapping[str, tc.NameInfo]:
+    """The version/platform-resolved ``{name: NameInfo}`` a module's stub declares,
+    or ``{}`` when it has no stub."""
+    try:
+        return tc.get_stub_names(module, search_context=search_context()) or {}
+    except Exception:
+        return {}
+
+
+@functools.lru_cache(maxsize=None)
+def stub_source(module: str) -> Optional[str]:
+    """The text of a module's stub file, or None."""
+    try:
+        path = tc.get_stub_file(module, search_context=search_context())
+    except Exception:
+        return None
+    if path is None:
+        return None
+    try:
+        return path.read_text()
+    except OSError:
+        return None
+
+
+@functools.lru_cache(maxsize=None)
+def stub_module_ast(module: str) -> Optional[ast.Module]:
+    """The parsed stub module, or None. Useful for the statements ``stub_names``
+    discards, e.g. the imports that a name's annotations resolve against."""
+    try:
+        node = tc.get_stub_ast(module, search_context=search_context())
+    except Exception:
+        return None
+    return node if isinstance(node, ast.Module) else None
+
+
+def _resolve(
+    name_info: Optional[tc.NameInfo], module: str, depth: int
+) -> Optional[Tuple[tc.NameInfo, str]]:
+    """Follow ``name_info`` across re-exports to the (NameInfo, defining module)
+    that actually holds a definition."""
+    if name_info is None or depth > _MAX_DEPTH:
+        return None
+    node = name_info.ast
+    if not isinstance(node, tc.ImportedName):
+        return (name_info, module)
+    target_module = ".".join(node.module_name)
+    target_name = cast(str, node.name or name_info.name)
+    return _resolve(
+        stub_names(target_module).get(target_name), target_module, depth + 1
+    )
+
+
+def resolve_name(name: str, module: str) -> Optional[Tuple[tc.NameInfo, str]]:
+    """The (NameInfo, defining module) for a module-level name, re-exports followed."""
+    return _resolve(stub_names(module).get(name), module, 0)
+
+
+def funcdefs(name_info: Optional[tc.NameInfo], module: str) -> List[FunctionDef]:
+    """The function definitions behind a NameInfo: a plain ``def``, every member of
+    an ``@overload`` group, or whatever a re-export points at. ``[]`` for anything
+    that isn't a function."""
+    resolved = _resolve(name_info, module, 0)
+    if resolved is None:
+        return []
+    node = resolved[0].ast
+    if isinstance(node, _FUNCTION_DEFS):
+        return [node]
+    if isinstance(node, tc.OverloadedName):
+        return [d for d in node.definitions if isinstance(d, _FUNCTION_DEFS)]
+    return []
+
+
+def module_funcdefs(module: str) -> Dict[str, List[FunctionDef]]:
+    """Every free function a module declares, name -> overloads."""
+    out: Dict[str, List[FunctionDef]] = {}
+    for name, name_info in stub_names(module).items():
+        defs = funcdefs(name_info, module)
+        if defs:
+            out[name] = defs
+    return out
+
+
+def stub_class(
+    name: str, module: str = "builtins"
+) -> Optional[Tuple[tc.NameInfo, str]]:
+    """The (class NameInfo, defining module) for ``name``, searched in ``module``
+    then builtins and typing, following re-exports."""
+    for candidate_module in (module, *_CLASS_FALLBACK_MODULES):
+        resolved = _resolve(stub_names(candidate_module).get(name), candidate_module, 0)
+        if resolved is not None and isinstance(resolved[0].ast, ast.ClassDef):
+            return resolved
+    return None
+
+
+def _base_ref(base: ast.expr, default_module: str) -> Optional[Tuple[str, str]]:
+    """(base class name, module to resolve it in) for a base-class expression.
+
+    A bare ``Name`` (``class Fraction(Rational)``) resolves in the module holding
+    the deriving class. A dotted ``Attribute`` (``class RegexFlag(enum.IntFlag)``)
+    resolves its final attribute in the *qualifier* module, so a base imported as
+    ``import enum`` still follows to where the class is defined.
+    """
+    if isinstance(base, ast.Name):
+        return (base.id, default_module)
+    if isinstance(base, ast.Attribute):
+        qualifier: List[str] = []
+        node: ast.expr = base.value
+        while isinstance(node, ast.Attribute):
+            qualifier.append(node.attr)
+            node = node.value
+        if isinstance(node, ast.Name):
+            qualifier.append(node.id)
+            return (base.attr, ".".join(reversed(qualifier)))
+    return None
+
+
+@functools.lru_cache(maxsize=None)
+def class_chain(
+    name: str, module: str = "builtins"
+) -> Tuple[Tuple[tc.NameInfo, str], ...]:
+    """Typeshed's MRO for a class: derived-first (NameInfo, defining module) pairs
+    following declared bases, with ``object`` last."""
+    chain: List[Tuple[tc.NameInfo, str]] = []
+    seen = set()
+
+    def visit(cls_name: str, cls_module: str) -> None:
+        if cls_name in seen:
+            return
+        resolved = stub_class(cls_name, cls_module)
+        if resolved is None:
+            return
+        name_info, found_module = resolved
+        seen.add(cls_name)
+        chain.append(resolved)
+        for base in cast(ast.ClassDef, name_info.ast).bases:
+            node = base.value if isinstance(base, ast.Subscript) else base
+            ref = _base_ref(node, found_module)
+            if ref is not None and ref[0] not in ("Generic", "Protocol"):
+                visit(*ref)
+
+    visit(name, module)
+    if "object" not in seen:
+        obj = stub_class("object")
+        if obj is not None:
+            chain.append(obj)
+    return tuple(chain)
+
+
+def method_funcdefs(
+    class_name: str, method: str, module: str = "builtins"
+) -> Tuple[List[FunctionDef], str]:
+    """(overloads, defining module) for a method, resolved up typeshed's MRO: the
+    first class declaring it wins, so an override beats what it inherits.
+    ``([], module)`` when no class in the chain declares it."""
+    for name_info, found_module in class_chain(class_name, module):
+        defs = funcdefs((name_info.child_nodes or {}).get(method), found_module)
+        if defs:
+            return (defs, found_module)
+    return ([], module)
+
+
+def qualname_funcdefs(
+    module: str, path: Sequence[str]
+) -> Tuple[List[FunctionDef], str]:
+    """(overloads, defining module) for a ``__qualname__`` path inside a module's
+    stub. A ``Class.method`` path resolves up the MRO; deeper paths descend nested
+    classes literally."""
+    if not path:
+        return ([], module)
+    if len(path) == 1:
+        return (funcdefs(stub_names(module).get(path[0]), module), module)
+    if len(path) == 2:
+        return method_funcdefs(path[0], path[1], module)
+    outer = stub_class(path[0], module)
+    if outer is None:
+        return ([], module)
+    name_info, found_module = outer
+    for step in path[1:-1]:
+        nested = _resolve((name_info.child_nodes or {}).get(step), found_module, 0)
+        if nested is None:
+            return ([], found_module)
+        name_info, found_module = nested
+    return (
+        funcdefs((name_info.child_nodes or {}).get(path[-1]), found_module),
+        found_module,
+    )
+
+
+def decorator_names(funcdef: FunctionDef) -> FrozenSet[str]:
+    """The bare/dotted decorator names on a definition, e.g. ``{"overload"}``."""
+    names = set()
+    for node in funcdef.decorator_list:
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+    return frozenset(names)
+
+
+@dataclass(frozen=True)
+class StubParams:
+    """A stub definition's parameters, with the receiver split out.
+
+    ``receiver`` is identified by POSITION, not by name -- typeshed does not always
+    call it ``self`` (``fractions.pyi`` declares ``def __neg__(a) -> Fraction``).
+    """
+
+    receiver: Optional[ast.arg]
+    positional: Tuple[ast.arg, ...]
+    defaults: Tuple[ast.expr, ...]
+    vararg: Optional[ast.arg]
+    kwonly: Tuple[ast.arg, ...]
+    kwonly_defaults: Tuple[Optional[ast.expr], ...]
+    kwarg: Optional[ast.arg]
+
+    @property
+    def required_positional(self) -> Tuple[ast.arg, ...]:
+        """Positional parameters with no default."""
+        if not self.defaults:
+            return self.positional
+        return self.positional[: max(0, len(self.positional) - len(self.defaults))]
+
+    @property
+    def required_kwonly(self) -> Tuple[ast.arg, ...]:
+        """Keyword-only parameters with no default."""
+        return tuple(
+            arg
+            for arg, default in zip(self.kwonly, self.kwonly_defaults)
+            if default is None
+        )
+
+
+def params(funcdef: FunctionDef, is_method: bool = False) -> StubParams:
+    """Split a stub definition's parameters into a :class:`StubParams`.
+
+    ``is_method`` claims the leading positional parameter as the receiver, except
+    on a ``@staticmethod`` (whose first parameter is a real argument, as in
+    ``str.maketrans``).
+    """
+    args = funcdef.args
+    positional = list(args.posonlyargs) + list(args.args)
+    receiver = None
+    if is_method and positional and "staticmethod" not in decorator_names(funcdef):
+        receiver = positional.pop(0)
+    return StubParams(
+        receiver=receiver,
+        positional=tuple(positional),
+        defaults=tuple(args.defaults),
+        vararg=args.vararg,
+        kwonly=tuple(args.kwonlyargs),
+        kwonly_defaults=tuple(args.kw_defaults),
+        kwarg=args.kwarg,
+    )

--- a/crosshair/typeshed_lookup_test.py
+++ b/crosshair/typeshed_lookup_test.py
@@ -1,0 +1,160 @@
+"""Tests for crosshair.typeshed_lookup -- typeshed stub resolution."""
+
+import ast
+import sys
+
+import pytest
+
+from crosshair.typeshed_lookup import (
+    class_chain,
+    decorator_names,
+    method_funcdefs,
+    module_funcdefs,
+    params,
+    qualname_funcdefs,
+    resolve_name,
+    search_context,
+    stub_class,
+    stub_names,
+    stub_source,
+)
+
+
+def test_search_context_pins_the_running_interpreter():
+    ctx = search_context()
+    assert ctx.version == sys.version_info[:2]
+    assert ctx.platform == sys.platform
+
+
+def test_missing_module_resolves_empty():
+    assert stub_names("no_such_module_at_all_xyz") == {}
+    assert stub_source("no_such_module_at_all_xyz") is None
+    assert module_funcdefs("no_such_module_at_all_xyz") == {}
+
+
+def test_overloads_are_grouped():
+    defs, module = method_funcdefs("str", "center", "builtins")
+    assert module == "builtins"
+    assert len(defs) > 1
+    assert all(isinstance(d, ast.FunctionDef) for d in defs)
+    assert all("overload" in decorator_names(d) for d in defs)
+
+
+@pytest.mark.parametrize(
+    "module,name,expect_module",
+    [
+        ("bisect", "bisect_left", "_bisect"),  # re-export of a function
+        ("io", "StringIO", "_io"),  # re-export of a class
+    ],
+)
+def test_re_exports_are_followed(module, name, expect_module):
+    resolved = resolve_name(name, module)
+    assert resolved is not None
+    assert resolved[1] == expect_module
+
+
+def test_method_on_a_re_exported_class_resolves():
+    """io.pyi re-exports StringIO from _io; the method still resolves."""
+    defs, module = method_funcdefs("StringIO", "getvalue", "io")
+    assert module == "_io"
+    assert len(defs) == 1
+    assert defs[0].name == "getvalue"
+
+
+def test_class_chain_crosses_modules():
+    chain = class_chain("Fraction", "fractions")
+    assert [ni.name for ni, _ in chain][:2] == ["Fraction", "Rational"]
+    # Fraction's bases live in `numbers`, not `fractions`.
+    assert dict(((ni.name, mod) for ni, mod in chain))["Rational"] == "numbers"
+    assert chain[-1][0].name == "object"
+
+
+def test_method_resolves_up_the_chain():
+    """A method typeshed declares only on a base class is found from the subclass."""
+    defs, module = method_funcdefs("Fraction", "__sizeof__", "fractions")
+    assert module == "builtins"
+    assert len(defs) == 1
+
+
+def test_stub_class_falls_back_to_builtins_and_typing():
+    assert stub_class("int", "no_such_module_xyz")[1] == "builtins"
+    assert stub_class("MutableSequence", "no_such_module_xyz")[1] == "typing"
+
+
+# ---------------------------------------------------------------------------
+# parameter splitting: the receiver goes by POSITION, not by name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ["__neg__", "__abs__", "__bool__"])
+def test_unnamed_self_receiver_is_claimed(method):
+    """fractions.pyi writes `def __neg__(a) -> Fraction`; `a` is the receiver."""
+    defs, _ = method_funcdefs("Fraction", method, "fractions")
+    assert defs
+    parsed = params(defs[0], is_method=True)
+    assert parsed.receiver is not None and parsed.receiver.arg == "a"
+    assert parsed.required_positional == ()
+
+
+def test_unnamed_self_receiver_leaves_the_real_argument():
+    defs, _ = method_funcdefs("Fraction", "__add__", "fractions")
+    assert defs
+    for funcdef in defs:
+        parsed = params(funcdef, is_method=True)
+        assert parsed.receiver.arg == "a"
+        assert [a.arg for a in parsed.required_positional] == ["b"]
+
+
+def test_staticmethod_keeps_its_first_parameter():
+    """str.maketrans is a @staticmethod: its leading parameter is a real argument."""
+    defs, _ = method_funcdefs("str", "maketrans", "builtins")
+    assert defs
+    for funcdef in defs:
+        parsed = params(funcdef, is_method=True)
+        assert parsed.receiver is None
+        assert parsed.required_positional, funcdef.name
+
+
+def test_classmethod_receiver_is_claimed():
+    defs, _ = method_funcdefs("dict", "fromkeys", "builtins")
+    assert defs
+    parsed = params(defs[0], is_method=True)
+    assert parsed.receiver is not None and parsed.receiver.arg == "cls"
+    assert "iterable" in [a.arg for a in parsed.required_positional]
+
+
+def test_free_function_keeps_a_parameter_named_cls():
+    """builtins.issubclass(cls, class_or_tuple) -- `cls` is an argument here."""
+    defs = module_funcdefs("builtins")["issubclass"]
+    parsed = params(defs[0], is_method=False)
+    assert parsed.receiver is None
+    assert [a.arg for a in parsed.required_positional] == ["cls", "class_or_tuple"]
+
+
+def test_defaults_split_required_from_optional():
+    defs, _ = method_funcdefs("str", "split", "builtins")
+    parsed = params(defs[0], is_method=True)
+    assert [a.arg for a in parsed.positional] == ["sep", "maxsplit"]
+    assert parsed.required_positional == ()  # both are defaulted
+
+
+def test_keyword_only_parameters_are_exposed():
+    parsed = params(module_funcdefs("json")["dumps"][0])
+    kwonly = [a.arg for a in parsed.kwonly]
+    assert "ensure_ascii" in kwonly and "sort_keys" in kwonly
+    assert parsed.required_kwonly == ()  # json.dumps defaults all of them
+
+
+def test_vararg_is_reported():
+    parsed = params(module_funcdefs("math")["gcd"][0])
+    assert parsed.vararg is not None
+    assert parsed.required_positional == ()
+
+
+def test_qualname_funcdefs_handles_module_level_and_methods():
+    defs, _ = qualname_funcdefs("math", ["sqrt"])
+    assert len(defs) == 1 and defs[0].name == "sqrt"
+    defs, _ = qualname_funcdefs("random", ["Random", "randint"])
+    assert len(defs) == 1 and defs[0].name == "randint"
+    assert qualname_funcdefs("math", []) == ([], "math")
+    assert qualname_funcdefs("math", ["no_such_function_xyz"]) == ([], "math")


### PR DESCRIPTION
Two typeshed consumers had grown up independently: `stubs_parser` (which backs `register_contract`) walked stub ASTs by hand, while `inputgen` had its own resolver for the operation catalog. Neither was a superset of the other. This extracts the shared resolution layer, then fixes several places where input generation turned out to be narrower than the surface it describes.

## `crosshair/typeshed_lookup.py` (new)

Pure stub resolution — everything stops at the AST. Both callers keep their own annotation interpreters on top, since a faithful `inspect.Signature` and a fuzzable approximation are different products:

```
search_context()                     stub_names(module)        stub_source(module)
stub_module_ast(module)              resolve_name(name, mod)   funcdefs(name_info, mod)
module_funcdefs(module)              stub_class(name, mod)     class_chain(name, mod)
method_funcdefs(cls, meth, mod)      qualname_funcdefs(mod, path)
decorator_names(funcdef)             params(funcdef, is_method) -> StubParams
```

Version/platform guards, `@overload` grouping, and re-exports are delegated to `typeshed_client` rather than hand-rolled, and lookups are cached.

### `stubs_parser`: strictly more signatures, much faster

Old vs new side by side in one process, over 3649 lookups:

```
timing: old=420.8s  new=1.7s  → 255x
gained 556, lost 0, changed 0
```

Every gain is an inherited method resolved through typeshed's MRO — `codecs.BufferedIncrementalDecoder.getstate` (declared on `IncrementalDecoder`), `json.JSONDecodeError.__reduce__` (crossing into `builtins.object`). The old code searched only `fn.__module__`'s own stub by qualname, so these resolved to nothing and `register_contract` warned that no signature was available. About 100 lines went away with it: `_sig_from_ast`, the qualname descent, and the hand-rolled `ast.If` + `"sys." in text` guard evaluator.

### `inputgen`: same resolution, one bug fixed

Over 3692 (type, method) and free-function pairs: **63 gained, 1 lost, 1 changed** — the loss and the change are both corrections.

`_overload_sigs` dropped the receiver *by name*, so typeshed's `fractions.pyi` convention leaked through:

```python
def __neg__(a) -> Fraction: ...          # 'a' read as an unannotated argument
def __add__(a, b: int | Fraction): ...   # → len mismatch → overload discarded
```

Fraction's entire operator surface was invisible, as was `statistics.NormalDist`'s and every `classmethod` whose `cls` was read as an argument (`dict.fromkeys`, `datetime.date.fromisoformat`, `int.from_bytes`). `params()` now identifies the receiver **by position**, skipping that on a `@staticmethod` (whose leading parameter is a real argument, as in `str.maketrans`).

The two non-gains: `functools.total_ordering` was yielding a zero-argument candidate that could only `TypeError`, because its `cls: type[_T]` was name-dropped — it now reports as undrivable. And `builtins.issubclass` was driven with **one** argument instead of two, same cause.

## Driving every overload shape

`_candidate_specs_for` unioned only overloads sharing the primary sig's arity, and the call expression came from the primary sig alone, so a shape taking a different number of arguments was unreachable.

`builtins.pow`'s primary sig is the 3-argument `(base, exp, mod)` form — which always takes the `mod is not None` realize path. So **1 of its 10 overloads was ever driven**, and the nine 2-argument ones, carrying the float/complex bases and the `Literal[-1..-20]` negative exponents, were not tested at all:

```
builtins.pow   primary='_fn(base, exp, mod)'   alt=('_fn(base, exp)', arity 2)
  arity 3 -> [(13, 0, 0), (13, 98, 138), (611, -33, 843)]
  arity 2 -> [(0.0, 0), (-2.8642164135356e+16, 580), (38, 16)]
```

`candidate_arities()` now enumerates the distinct shapes and `Operation.alt_calls` carries one spec per shape; the differential gate drives them all. 126 ops gain a shape, 80 of them at the gate. Also newly reached: `getattr`'s 3-argument `default` form, `int.__pow__`'s `(value, mod)`, `re.Match.group`'s 0/2/3-argument forms, `max`/`min`'s 1-argument iterable form, `dict.get`/`pop`/`setdefault`'s `default`.

Two supporting fixes fell out:

- **`call_expr` no longer drops arguments it can't place.** Operator syntax takes exactly one operand, so an overload supplying more (`int.__pow__`'s `(value, mod)`) now uses the explicit dunder form instead of silently discarding the extra. A test asserts across the whole catalog that every generated argument name appears in the expression driving it.
- **A purely variadic overload stops offering its bare no-argument form.** Passing nothing to `set.difference_update(*s)` exercises none of it; driving that shape produced two spurious divergences on the first gate run, which `primary_sig`'s own docstring had already warned about. `re.Match.group()`'s genuinely *declared* zero-argument overload is unaffected.

## Hardening method signature lookup

`_sig_for` recognized a method only by `__objclass__`, which a class written in Python does not carry, and fell through to the free-function branch — where a module often exports a function sharing the method's name:

```
gettext.NullTranslations.install:
   has __objclass__: False
   _sig_for -> kind='func' owner='gettext' name='install'
   ...i.e. the MODULE-LEVEL function's sigs: [[('domain', 'str', ())]]
   inputs: [('×\U0010655c\x9b',), ('o\x90𱇚',), ('\x0fU©',)]
```

The **receiver** of `a.install()` was being bound to a fuzzed `str` drawn from `gettext.install(domain)`. `NormalDist.quantiles` took `statistics.quantiles`' `List[int]`; `socket.socket.dup` took `socket.dup(fd)`. Twelve ops were driven this way, nine of them "passing" vacuously (both runs raised `AttributeError`).

`_method_owner` now resolves the owner from `__qualname__` when `__objclass__` is absent — the longest leading prefix that resolves to a type, which also finds the class behind a closure-built method (`Fraction.__add__` is `Fraction._operator_fallbacks.<locals>.forward`) — and a method whose receiver type has no construction strategy resolves to nothing rather than to that unrelated function.

Net at the gate: 21 ops that were driven with fabricated receivers are now reported as having no synthesizable inputs, and 39 previously-skipped ops generate real receivers (18 of which run and pass). `Fraction` (26 ops), `Decimal` (76), `Counter` (31), `deque` (28), `Random` (20), `OrderedDict` (20) now participate.

## `CallSpec`

The `(fn, expr, arg_names, eval_globals)` quad-tuple is now a dataclass carrying the overload arity it drives, replacing 12 occurrences of `Tuple[Any, str, List[str], Dict[str, Any]]` and this:

```python
alt_calls: Tuple[Tuple[Tuple[Any, str, List[str], Dict[str, Any]], int], ...] = ()
# →
alt_calls: Tuple[CallSpec, ...] = ()
```

`invoke()`/`accepts()` de-duplicate the eval incantation and the length check that both drivers had copied.

It lives in `behavior_compare` beside `run_differential`, which now takes its inputs rather than generating them (shedding `k`, `seed`, and `seedkey`, which only existed to forward to the generator). Consequence: the module that ships with `diffbehavior` reaches for `crosshair.inputgen` — and hypothesis, a **dev-only extra** — neither at runtime nor for a type. Verified with hypothesis blocked from `sys.meta_path` entirely:

```
inputgen loaded : False
hypothesis loaded: False
behavior_compare imports with hypothesis BLOCKED: OK
```

## `ctypes.POINTER`

typeshed declares `POINTER(cls: str)` only under `sys.version_info >= (3, 14)`, so the op is undrivable below that and drivable from 3.14 on. Driven there, it caches the pointer type it builds in a module-level dict **keyed by its argument**, leaving the fuzzed symbolic string in ctypes' cache; the following concrete run compares against that key with no state space in scope and raises `CrossHairInternal: Not in a statespace context`. Classified in `GLOBAL_STATE_OVERRIDES` alongside `SetPointerType`, which writes the same table.

This is what failed CI on 3.14/3.15-dev before the last commit.

## Verification

- Full suite: **14207 passed**, 1 pre-existing macOS-only failure (`test_uncategorized_ops_probe_cleanly`, a `locale.dcgettext` abort that reproduces identically on an unmodified tree; no macOS job in CI).
- Differential gate: **2529 passed, 823 skipped, 24 xfailed, 78 xpassed, 0 failed**.
- black 26.5.1, isort 8.0.1, flake8 7.1.2, mypy 2.3.0 (the pinned versions) all clean.
- CI: `Test CrossHair` green on all 8 jobs — ubuntu 3.10/3.11/3.12/3.13/3.14/3.15-dev and windows 3.11/3.14.

New tests: `crosshair/typeshed_lookup_test.py` (20) plus additions to `inputgen_test.py` and `stubs_parser_test.py`.

## Deliberately out of scope

- **The support map still measures only the primary shape**, so published cell colors and demo links are unchanged. Driving alt shapes there would move cells.
- **Keyword-only argument generation.** `_overload_sigs` reads only required positionals, so an op whose interesting parameters are keyword-only is still driven with none. This is also why enum-member `Literal` resolution (`_literal_const` now handles a dotted `ast.Attribute`) has no measurable effect yet: its only occurrence on the current surface is `dataclasses.field`'s `_MISSING_TYPE.MISSING` sentinel, whose parameters are all keyword-only — and which typeshed models as an `Enum` member the runtime class does not actually have.
