### PR TITLE
Preserve the class type through proxy_for_class (#418)

### DIFF
--- a/crosshair/core.py
+++ b/crosshair/core.py
@@ -555,7 +555,7 @@ def get_constructor_signature(cls: Type) -> Optional[inspect.Signature]:
 _TYPE_HINTS = IdKeyedDict()
 
 
-def proxy_for_class(typ: Type, varname: str) -> object:
+def proxy_for_class(typ: Type[_T], varname: str) -> _T:
     # Unwrap parameterized generics (e.g. Container[int] → Container) so that
     # get_type_hints and inspect-based helpers receive a plain class.
     cls = origin_of(typ)
@@ -579,7 +579,11 @@ def proxy_for_class(typ: Type, varname: str) -> object:
             for k in data_members.keys()
             if k not in optional_keys or context_statespace().smt_fork()
         )
-        return {k: proxy_for_type(data_members[k], varname + "." + k) for k in keys}
+        # A TypedDict instance *is* a dict at runtime, so this does satisfy the
+        # declared return type; mypy just cannot connect the two through _T.
+        return cast(
+            _T, {k: proxy_for_type(data_members[k], varname + "." + k) for k in keys}
+        )
 
     constructor_sig = get_constructor_signature(cls)
     if constructor_sig is None:

--- a/crosshair/core_test.py
+++ b/crosshair/core_test.py
@@ -864,7 +864,7 @@ def test_proxy_for_parameterized_generic() -> None:
     with standalone_statespace:
         with NoTracing():
             obj = proxy_for_class(Container[int], "x")
-    assert isinstance(obj.value, SymbolicInt)  # type: ignore[attr-defined]
+    assert isinstance(obj.value, SymbolicInt)
 
 
 def test_proxy_for_multi_typevar_generic() -> None:
@@ -879,8 +879,8 @@ def test_proxy_for_multi_typevar_generic() -> None:
     with standalone_statespace:
         with NoTracing():
             obj = proxy_for_class(Pair[int, str], "x")
-    assert isinstance(obj.first, SymbolicInt)  # type: ignore[attr-defined]
-    assert isinstance(obj.second, LazyIntSymbolicStr)  # type: ignore[attr-defined]
+    assert isinstance(obj.first, SymbolicInt)
+    assert isinstance(obj.second, LazyIntSymbolicStr)
 
 
 def test_proxy_for_class_with_unresolvable_forward_ref() -> None:


### PR DESCRIPTION
Fixes #418.

`proxy_for_class` was annotated `(typ: Type, varname: str) -> object`, so callers got back something with no attributes and had to cast or silence mypy to use it.

## The change

```python
-def proxy_for_class(typ: Type, varname: str) -> object:
+def proxy_for_class(typ: Type[_T], varname: str) -> _T:
```

reusing the `_T` already defined in `core.py`. This is a pure annotation change — no runtime behavior differs.

The annotation matches what the function already does: the main path returns `WithEnforcement(cls)(*args.args, **args.kwargs)`, an instance of the requested class. The parameterized-generic case works out too, since mypy types `Container[int]` in expression position as `type[Container[int]]`, so `_T` binds to `Container[int]` and the result keeps its parameter.

The one place needing help is the TypedDict branch, which returns a dict comprehension. A TypedDict instance *is* a dict at runtime, so the value genuinely satisfies the declared return type, but mypy can't connect that through `_T`. I used a `cast` with a comment there rather than widening the signature back out — the alternative would give up the improvement for every other class to accommodate one branch.

## What pins it

`core_test.py` carried three `# type: ignore[attr-defined]` comments — the exact workaround the issue describes:

```python
assert isinstance(obj.value, SymbolicInt)   # type: ignore[attr-defined]
assert isinstance(obj.first, SymbolicInt)   # type: ignore[attr-defined]
assert isinstance(obj.second, LazyIntSymbolicStr)  # type: ignore[attr-defined]
```

They are removed. Since mypy runs over all Python files via the pre-commit hook, those lines now act as the regression check for this signature — **verified by reverting `core.py` and leaving the tests as-is**:

```
crosshair/core_test.py:867: error: "object" has no attribute "value"  [attr-defined]
crosshair/core_test.py:882: error: "object" has no attribute "first"  [attr-defined]
crosshair/core_test.py:883: error: "object" has no attribute "second"  [attr-defined]
```

With the change, `mypy --ignore-missing-imports --scripts-are-modules crosshair/core.py crosshair/core_test.py` reports `Success: no issues found`.

## Testing

- `crosshair/core_test.py`: **95 passed, 3 skipped**.
- `black --check` and `isort --check-only` clean on both files.
- `flake8` reports the same three pre-existing `F824` warnings in `core.py` before and after; nothing new.