### PR TITLE
Fix keyword-only arg crash, max_iterations=0 NameError, and format_boundargs TypeError

### DIFF
--- a/crosshair/condition_parser.py
+++ b/crosshair/condition_parser.py
@@ -919,17 +919,21 @@ class DealParser(ConcreteConditionParser):
     def _extract_a_and_kw(
         self, bindings: Mapping[str, object], sig: Signature
     ) -> Tuple[List[object], Dict[str, object]]:
-        positional_args = []
-        keyword_args = {}
+        positional_args: List[object] = []
+        keyword_args: Dict[str, object] = {}
         for param in sig.parameters.values():
             if param.name not in bindings:
                 continue
             if param.kind == inspect.Parameter.KEYWORD_ONLY:
                 keyword_args[param.name] = bindings[param.name]
             elif param.kind == inspect.Parameter.VAR_KEYWORD:
-                keyword_args.update(bindings[param.name])
+                value = bindings[param.name]
+                if isinstance(value, dict):
+                    keyword_args.update(value)
             elif param.kind == inspect.Parameter.VAR_POSITIONAL:
-                positional_args.extend(bindings[param.name])
+                value = bindings[param.name]
+                if isinstance(value, (list, tuple)):
+                    positional_args.extend(value)
             else:
                 positional_args.append(bindings[param.name])
         return (positional_args, keyword_args)

--- a/crosshair/condition_parser.py
+++ b/crosshair/condition_parser.py
@@ -922,9 +922,16 @@ class DealParser(ConcreteConditionParser):
         positional_args = []
         keyword_args = {}
         for param in sig.parameters.values():
+            if param.name not in bindings:
+                continue
             if param.kind == inspect.Parameter.KEYWORD_ONLY:
                 keyword_args[param.name] = bindings[param.name]
-            positional_args.append(bindings[param.name])
+            elif param.kind == inspect.Parameter.VAR_KEYWORD:
+                keyword_args.update(bindings[param.name])
+            elif param.kind == inspect.Parameter.VAR_POSITIONAL:
+                positional_args.extend(bindings[param.name])
+            else:
+                positional_args.append(bindings[param.name])
         return (positional_args, keyword_args)
 
     def _make_pre_expr(

--- a/crosshair/condition_parser_test.py
+++ b/crosshair/condition_parser_test.py
@@ -331,6 +331,22 @@ class TestIcontractParser:
 
 
 @pytest.mark.skipif(not deal, reason="deal is not installed")
+def test_deal_pre_keyword_only_arg():
+    """A deal pre on a function with a keyword-only arg must not pass the
+    same value twice (regression: keyword-only args were appended to both
+    the positional and the keyword args)."""
+
+    @deal.pre(lambda x, y: y > 0)
+    def f(x: int, *, y: int) -> int:
+        return x + y
+
+    conditions = DealParser().get_fn_conditions(FunctionInfo.from_fn(f))
+    (pre,) = conditions.pre
+    assert pre.evaluate({"x": 1, "y": 2}) == True  # noqa: E712
+    assert pre.evaluate({"x": 1, "y": -1}) == False  # noqa: E712
+
+
+@pytest.mark.skipif(not deal, reason="deal is not installed")
 def test_deal_basics():
     @deal.raises(ZeroDivisionError)
     @deal.pre(lambda a, b: a >= 0 and b >= 0)

--- a/crosshair/core.py
+++ b/crosshair/core.py
@@ -1335,6 +1335,7 @@ def analyze_calltree(
     patched = Patched()
     # TODO clean up how encofrced conditions works here?
     with patched:
+        i = 1  # used by the summary below, which runs even when the loop does not
         for i in range(1, options.max_iterations + 1):
             start = process_time()
             if start > options.deadline:

--- a/crosshair/core_test.py
+++ b/crosshair/core_test.py
@@ -1396,6 +1396,23 @@ def test_crosshair_modules_can_be_reloaded():
     importlib.reload(core_and_libs)
 
 
+def test_max_iterations_zero_does_not_crash():
+    """`max_iterations=0` must not raise NameError in the calltree summary
+    (regression: the debug log referenced the loop variable `i` before the
+    loop ever ran)."""
+
+    def f(x: int) -> int:
+        """
+        post: _ != -1
+        """
+        return x + 1
+
+    opts = AnalysisOptionSet(max_iterations=0)
+    msgs = run_checkables(analyze_function(f, opts))
+    states = {m.state for m in msgs}
+    assert EXEC_ERR not in states
+
+
 def profile():
     # This is a scratch area to run quick profiles.
     def f(x: int) -> int:

--- a/crosshair/util.py
+++ b/crosshair/util.py
@@ -406,12 +406,14 @@ def format_boundargs(bound_args: BoundArguments) -> str:
     arg_strings: List[str] = []
     for name, param in bound_args.signature.parameters.items():
         param_kind = param.kind
-        vals = bound_args.arguments.get(name, param.default)
         if param_kind == Parameter.VAR_POSITIONAL:
+            vals = bound_args.arguments.get(name, ())
             arg_strings.extend(map(repr, vals))
         elif param_kind == Parameter.VAR_KEYWORD:
+            vals = bound_args.arguments.get(name, {})
             arg_strings.extend(f"{k}={repr(v)}" for k, v in vals.items())
         else:
+            vals = bound_args.arguments.get(name, param.default)
             if param_kind == Parameter.POSITIONAL_ONLY:
                 use_keyword = False
             elif param_kind == Parameter.KEYWORD_ONLY:

--- a/crosshair/util_test.py
+++ b/crosshair/util_test.py
@@ -109,6 +109,13 @@ def test_format_boundargs():
     assert format_boundargs(bound) == "1, 2, 3, kw1=4, kw2=5, other=6"
 
 
+def test_format_boundargs_without_varargs():
+    """A plain bind() that leaves *args/**kwargs unbound must not crash
+    (regression: the unbound varargs fell back to inspect._empty)."""
+    bound = signature(eat_things).bind(1)
+    assert format_boundargs(bound) == "1, kw1=4, kw2='default'"
+
+
 class Color(Enum):
     RED = 0
 


### PR DESCRIPTION
## Summary
Fixes three crashes:

1. **condition_parser._extract_a_and_kw** — KEYWORD_ONLY parameters were appended to both positional and keyword args, crashing on re-call for deal contracts. Now handled via \param.kind\ including VAR_KEYWORD/VAR_POSITIONAL.
2. **core.analyze_calltree** — \max_iterations=0\ raised \NameError: i not defined\ in the iteration-count debug message.
3. **util.format_boundargs** — unbound VAR_POSITIONAL/VAR_KEYWORD args fell back to \inspect._empty\, raising TypeError. Now defaults to \()\ / \{}\.

## Tests
Added: \	est_deal_pre_keyword_only_arg\, \	est_max_iterations_zero_does_not_crash\, \	est_format_boundargs_without_varargs\.
Affected files: 133 passed, 3 skipped.